### PR TITLE
feat: add IR-only controls, TUI preferences, and guided diagnostics

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -35,6 +35,7 @@ on:
       - "Cargo.lock"
       - ".github/workflows/asan.yml"
       - ".github/lsan-suppressions.txt"
+      - "scripts/ci-bubblewrap.sh"
   schedule:
     - cron: "40 4 * * 3" # Wednesdays 04:40 UTC, clear of the other scheduled jobs
   workflow_dispatch:
@@ -87,7 +88,10 @@ jobs:
           command -v apt-get >/dev/null || { echo "deps preinstalled on the self-hosted runner"; exit 0; }
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            build-essential pkg-config clang libclang-dev libpam0g-dev libtss2-dev libudev-dev libdbus-1-dev dbus-daemon llvm bubblewrap
+            build-essential pkg-config clang libclang-dev libpam0g-dev libtss2-dev libudev-dev libdbus-1-dev dbus-daemon llvm bubblewrap apparmor
+
+      - name: Prepare and verify isolated CLI test namespaces
+        run: bash scripts/ci-bubblewrap.sh
 
       # A leak suppression matches the SYMBOL NAMES in an allocation stack, so
       # without a symbolizer it matches nothing and the deliberate test leak

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -87,7 +87,7 @@ jobs:
           command -v apt-get >/dev/null || { echo "deps preinstalled on the self-hosted runner"; exit 0; }
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            build-essential pkg-config clang libclang-dev libpam0g-dev libtss2-dev libudev-dev libdbus-1-dev dbus-daemon llvm
+            build-essential pkg-config clang libclang-dev libpam0g-dev libtss2-dev libudev-dev libdbus-1-dev dbus-daemon llvm bubblewrap
 
       # A leak suppression matches the SYMBOL NAMES in an allocation stack, so
       # without a symbolizer it matches nothing and the deliberate test leak

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,10 +109,13 @@ jobs:
           if command -v apt-get >/dev/null; then
             sudo apt-get update
             sudo apt-get install -y --no-install-recommends \
-              build-essential pkg-config clang libclang-dev libpam0g-dev libtss2-dev libudev-dev libdbus-1-dev dbus-daemon strace bubblewrap
+              build-essential pkg-config clang libclang-dev libpam0g-dev libtss2-dev libudev-dev libdbus-1-dev dbus-daemon strace bubblewrap apparmor
           else
             for t in cc pkg-config clang; do command -v "$t" >/dev/null || { echo "::error::$t missing on the runner"; exit 1; }; done
           fi
+
+      - name: Prepare and verify isolated CLI test namespaces
+        run: bash scripts/ci-bubblewrap.sh
 
       - name: Install Rust 1.88 (MSRV) with rustfmt + clippy
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
@@ -376,10 +379,13 @@ jobs:
           if command -v apt-get >/dev/null; then
             sudo apt-get update
             sudo apt-get install -y --no-install-recommends \
-              build-essential pkg-config clang libclang-dev libpam0g-dev libtss2-dev libudev-dev libdbus-1-dev dbus-daemon bubblewrap
+              build-essential pkg-config clang libclang-dev libpam0g-dev libtss2-dev libudev-dev libdbus-1-dev dbus-daemon bubblewrap apparmor
           else
             for t in cc pkg-config clang; do command -v "$t" >/dev/null || { echo "::error::$t missing on the runner"; exit 1; }; done
           fi
+
+      - name: Prepare and verify isolated CLI test namespaces
+        run: bash scripts/ci-bubblewrap.sh
 
       - name: Install stable Rust
         # @master (declares the `toolchain` input); the version tag branches

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
           if command -v apt-get >/dev/null; then
             sudo apt-get update
             sudo apt-get install -y --no-install-recommends \
-              build-essential pkg-config clang libclang-dev libpam0g-dev libtss2-dev libudev-dev libdbus-1-dev dbus-daemon
+              build-essential pkg-config clang libclang-dev libpam0g-dev libtss2-dev libudev-dev libdbus-1-dev dbus-daemon strace bubblewrap
           else
             for t in cc pkg-config clang; do command -v "$t" >/dev/null || { echo "::error::$t missing on the runner"; exit 1; }; done
           fi
@@ -140,11 +140,23 @@ jobs:
       - name: Action pins (SHA-pinned; SLSA generator excepted)
         run: bash scripts/check-action-pins.sh
 
+      - name: Non-granting IR harness offline tests (no camera)
+        run: python3 -m unittest discover -s scripts/ir-evaluation -p 'test_*.py'
+
       - name: rustfmt
         run: cargo fmt --all --check
 
       - name: clippy (warnings are errors)
         run: cargo clippy --all-targets -- -D warnings
+
+      # Required-feature examples and cfg-gated library code are skipped by the
+      # default workspace checks. Exercise the non-granting diagnostic explicitly.
+      - name: Optional IR diagnostic checks (no camera)
+        run: |
+          cargo clippy --locked -p irlume-auth -p irlume-camera --features irlume-auth/ir-only-evaluation --all-targets -- -D warnings
+          cargo test --locked -p irlume-auth --features ir-only-evaluation --lib --examples
+          cargo test --locked -p irlume-camera --features capture-timing --lib
+          RUSTDOCFLAGS="-D warnings" cargo doc --locked -p irlume-auth -p irlume-camera --features irlume-auth/ir-only-evaluation --no-deps
 
       # Optional ONNX Runtime execution providers are compile-time APIs. The
       # default CPU build cannot catch an upstream rename in one of these paths
@@ -329,6 +341,11 @@ jobs:
       - name: test (PAM FFI, against pam_wrapper)
         run: ./scripts/run-tests-guarded.sh --min 16 -- cargo test -p irlume-pam --locked -- --include-ignored --test-threads=1
 
+      - name: test (root-only password helper, private synthetic PAM)
+        run: |
+          sudo apt-get install -y --no-install-recommends libpam-wrapper libpam0g-dev gcc util-linux
+          ./scripts/test-password-helper.sh
+
   # Build + test on current stable, because that is what the packaging lanes
   # and most from-source users compile with. fmt/clippy stay on the MSRV job
   # only, so new-stable lint churn never blocks a PR. REQUIRED (see the seven-check list in the header).
@@ -359,7 +376,7 @@ jobs:
           if command -v apt-get >/dev/null; then
             sudo apt-get update
             sudo apt-get install -y --no-install-recommends \
-              build-essential pkg-config clang libclang-dev libpam0g-dev libtss2-dev libudev-dev libdbus-1-dev dbus-daemon
+              build-essential pkg-config clang libclang-dev libpam0g-dev libtss2-dev libudev-dev libdbus-1-dev dbus-daemon bubblewrap
           else
             for t in cc pkg-config clang; do command -v "$t" >/dev/null || { echo "::error::$t missing on the runner"; exit 1; }; done
           fi

--- a/.github/workflows/install-matrix.yml
+++ b/.github/workflows/install-matrix.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Install toolchain and system deps
         run: |
           pacman -Syu --noconfirm --needed \
-            base-devel git rust clang pam tpm2-tss curl ca-certificates
+            base-devel git rust clang pam tpm2-tss curl ca-certificates bubblewrap
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Changed
 
+- Read KDE wallet salts through the packaged helper after it permanently enters
+  the target account, then pass the fixed-size value to the daemon's unchanged KDF.
+  The daemon no longer opens that user path as root or falls back to doing so;
+  envelopes and wallets need no migration. Upgrade the daemon, CLI, PAM module,
+  and helper together and restart the daemon: an old client gets a clear refusal
+  from a new daemon, while a new client alone cannot correct an old daemon.
+
 - Collect complete sequential login PAD evidence in bounded RGB/IR groups and
   defer identity inference to the final eligible sample.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,9 @@ is back to one; `git commit --amend -s --no-edit` fixes a missing one.
   `padreport` and
   include the per-species APCER/BPCER numbers. See
   [`docs/PAD_SELFTEST.md`](docs/PAD_SELFTEST.md) for the methodology and protocol.
+  Optional IR-only full-path evaluation additionally follows
+  [`docs/IR_ONLY_QUALIFICATION.md`](docs/IR_ONLY_QUALIFICATION.md); the component
+  self-test does not qualify the proposed login mode.
 - **A pull request from a fork is not CodeQL-scanned before merge.** GitHub's
   default setup for code scanning does not analyse fork pull requests, so an
   external contribution reaches review with the ordinary CI behind it (clippy as

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,6 +691,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1016,6 +1022,7 @@ dependencies = [
  "irlume-core",
  "irlume-liveness",
  "irlume-vision",
+ "libc",
  "serde_json",
  "sha2 0.11.0",
 ]
@@ -1122,6 +1129,7 @@ version = "0.11.3"
 dependencies = [
  "irlume-common",
  "libc",
+ "zeroize",
 ]
 
 [[package]]
@@ -1140,6 +1148,15 @@ dependencies = [
  "libc",
  "pamsm",
  "serde_json",
+ "zeroize",
+]
+
+[[package]]
+name = "irlume-password-verify"
+version = "0.11.3"
+dependencies = [
+ "libc",
+ "tempfile",
  "zeroize",
 ]
 
@@ -2574,6 +2591,19 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "termina"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/irlume-core",
     "crates/irlume-kwallet-init",
     "crates/irlume-gkr-unlock",
+    "crates/irlume-password-verify",
     "crates/irlume-auth",
     "crates/irlume-fingerprint",
     "crates/irlume-daemon",

--- a/crates/irlume-auth/Cargo.toml
+++ b/crates/irlume-auth/Cargo.toml
@@ -8,7 +8,16 @@ license.workspace = true
 # embed + liveness gate -> match. Used by both the CLI and the irlumed daemon so
 # the security-critical pipeline lives in exactly one place.
 
+[features]
+default = []
+ir-only-evaluation = ["dep:libc", "irlume-camera/capture-timing"]
+
+[[example]]
+name = "ir_only_evaluation"
+required-features = ["ir-only-evaluation"]
+
 [dependencies]
+libc = { workspace = true, optional = true }
 sha2.workspace = true
 irlume-common.workspace = true
 irlume-camera.workspace = true
@@ -19,3 +28,7 @@ serde_json.workspace = true
 
 [lints]
 workspace = true
+
+[[example]]
+name = "ir_recorded_pad"
+required-features = ["ir-only-evaluation"]

--- a/crates/irlume-auth/examples/ir_only_evaluation.rs
+++ b/crates/irlume-auth/examples/ir_only_evaluation.rs
@@ -1,0 +1,313 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! Root-only, non-granting, one-presentation IR developer diagnostic.
+use irlume_auth::ir_only_evaluation::{valid_budget, Category, Report};
+use std::{
+    io::Read,
+    os::fd::AsRawFd,
+    path::Path,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::{Duration, Instant},
+};
+
+const HELP: &str = "Non-granting IR-only developer evaluation. Never authenticates or releases credentials.\nUsage: ir_only_evaluation (--evaluate|--preflight) USER DETECTOR RECOGNIZER FLIR --budget-ms 100..30000 [--adapter PATH] [--cancel-on-stdin]\nModel paths must be absolute. Reads the configured camera pair without discovery.\n--preflight loads models/enrollment but never opens cameras. --evaluate needs an attended start cue.\nWith --cancel-on-stdin, any byte, EOF or read error requests cooperative cancellation.\nThe budget covers capture/inference, not model loading or template-key unseal.\n";
+
+#[derive(Debug, PartialEq, Eq)]
+struct Options {
+    preflight: bool,
+    user: String,
+    detector: String,
+    recognizer: String,
+    pad: String,
+    budget_ms: u64,
+    adapter: Option<String>,
+    cancel_on_stdin: bool,
+}
+
+fn parse(args: &[String]) -> Option<Options> {
+    if args.len() < 7 || args.len() > 10 || args.iter().any(|s| s.is_empty() || s.len() > 4096) {
+        return None;
+    }
+    let preflight = match args[0].as_str() {
+        "--preflight" => true,
+        "--evaluate" => false,
+        _ => return None,
+    };
+    let user = &args[1];
+    if user.len() > 256
+        || !user
+            .bytes()
+            .next()
+            .is_some_and(|b| b.is_ascii_alphabetic() || b == b'_')
+        || !user
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-' | b'.'))
+    {
+        return None;
+    }
+    if !args[2..5].iter().all(|path| Path::new(path).is_absolute()) {
+        return None;
+    }
+    let mut budget = None;
+    let mut adapter = None;
+    let mut cancel_on_stdin = false;
+    let mut rest = args[5..].iter();
+    while let Some(arg) = rest.next() {
+        match arg.as_str() {
+            "--budget-ms" if budget.is_none() => budget = Some(rest.next()?.parse::<u64>().ok()?),
+            "--adapter" if adapter.is_none() => {
+                let path = rest.next()?;
+                if !Path::new(path).is_absolute() {
+                    return None;
+                }
+                adapter = Some(path.clone());
+            }
+            "--cancel-on-stdin" if !cancel_on_stdin => cancel_on_stdin = true,
+            _ => return None,
+        }
+    }
+    let budget_ms = budget?;
+    if !valid_budget(Duration::from_millis(budget_ms)) {
+        return None;
+    }
+    Some(Options {
+        preflight,
+        user: user.clone(),
+        detector: args[2].clone(),
+        recognizer: args[3].clone(),
+        pad: args[4].clone(),
+        budget_ms,
+        adapter,
+        cancel_on_stdin,
+    })
+}
+
+fn root() -> bool {
+    // SAFETY: getuid/geteuid take no pointers and have no failure convention.
+    unsafe { libc::getuid() == 0 && libc::geteuid() == 0 }
+}
+
+fn disable_process_dumps() -> bool {
+    let limits = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+    // SAFETY: limits points to the initialized platform rlimit ABI type.
+    if unsafe { libc::setrlimit(libc::RLIMIT_CORE, &limits) } != 0 {
+        return false;
+    }
+    // SAFETY: PR_SET_DUMPABLE takes a boolean scalar and no pointer arguments.
+    unsafe {
+        libc::prctl(
+            libc::PR_SET_DUMPABLE,
+            0 as libc::c_ulong,
+            0 as libc::c_ulong,
+            0 as libc::c_ulong,
+            0 as libc::c_ulong,
+        ) == 0
+    }
+}
+
+fn quiet_dependencies() -> bool {
+    let Ok(null) = std::fs::OpenOptions::new().write(true).open("/dev/null") else {
+        return false;
+    };
+    // SAFETY: null owns a valid descriptor and STDERR_FILENO is the process's
+    // standard error slot. Called before spawning the stdin/model worker threads.
+    unsafe { libc::dup2(null.as_raw_fd(), libc::STDERR_FILENO) >= 0 }
+}
+
+fn run(options: &Options) -> Report {
+    if !root() {
+        return Report::new(Category::RootRequired);
+    }
+    // The reused libraries can emit diagnostic measurements. Refuse debug mode
+    // and suppress all dependency stderr before model loading or biometric reads.
+    if irlume_common::dbglog::on()
+        || std::env::var_os("IRLUME_TEST_ALLOW_VIRTUAL_CAMERA").is_some()
+        || !disable_process_dumps()
+        || !quiet_dependencies()
+    {
+        return Report::new(Category::InvalidRequest);
+    }
+    std::panic::set_hook(Box::new(|_| {}));
+    let cancelled = Arc::new(AtomicBool::new(false));
+    if options.cancel_on_stdin {
+        let signal = Arc::clone(&cancelled);
+        if std::thread::Builder::new()
+            .name("ir-evaluation-cancel".into())
+            .spawn(move || {
+                let _ = std::io::stdin().read(&mut [0u8; 1]);
+                signal.store(true, Ordering::Release);
+            })
+            .is_err()
+        {
+            return Report::new(Category::InvalidRequest);
+        }
+    }
+    let control = irlume_camera::CaptureControl::new(
+        irlume_camera::no_progress(),
+        Arc::new(move || cancelled.load(Ordering::Acquire)),
+    );
+    let load = || -> Result<_, Category> {
+        control.check().map_err(|_| Category::Cancelled)?;
+        let (rgb, ir) =
+            irlume_camera::configured_pair_no_probe().ok_or(Category::CameraUnavailable)?;
+        if !irlume_common::platform::user_exists(&options.user) {
+            return Err(Category::EnrollmentUnavailable);
+        }
+        for path in [&options.detector, &options.recognizer, &options.pad]
+            .into_iter()
+            .chain(options.adapter.iter())
+        {
+            if !Path::new(path).is_file() {
+                return Err(Category::ModelsUnavailable);
+            }
+        }
+        let mut engine = irlume_auth::Engine::load(&options.detector, &options.recognizer)
+            .map_err(|_| Category::ModelsUnavailable)?
+            .with_devices(&rgb, &ir);
+        control.check().map_err(|_| Category::Cancelled)?;
+        engine = engine
+            .with_pad_ir(&options.pad)
+            .map_err(|_| Category::ModelsUnavailable)?;
+        if let Some(path) = &options.adapter {
+            engine = engine
+                .with_ir_adapter(path)
+                .map_err(|_| Category::ModelsUnavailable)?;
+        }
+        control.check().map_err(|_| Category::Cancelled)?;
+        // Existing protected enrollment loader, read-only. An encrypted store
+        // may unseal its template encryption key; no login credential API.
+        let enrollment = irlume_core::storage::load_read_only(&options.user)
+            .map_err(|_| Category::EnrollmentUnavailable)?
+            .ok_or(Category::EnrollmentUnavailable)?;
+        if enrollment.user != options.user {
+            return Err(Category::EnrollmentUnavailable);
+        }
+        control.check().map_err(|_| Category::Cancelled)?;
+        Ok((engine, enrollment))
+    };
+    match load() {
+        Err(category) => Report::new(category),
+        Ok((mut engine, enrollment)) if !options.preflight => engine.evaluate_ir_only(
+            &enrollment,
+            &control,
+            Duration::from_millis(options.budget_ms),
+        ),
+        Ok((engine, enrollment)) => {
+            let start = Instant::now();
+            let category = engine.ir_only_evaluation_preflight(&enrollment);
+            let mut report = Report::new(if control.check().is_err() {
+                Category::Cancelled
+            } else {
+                category
+            });
+            report.elapsed_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
+            report
+        }
+    }
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.as_slice() == ["--help"] {
+        print!("{HELP}");
+        return;
+    }
+    let Some(options) = parse(&args) else {
+        println!("{}", Report::new(Category::InvalidRequest).to_json());
+        std::process::exit(2);
+    };
+    let report = run(&options);
+    println!("{}", report.to_json());
+    // Status 0 means a diagnostic completed, including refusals. Never login.
+    if report.category == Category::RootRequired {
+        std::process::exit(2);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn args() -> Vec<String> {
+        [
+            "--evaluate",
+            "someone",
+            "/det",
+            "/emb",
+            "/pad",
+            "--budget-ms",
+            "5000",
+        ]
+        .map(str::to_owned)
+        .to_vec()
+    }
+    #[test]
+    fn ir_only_evaluation_arguments_require_explicit_bounded_action() {
+        let base = args();
+        assert!(parse(&base).is_some());
+        for (index, value) in [
+            (0, "--authenticate"),
+            (1, "../private"),
+            (2, "relative"),
+            (6, "0"),
+            (6, "99"),
+            (6, "30001"),
+            (6, "NaN"),
+            (6, "18446744073709551616"),
+        ] {
+            let mut input = base.clone();
+            input[index] = value.into();
+            assert!(parse(&input).is_none(), "accepted invalid argument {index}");
+        }
+        assert!(parse(&base[..5]).is_none());
+    }
+    #[test]
+    fn ir_only_evaluation_arguments_accept_preflight_and_cancel_but_reject_duplicates() {
+        let mut input = args();
+        input[0] = "--preflight".into();
+        input.extend(["--adapter", "/adapter", "--cancel-on-stdin"].map(str::to_owned));
+        let parsed = parse(&input).expect("preflight arguments");
+        assert!(parsed.preflight && parsed.cancel_on_stdin);
+        assert_eq!(parsed.adapter.as_deref(), Some("/adapter"));
+        input.push("--cancel-on-stdin".into());
+        assert!(parse(&input).is_none());
+        let mut input = args();
+        input.extend(["--budget-ms", "5000"].map(str::to_owned));
+        assert!(parse(&input).is_none());
+    }
+    #[test]
+    fn ir_only_evaluation_disables_crash_dump_persistence_in_child() {
+        const CHILD: &str = "IRLUME_EVALUATION_DUMP_TEST_CHILD";
+        if std::env::var_os(CHILD).is_some() {
+            assert!(disable_process_dumps());
+            // SAFETY: GET_DUMPABLE reads the current process flag without pointers.
+            assert_eq!(unsafe { libc::prctl(libc::PR_GET_DUMPABLE, 0, 0, 0, 0) }, 0);
+            let mut limits = libc::rlimit {
+                rlim_cur: 1,
+                rlim_max: 1,
+            };
+            // SAFETY: limits is writable storage of the expected ABI type.
+            assert_eq!(
+                unsafe { libc::getrlimit(libc::RLIMIT_CORE, &mut limits) },
+                0
+            );
+            assert_eq!((limits.rlim_cur, limits.rlim_max), (0, 0));
+            return;
+        }
+        let status = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "tests::ir_only_evaluation_disables_crash_dump_persistence_in_child",
+            ])
+            .env(CHILD, "1")
+            .status()
+            .unwrap();
+        assert!(status.success());
+    }
+}

--- a/crates/irlume-auth/examples/ir_recorded_pad.rs
+++ b/crates/irlume-auth/examples/ir_recorded_pad.rs
@@ -1,0 +1,299 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! Offline frame-level PAD regression only; no identity match or authentication.
+//! Usage: ir_recorded_pad ABS_DETECTOR ABS_FLIR ABS_DIRECTORY
+//! All stored PGM frames are processed. Illumination metadata, strobe pairing,
+//! burst selection, and other authentication gates are unavailable here.
+
+#[derive(Default)]
+struct Counts {
+    total_frames: usize,
+    no_face: usize,
+    pad_evaluated: usize,
+    pad_refused: usize,
+    pad_below_threshold: usize,
+    invalid_or_failed: usize,
+}
+
+const MAX_PIXELS: usize = 16 * 1024 * 1024;
+const MAX_FILE_BYTES: usize = MAX_PIXELS + 4096;
+const MAX_FRAMES: usize = 4096;
+
+/// P5 with a bounded header, 8-bit full-scale pixels, and exactly one raster.
+/// Exactly one whitespace byte follows maxval: binary whitespace is pixel data.
+fn parse_pgm(raw: &[u8]) -> Result<(u32, u32, &[u8]), ()> {
+    if raw.len() > MAX_FILE_BYTES
+        || !raw.starts_with(b"P5")
+        || !raw.get(2).is_some_and(u8::is_ascii_whitespace)
+    {
+        return Err(());
+    }
+    let mut i = 2;
+    let mut fields = [0usize; 3];
+    for field in &mut fields {
+        loop {
+            while raw.get(i).is_some_and(u8::is_ascii_whitespace) {
+                i += 1;
+            }
+            if raw.get(i) != Some(&b'#') {
+                break;
+            }
+            while raw.get(i).is_some_and(|b| *b != b'\n') {
+                i += 1;
+            }
+        }
+        let start = i;
+        while let Some(b) = raw.get(i).filter(|b| b.is_ascii_digit()) {
+            *field = field
+                .checked_mul(10)
+                .and_then(|v| v.checked_add((*b - b'0') as usize))
+                .ok_or(())?;
+            i += 1;
+        }
+        if start == i || i > 4095 || !raw.get(i).is_some_and(u8::is_ascii_whitespace) {
+            return Err(());
+        }
+    }
+    i += 1;
+    let [w, h, maxval] = fields;
+    if w == 0 || h == 0 || w > 4096 || h > 4096 || maxval != 255 {
+        return Err(());
+    }
+    let len = w.checked_mul(h).filter(|v| *v <= MAX_PIXELS).ok_or(())?;
+    if i.checked_add(len) != Some(raw.len()) {
+        return Err(());
+    }
+    Ok((w as u32, h as u32, &raw[i..]))
+}
+
+impl Counts {
+    fn record(&mut self, result: Result<Option<f32>, ()>, threshold: f32) {
+        self.total_frames += 1;
+        match result {
+            Ok(None) => self.no_face += 1,
+            Ok(Some(p)) if p.is_finite() && (0.0..=1.0).contains(&p) => {
+                self.pad_evaluated += 1;
+                if p >= threshold {
+                    self.pad_refused += 1;
+                } else {
+                    self.pad_below_threshold += 1;
+                }
+            }
+            _ => self.invalid_or_failed += 1,
+        }
+    }
+    fn exit_code(&self) -> u8 {
+        u8::from(self.invalid_or_failed > 0)
+    }
+}
+
+use std::io::{Read, Write};
+use std::os::fd::AsRawFd;
+use std::path::{Path, PathBuf};
+
+fn protect_process() -> Result<(), ()> {
+    let limits = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+    // SAFETY: limits is an initialized rlimit ABI structure.
+    if unsafe { libc::setrlimit(libc::RLIMIT_CORE, &limits) } != 0 {
+        return Err(());
+    }
+    // SAFETY: PR_SET_DUMPABLE consumes scalar arguments and no pointers.
+    if unsafe {
+        libc::prctl(
+            libc::PR_SET_DUMPABLE,
+            0 as libc::c_ulong,
+            0 as libc::c_ulong,
+            0 as libc::c_ulong,
+            0 as libc::c_ulong,
+        )
+    } != 0
+    {
+        return Err(());
+    }
+    let null = std::fs::OpenOptions::new()
+        .write(true)
+        .open("/dev/null")
+        .map_err(|_| ())?;
+    // SAFETY: null owns a valid FD; stderr is replaced before library threads start.
+    if unsafe { libc::dup2(null.as_raw_fd(), libc::STDERR_FILENO) } < 0 {
+        return Err(());
+    }
+    Ok(())
+}
+
+fn pgms(root: &Path) -> Result<Vec<PathBuf>, ()> {
+    if !root.is_absolute() || !root.is_dir() {
+        return Err(());
+    }
+    let mut paths = Vec::new();
+    for entry in std::fs::read_dir(root).map_err(|_| ())? {
+        let entry = entry.map_err(|_| ())?;
+        if entry.path().extension().is_some_and(|ext| ext == "pgm") {
+            if !entry.file_type().map_err(|_| ())?.is_file() || paths.len() == MAX_FRAMES {
+                return Err(());
+            }
+            paths.push(entry.path());
+        }
+    }
+    if paths.is_empty() {
+        return Err(());
+    }
+    paths.sort();
+    Ok(paths)
+}
+
+fn frame(
+    path: &Path,
+    det: &mut irlume_vision::Detector,
+    pad: &mut irlume_vision::PadIr,
+) -> Result<Option<f32>, ()> {
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
+        .open(path)
+        .map_err(|_| ())?;
+    let metadata = file.metadata().map_err(|_| ())?;
+    if !metadata.is_file() || metadata.len() > MAX_FILE_BYTES as u64 {
+        return Err(());
+    }
+    let mut raw = Vec::new();
+    file.take((MAX_FILE_BYTES + 1) as u64)
+        .read_to_end(&mut raw)
+        .map_err(|_| ())?;
+    let (width, height, grey) = parse_pgm(&raw)?;
+    let rgb = irlume_camera::grey_to_rgb(grey);
+    let view = irlume_vision::align::RgbView {
+        data: &rgb,
+        width,
+        height,
+    };
+    let faces = det.detect(&view).map_err(|_| ())?;
+    let Some(face) = faces.iter().max_by(|a, b| a.score.total_cmp(&b.score)) else {
+        return Ok(None);
+    };
+    // Same highest-score selection as authentication; invalid output fails closed.
+    if !irlume_vision::detection_is_finite(face)
+        || !(0.0..=1.0).contains(&face.score)
+        || face.bbox[2] <= face.bbox[0]
+        || face.bbox[3] <= face.bbox[1]
+    {
+        return Err(());
+    }
+    pad.p_fake(&view, &face.bbox).map(Some).map_err(|_| ())
+}
+
+use std::os::unix::fs::OpenOptionsExt;
+
+fn run() -> Result<Counts, ()> {
+    let args: Vec<_> = std::env::args().skip(1).collect();
+    let [detector, flir, directory] = args.as_slice() else {
+        return Err(());
+    };
+    if irlume_common::dbglog::on()
+        || [detector, flir]
+            .iter()
+            .any(|p| !Path::new(p).is_absolute() || !Path::new(p).is_file())
+    {
+        return Err(());
+    }
+    let paths = pgms(Path::new(directory))?;
+    let mut det = irlume_vision::Detector::load_from_file(detector).map_err(|_| ())?;
+    let mut pad = irlume_vision::PadIr::load_from_file(flir).map_err(|_| ())?;
+    let mut counts = Counts::default();
+    for path in paths {
+        counts.record(
+            frame(&path, &mut det, &mut pad),
+            irlume_auth::IR_PAD_THRESHOLD,
+        );
+    }
+    Ok(counts)
+}
+
+fn main() -> std::process::ExitCode {
+    // No input/model reads occur until dump prevention and stderr suppression succeed.
+    let result = protect_process().and_then(|()| {
+        std::panic::set_hook(Box::new(|_| {}));
+        std::panic::catch_unwind(run).map_err(|_| ())?
+    });
+    // Setup failures have zero frames and one invalid_or_failed operation.
+    let counts = result.unwrap_or(Counts {
+        invalid_or_failed: 1,
+        ..Counts::default()
+    });
+    let output = serde_json::json!({
+        "schema_version": 1, "diagnostic_only": true, "authentication_granted": false,
+        "total_frames": counts.total_frames, "no_face": counts.no_face,
+        "pad_evaluated": counts.pad_evaluated, "pad_refused": counts.pad_refused,
+        "pad_below_threshold": counts.pad_below_threshold, "invalid_or_failed": counts.invalid_or_failed,
+    });
+    if writeln!(std::io::stdout().lock(), "{output}").is_err() {
+        return std::process::ExitCode::FAILURE;
+    }
+    std::process::ExitCode::from(counts.exit_code())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn preserves_binary_whitespace_and_hash_pixels() {
+        let raw = b"P5\n# fixture\n3 1\n255\n\n #";
+        assert_eq!(parse_pgm(raw), Ok((3, 1, &b"\n #"[..])));
+    }
+    #[test]
+    fn rejects_malformed_dimensions_headers_and_raster_lengths() {
+        for raw in [
+            &b"P5\n0 1\n255\n"[..],
+            &b"P5\n4097 1\n255\nx"[..],
+            &b"P5\n184467440737095516160 1\n255\nx"[..],
+            &b"P5\n1 1\n256\nx"[..],
+            &b"P5\n1 1\n255x"[..],
+            &b"P51 1 255\nx"[..],
+            &b"P2\n1 1\n255\nx"[..],
+            &b"P5\n1 1\n255\n"[..],
+            &b"P5\n1 1\n255\nxy"[..],
+            &b"P5\n1x1\n255\nx"[..],
+            &b"P5\n# unfinished"[..],
+        ] {
+            assert!(parse_pgm(raw).is_err());
+        }
+    }
+    #[test]
+    fn missing_face_never_credits_pad() {
+        let mut c = Counts::default();
+        c.record(Ok(None), 0.9);
+        assert_eq!(
+            (
+                c.total_frames,
+                c.no_face,
+                c.pad_evaluated,
+                c.pad_below_threshold,
+                c.invalid_or_failed
+            ),
+            (1, 1, 0, 0, 0)
+        );
+    }
+    #[test]
+    fn threshold_equality_refuses_and_invalid_pad_fails() {
+        let mut c = Counts::default();
+        for p in [0.0, 0.9, 1.0, f32::NAN, f32::INFINITY, -0.1, 1.1] {
+            c.record(Ok(Some(p)), 0.9);
+        }
+        c.record(Err(()), 0.9);
+        assert_eq!(
+            (
+                c.total_frames,
+                c.pad_evaluated,
+                c.pad_refused,
+                c.pad_below_threshold,
+                c.invalid_or_failed
+            ),
+            (8, 3, 2, 1, 5)
+        );
+        assert_ne!(c.exit_code(), 0);
+    }
+}

--- a/crates/irlume-auth/src/authentication_window.rs
+++ b/crates/irlume-auth/src/authentication_window.rs
@@ -1,0 +1,61 @@
+use std::time::{Duration, Instant};
+
+/// One presence window, retained through the daemon's response admission.
+/// Zero milliseconds preserves the explicit legacy one-shot configuration.
+#[derive(Clone, Copy)]
+pub struct AuthenticationWindow {
+    pub(crate) deadline: Instant,
+    pub(crate) milliseconds: u64,
+}
+
+impl AuthenticationWindow {
+    /// Start the configured window for a PAM service.
+    pub fn for_service(service: Option<&str>) -> Self {
+        Self::new(super::grace_window_ms(service))
+    }
+
+    pub(crate) fn new(milliseconds: u64) -> Self {
+        Self {
+            deadline: Instant::now() + Duration::from_millis(milliseconds),
+            milliseconds,
+        }
+    }
+
+    pub(crate) fn capture_deadline(self) -> Option<Instant> {
+        (self.milliseconds != 0).then_some(self.deadline)
+    }
+
+    /// Remaining response-write budget, or None for legacy one-shot mode.
+    pub fn remaining(self) -> Option<Duration> {
+        self.capture_deadline()
+            .map(|deadline| deadline.saturating_duration_since(Instant::now()))
+    }
+
+    /// Check response eligibility; this cannot interrupt a blocking system call.
+    ///
+    /// # Errors
+    /// Returns [`irlume_common::Error::DeadlineExpired`] once the window expires.
+    pub fn check(self) -> irlume_common::Result<()> {
+        if self
+            .capture_deadline()
+            .is_some_and(|deadline| Instant::now() >= deadline)
+        {
+            Err(irlume_common::Error::DeadlineExpired)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// Restore request-local state on early return and unwind. The reusable engine's
+/// enrollment/diagnostic paths must never inherit an authentication deadline.
+pub(super) struct Scope<'a> {
+    pub(super) engine: &'a mut super::Engine,
+    pub(super) previous: Option<Instant>,
+}
+
+impl Drop for Scope<'_> {
+    fn drop(&mut self) {
+        self.engine.authentication_deadline = self.previous;
+    }
+}

--- a/crates/irlume-auth/src/engine_tests/grouped_tests.rs
+++ b/crates/irlume-auth/src/engine_tests/grouped_tests.rs
@@ -201,6 +201,46 @@ fn grouped_deadline_checks_before_and_after_inference() {
 }
 
 #[test]
+fn grouped_request_cancellation_checks_before_and_after_inference() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    let _guard = env_guard();
+    let mut s = shared();
+    for cancel_at in [0, 1, 5, 6] {
+        let cancelled = std::sync::Arc::new(AtomicBool::new(cancel_at == 0));
+        let signal = std::sync::Arc::clone(&cancelled);
+        s.engine
+            .set_request_cancel_signal(std::sync::Arc::new(move || signal.load(Ordering::SeqCst)));
+        let identities = Cell::new(0);
+        let assessed = Cell::new(0);
+        let result = s.engine.evaluate_grouped_samples_with(
+            (0..5).collect(),
+            Instant::now() + Duration::from_secs(15),
+            |e, i| {
+                assessed.set(assessed.get() + 1);
+                let evidence = sample(e, i, 0.2);
+                if cancel_at == i + 1 {
+                    cancelled.store(true, Ordering::SeqCst);
+                }
+                Ok(evidence)
+            },
+            |_, evidence| {
+                identities.set(identities.get() + 1);
+                cancelled.store(true, Ordering::SeqCst);
+                Ok(evidence.assessment)
+            },
+            Instant::now,
+        );
+        s.engine.request_cancelled = None;
+        let cleared = s.engine.vit_scores.is_empty();
+        s.engine.vit_scores.clear();
+        assert!(matches!(result, Err(irlume_common::Error::Preempted(_))));
+        assert_eq!(identities.get(), usize::from(cancel_at == 6));
+        assert_eq!(assessed.get(), cancel_at.min(5));
+        assert!(cleared, "cancelled group must discard pending evidence");
+    }
+}
+
+#[test]
 fn grouped_inference_errors_clear_all_evidence() {
     let _guard = env_guard();
     let mut s = shared();
@@ -848,4 +888,23 @@ fn grouped_missing_face_not_applicable_is_retryable_before_valid_dark_identity()
         s.engine.vit_scores.clear();
         assert!(out.granted, "{}", out.reason);
     }
+}
+
+#[test]
+fn grouped_deadline_classification_survives_the_real_engine_scope() {
+    let _guard = env_guard();
+    let mut state = shared();
+    let expired = Instant::now();
+    state.engine.authentication_deadline = Some(expired);
+    let result = state.engine.evaluate_grouped_samples_with(
+        (0..5).collect(),
+        expired,
+        |_, _| panic!("expired group must not assess evidence"),
+        |_, _: DeferredAssessment<()>| panic!("expired group must not materialize identity"),
+        Instant::now,
+    );
+    state.engine.authentication_deadline = None;
+    assert!(
+        matches!(result, Ok(PreparedGroup::Refused(ref outcome)) if outcome.kind == OutcomeKind::DeadlineExpired)
+    );
 }

--- a/crates/irlume-auth/src/grouped_auth.rs
+++ b/crates/irlume-auth/src/grouped_auth.rs
@@ -165,6 +165,7 @@ impl Engine {
         self.begin_grouped_attempt();
         // The closure makes all errors and refusals share the evidence reset.
         let result = (|| {
+            self.check_request_cancelled()?;
             if samples.len() != VIT_PAD_VOTE_N {
                 return Err(irlume_common::Error::Hardware(
                     "incomplete grouped evidence".into(),
@@ -172,10 +173,12 @@ impl Engine {
             }
             for (index, sample) in samples.into_iter().enumerate() {
                 self.note_capture_boundary();
+                self.check_request_cancelled()?;
                 if now() >= deadline {
                     return Ok(PreparedGroup::Refused(expired()));
                 }
                 let mut evidence = assess(self, sample)?;
+                self.check_request_cancelled()?;
                 self.last_attempt_facts = AttemptFacts::from_assessment(&evidence.assessment);
                 if now() >= deadline {
                     return Ok(PreparedGroup::Refused(expired()));
@@ -195,10 +198,12 @@ impl Engine {
                     continue;
                 }
                 if final_sample {
+                    self.check_request_cancelled()?;
                     if now() >= deadline {
                         return Ok(PreparedGroup::Refused(expired()));
                     }
                     let assessment = materialize(self, evidence)?;
+                    self.check_request_cancelled()?;
                     if now() >= deadline {
                         return Ok(PreparedGroup::Refused(expired()));
                     }
@@ -239,9 +244,9 @@ impl Engine {
                 "grouped capture requires an exact runtime contract".into(),
             )
         })?;
-        let progress = self.capture_progress();
+        let control = self.capture_control();
         let started = Instant::now();
-        let samples = irlume_camera::capture_sequential_batch_with_progress(
+        let samples = irlume_camera::capture_sequential_batch_with_control(
             &cameras.0,
             &cameras.1,
             contract,
@@ -250,7 +255,7 @@ impl Engine {
                 pair_gap_limit: SEQUENTIAL_MAX_CROSS_SPECTRUM_SKEW,
                 deadline,
             },
-            &progress,
+            &control,
         )?;
         irlume_common::dlog!(
             "[assessment-stage] grouped-capture: pairs={} elapsed={}ms",

--- a/crates/irlume-auth/src/ir_assessment.rs
+++ b/crates/irlume-auth/src/ir_assessment.rs
@@ -1,0 +1,1194 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! Private IR evidence shared by diagnostic and authentication consumers.
+
+use super::*;
+
+pub(super) struct IrAssessment {
+    pub(super) matched: IrMatch,
+    pub(super) signals: Signals,
+    pub(super) pad: PadEvidence,
+}
+
+fn enrollment_readiness(
+    enrollment: &irlume_core::storage::Enrollment,
+    identity: &str,
+    compatible_templates: usize,
+) -> irlume_common::IrOnlyReadiness {
+    use irlume_common::IrOnlyReadiness as Ready;
+    if legacy_eye_policy(enrollment).is_err() {
+        return Ready::IncompatibleEnrollment;
+    }
+    let Some(binding) = enrollment
+        .camera_binding
+        .as_ref()
+        .and_then(|binding| binding.ir.as_deref())
+    else {
+        return Ready::BindingUnavailable;
+    };
+    if binding != identity {
+        return Ready::BindingMismatch;
+    }
+    if compatible_templates == 0 {
+        return Ready::IncompatibleEnrollment;
+    }
+    Ready::ReadyForExperimentalAttempt
+}
+
+fn model_readiness(
+    target_available: bool,
+    adapter_required: bool,
+    adapter_loaded: bool,
+    pad_loaded: bool,
+) -> Option<irlume_common::IrOnlyReadiness> {
+    use irlume_common::IrOnlyReadiness as Ready;
+    if !target_available {
+        Some(Ready::TargetUnavailable)
+    } else if adapter_required && !adapter_loaded {
+        Some(Ready::ModelsUnavailable)
+    } else if !pad_loaded {
+        Some(Ready::PadUnavailable)
+    } else {
+        None
+    }
+}
+
+pub(super) fn assessed_outcome(
+    assessment: &IrAssessment,
+    enrollment: &irlume_core::storage::Enrollment,
+    adapter: bool,
+) -> Outcome {
+    let pad = match assessment.pad {
+        PadEvidence::Score(score) => Some(Ok(score)),
+        PadEvidence::InferenceFailed => Some(Err(irlume_common::Error::Hardware(
+            "IR PAD unavailable".into(),
+        ))),
+        _ => None,
+    };
+    if let Err(failure) = gate_policy(&assessment.signals, pad, enrollment) {
+        return refusal_outcome(failure);
+    }
+    let matched = &assessment.matched;
+    if matched.n_templates == 0 {
+        return refusal_outcome(IrFailure::IncompatibleEnrollment);
+    }
+    let (best, centroid) =
+        IdentityThresholds::new(matched.n_templates, enrollment.profiles.len(), adapter)
+            .arms(matched);
+    if best {
+        return Outcome::grant(
+            matched.best,
+            format!("match: {} (experimental IR-only)", matched.best_who),
+        );
+    }
+    if centroid {
+        if let Some((score, who)) = &matched.centroid {
+            return Outcome::grant(
+                *score,
+                format!("match: {who} (experimental IR-only centroid)"),
+            );
+        }
+    }
+    Outcome::deny_live(
+        OutcomeKind::BelowThreshold,
+        matched.best,
+        "below threshold (experimental IR-only)",
+    )
+}
+
+pub(super) fn refusal_outcome(failure: IrFailure) -> Outcome {
+    let (kind, reason) = match failure {
+        IrFailure::NoFace => (OutcomeKind::NoFace, "no face in IR"),
+        IrFailure::PadRefused => (
+            OutcomeKind::Spoof,
+            "IR PAD refused the presentation; use your password",
+        ),
+        IrFailure::LivenessRefused => (
+            OutcomeKind::OtherDeny,
+            "IR liveness refused the presentation; use your password",
+        ),
+        IrFailure::IncompatibleEnrollment => (
+            OutcomeKind::SetupUnavailable,
+            "no compatible IR enrollment; add fresh scans or use your password",
+        ),
+        IrFailure::PadUnavailable | IrFailure::PadInvalid => (
+            OutcomeKind::RuntimeUnavailable,
+            "required IR PAD evidence is unavailable; use your password",
+        ),
+        IrFailure::DeadlineExpired => (
+            OutcomeKind::DeadlineExpired,
+            "authentication deadline expired",
+        ),
+        _ => (
+            OutcomeKind::RuntimeUnavailable,
+            "IR assessment is unavailable; use your password",
+        ),
+    };
+    Outcome::deny(kind, reason)
+}
+
+pub(super) struct IdentityThresholds {
+    pub(super) best: f32,
+    pub(super) centroid: f32,
+}
+
+impl IdentityThresholds {
+    pub(super) fn new(templates: usize, profiles: usize, adapter: bool) -> Self {
+        let base = if adapter {
+            irlume_core::IR_ADAPTED_MATCH_THRESHOLD
+        } else {
+            irlume_core::IR_DARK_MATCH_THRESHOLD
+        };
+        Self {
+            best: irlume_core::scaled_threshold(base, templates),
+            centroid: irlume_core::scaled_threshold(base, profiles),
+        }
+    }
+
+    pub(super) fn arms(&self, matched: &IrMatch) -> (bool, bool) {
+        if matched.n_templates == 0 {
+            return (false, false);
+        }
+        (
+            matched.best.is_finite() && matched.best >= self.best,
+            matched
+                .centroid
+                .as_ref()
+                .is_some_and(|(score, _)| score.is_finite() && *score >= self.centroid),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn production_ir_model_readiness_requires_pad_and_explicit_adapter() {
+        use irlume_common::IrOnlyReadiness as Ready;
+        for available in [false, true] {
+            for required in [false, true] {
+                for adapter in [false, true] {
+                    for pad in [false, true] {
+                        let result = model_readiness(available, required, adapter, pad);
+                        assert_eq!(result.is_none(), available && (!required || adapter) && pad);
+                        if !available {
+                            assert_eq!(result, Some(Ready::TargetUnavailable));
+                        } else if required && !adapter {
+                            assert_eq!(result, Some(Ready::ModelsUnavailable));
+                        } else if !pad {
+                            assert_eq!(result, Some(Ready::PadUnavailable));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    struct SyntheticStages {
+        at: Option<&'static str>,
+        fail: Option<IrFailure>,
+        cancel: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        reached: Vec<&'static str>,
+        pad: PadEvidence,
+    }
+    impl SyntheticStages {
+        fn step(&mut self, at: &'static str) -> Result<(), IrFailure> {
+            self.reached.push(at);
+            if self.at == Some(at) {
+                if let Some(fail) = self.fail {
+                    return Err(fail);
+                }
+                self.cancel
+                    .store(true, std::sync::atomic::Ordering::Release);
+            }
+            Ok(())
+        }
+    }
+    impl AssessmentStages for SyntheticStages {
+        type Captured = ();
+        type Detected = ();
+        type Aligned = ();
+        type Embedded = ();
+        fn preflight(&mut self) -> Result<(), IrFailure> {
+            self.step("preflight")
+        }
+        fn capture(
+            &mut self,
+            _: &irlume_camera::CaptureControl,
+            _: Option<std::time::Instant>,
+        ) -> Result<(), IrFailure> {
+            self.step("capture")
+        }
+        fn detect(&mut self, _: ()) -> Result<(), IrFailure> {
+            self.step("detect")
+        }
+        fn signals(&self, _: &()) -> Signals {
+            Signals {
+                ir_face: Some(irlume_liveness::FaceBox {
+                    cx: 0.5,
+                    cy: 0.5,
+                    score: 0.99,
+                }),
+                ir_face_brightness: 100.0,
+                ir_center_edge_ratio: 1.5,
+                ir_ceiling_known: true,
+                ir_saturated_frac: Some(0.0),
+                ..Default::default()
+            }
+        }
+        fn pad(&mut self, _: &()) -> Result<PadEvidence, IrFailure> {
+            self.step("pad")?;
+            Ok(self.pad)
+        }
+        fn align(&mut self, _: ()) -> Result<(), IrFailure> {
+            self.step("align")
+        }
+        fn embed(&mut self, _: ()) -> Result<(), IrFailure> {
+            self.step("embed")
+        }
+        fn adapt(&mut self, _: ()) -> Result<Vec<f32>, IrFailure> {
+            self.step("adapt")?;
+            Ok(vec![1.0; EMBED_DIM])
+        }
+        fn identify(&mut self, _: &[f32]) -> IrMatch {
+            self.step("identify").unwrap();
+            IrMatch {
+                best: 1.0,
+                best_who: "synthetic".into(),
+                n_templates: 1,
+                centroid: None,
+            }
+        }
+    }
+
+    #[test]
+    fn production_ir_pipeline_cancels_before_any_later_stage_or_grant() {
+        use std::sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        };
+        let order = [
+            "preflight",
+            "capture",
+            "detect",
+            "pad",
+            "align",
+            "embed",
+            "adapt",
+            "identify",
+        ];
+        for stop in 0..order.len() {
+            let cancel = Arc::new(AtomicBool::new(false));
+            let observed = cancel.clone();
+            let control = irlume_camera::CaptureControl::new(
+                irlume_camera::no_progress(),
+                Arc::new(move || observed.load(Ordering::Acquire)),
+            );
+            let mut stages = SyntheticStages {
+                at: Some(order[stop]),
+                fail: None,
+                cancel,
+                reached: Vec::new(),
+                pad: PadEvidence::Score(0.1),
+            };
+            let run = assess_stages(&mut stages, &control, None);
+            assert!(
+                matches!(run.result, Err(IrFailure::Cancelled)),
+                "{}",
+                order[stop]
+            );
+            assert_eq!(stages.reached, order[..=stop]);
+        }
+    }
+
+    #[test]
+    fn production_ir_pipeline_preserves_zero_window_and_refuses_expiry_and_stage_errors() {
+        let enrollment = irlume_core::storage::Enrollment::new("synthetic");
+        let make = || SyntheticStages {
+            at: None,
+            fail: None,
+            cancel: Default::default(),
+            reached: Vec::new(),
+            pad: PadEvidence::Score(0.1),
+        };
+        let control = irlume_camera::CaptureControl::new(
+            irlume_camera::no_progress(),
+            std::sync::Arc::new(|| false),
+        );
+        let mut stages = make();
+        let run = assess_stages(&mut stages, &control, None);
+        assert!(assessed_outcome(&run.result.unwrap(), &enrollment, false).granted);
+        let mut stages = make();
+        let run = assess_stages(&mut stages, &control, Some(std::time::Instant::now()));
+        assert!(matches!(run.result, Err(IrFailure::DeadlineExpired)));
+        assert!(stages.reached.is_empty());
+        for (at, failure) in [
+            ("preflight", IrFailure::IncompatibleEnrollment),
+            ("capture", IrFailure::CameraCaptureFailed),
+            ("detect", IrFailure::NoFace),
+            ("detect", IrFailure::InvalidFrame),
+            ("pad", IrFailure::PadInvalid),
+            ("align", IrFailure::InferenceFailed),
+            ("embed", IrFailure::InferenceFailed),
+            ("adapt", IrFailure::InferenceFailed),
+        ] {
+            let mut stages = make();
+            stages.at = Some(at);
+            stages.fail = Some(failure);
+            let run = assess_stages(&mut stages, &control, None);
+            assert!(matches!(run.result, Err(found) if found == failure));
+            assert_eq!(stages.reached.last(), Some(&at));
+            assert!(!refusal_outcome(failure).granted);
+        }
+        for pad in [
+            PadEvidence::Unavailable,
+            PadEvidence::InferenceFailed,
+            PadEvidence::Score(f32::NAN),
+            PadEvidence::Score(-1.0),
+            PadEvidence::Score(1.1),
+        ] {
+            let mut stages = make();
+            stages.pad = pad;
+            let run = assess_stages(&mut stages, &control, None);
+            assert!(!assessed_outcome(&run.result.unwrap(), &enrollment, false).granted);
+        }
+    }
+
+    #[test]
+    fn production_ir_attempt_facts_do_not_invent_rgb_measurements() {
+        let signals = Signals {
+            ir_face_brightness: 103.0,
+            face_frac: 0.2,
+            ..Default::default()
+        };
+        let facts = AttemptFacts::from_ir_signals(Some(&signals));
+        let line = attempt_situation_line(OutcomeKind::NoFace, 0.0, &facts);
+        assert!(line.contains("face_frac=0.20") && line.contains("ir_bright=103"));
+        assert!(line.contains("yaw=n/a") && line.contains("rgb_bright=n/a"));
+    }
+
+    #[test]
+    fn ir_preflight_requires_current_binding_and_compatible_templates() {
+        use irlume_common::IrOnlyReadiness as Ready;
+        use irlume_core::storage::{CameraBinding, Enrollment};
+        let mut enrollment = Enrollment::new("synthetic");
+        assert_eq!(
+            enrollment_readiness(&enrollment, "target", 1),
+            Ready::BindingUnavailable
+        );
+        enrollment.camera_binding = Some(CameraBinding {
+            rgb: Some("irrelevant RGB".into()),
+            ir: None,
+        });
+        assert_eq!(
+            enrollment_readiness(&enrollment, "target", 1),
+            Ready::BindingUnavailable
+        );
+        enrollment.camera_binding.as_mut().unwrap().ir = Some("different".into());
+        assert_eq!(
+            enrollment_readiness(&enrollment, "target", 1),
+            Ready::BindingMismatch
+        );
+        enrollment.camera_binding.as_mut().unwrap().ir = Some("target".into());
+        assert_eq!(
+            enrollment_readiness(&enrollment, "target", 0),
+            Ready::IncompatibleEnrollment
+        );
+        assert_eq!(
+            enrollment_readiness(&enrollment, "target", 1),
+            Ready::ReadyForExperimentalAttempt
+        );
+        enrollment.require_eyes_open = true;
+        assert_eq!(
+            enrollment_readiness(&enrollment, "target", 1),
+            Ready::IncompatibleEnrollment
+        );
+    }
+
+    #[test]
+    fn production_ir_outcome_requires_real_pad_gate_and_identity() {
+        let enrollment = irlume_core::storage::Enrollment::new("synthetic");
+        for adapter in [false, true] {
+            let base = if adapter {
+                irlume_core::IR_ADAPTED_MATCH_THRESHOLD
+            } else {
+                irlume_core::IR_DARK_MATCH_THRESHOLD
+            };
+            let assessment = |pad, best, ratio| IrAssessment {
+                matched: IrMatch {
+                    best,
+                    best_who: "synthetic".into(),
+                    n_templates: 1,
+                    centroid: None,
+                },
+                signals: Signals {
+                    ir_face: Some(irlume_liveness::FaceBox {
+                        cx: 0.5,
+                        cy: 0.5,
+                        score: 0.99,
+                    }),
+                    ir_face_brightness: 100.0,
+                    ir_center_edge_ratio: ratio,
+                    ir_ceiling_known: true,
+                    ir_saturated_frac: Some(0.0),
+                    ..Default::default()
+                },
+                pad,
+            };
+            assert!(
+                assessed_outcome(
+                    &assessment(PadEvidence::Score(0.1), base, 1.5),
+                    &enrollment,
+                    adapter
+                )
+                .granted
+            );
+            for pad in [
+                PadEvidence::Unavailable,
+                PadEvidence::InferenceFailed,
+                PadEvidence::NotApplicable,
+                PadEvidence::Pending,
+                PadEvidence::Score(f32::NAN),
+                PadEvidence::Score(f32::INFINITY),
+                PadEvidence::Score(-0.01),
+                PadEvidence::Score(1.01),
+                PadEvidence::Score(0.9),
+            ] {
+                assert!(
+                    !assessed_outcome(&assessment(pad, 1.0, 1.5), &enrollment, adapter).granted,
+                    "{pad:?}"
+                );
+            }
+            assert!(
+                !assessed_outcome(
+                    &assessment(PadEvidence::Score(0.1), 1.0, 0.5),
+                    &enrollment,
+                    adapter
+                )
+                .granted
+            );
+            let mismatch = assessed_outcome(
+                &assessment(PadEvidence::Score(0.1), base - 0.01, 1.5),
+                &enrollment,
+                adapter,
+            );
+            assert!(!mismatch.granted);
+            assert_eq!(mismatch.kind, OutcomeKind::BelowThreshold);
+            assert!(!presence_retryable(&mismatch));
+        }
+    }
+
+    #[test]
+    fn ir_identity_thresholds_preserve_each_raw_and_adapter_boundary_arm() {
+        for adapter in [false, true] {
+            let base = if adapter {
+                irlume_core::IR_ADAPTED_MATCH_THRESHOLD
+            } else {
+                irlume_core::IR_DARK_MATCH_THRESHOLD
+            };
+            let best = irlume_core::scaled_threshold(base, 30);
+            let centroid = irlume_core::scaled_threshold(base, 2);
+            for (b, c, want) in [
+                (best - 0.01, centroid - 0.01, (false, false)),
+                (best, centroid - 0.01, (true, false)),
+                (best - 0.01, centroid, (false, true)),
+                (best, centroid, (true, true)),
+                (f32::NAN, f32::INFINITY, (false, false)),
+            ] {
+                let matched = IrMatch {
+                    best: b,
+                    best_who: "synthetic".into(),
+                    n_templates: 30,
+                    centroid: Some((c, "synthetic".into())),
+                };
+                assert_eq!(IdentityThresholds::new(30, 2, adapter).arms(&matched), want);
+            }
+            let incompatible = IrMatch {
+                best: 1.0,
+                best_who: "synthetic".into(),
+                n_templates: 0,
+                centroid: Some((1.0, "synthetic".into())),
+            };
+            assert_eq!(
+                IdentityThresholds::new(0, 2, adapter).arms(&incompatible),
+                (false, false)
+            );
+        }
+    }
+}
+
+mod pipeline {
+    use super::*;
+    use irlume_camera::CaptureControl;
+    use irlume_core::storage::Enrollment;
+    use std::time::Instant;
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub(crate) enum IrFailure {
+        NoFace,
+        LivenessRefused,
+        PadUnavailable,
+        PadInvalid,
+        PadRefused,
+        IncompatibleEnrollment,
+        InvalidFrame,
+        InferenceFailed,
+        #[cfg(feature = "ir-only-evaluation")]
+        CameraUnavailable,
+        CameraBusy,
+        CameraRateRefused,
+        CameraLeaseTimeout,
+        CameraLeaseRefused,
+        CameraIoFailed,
+        CameraHardwareFailed,
+        CameraAuthorizationRefused,
+        CameraPolicyRefused,
+        CameraCaptureFailed,
+
+        Cancelled,
+        DeadlineExpired,
+        #[cfg(feature = "ir-only-evaluation")]
+        InvalidRequest,
+    }
+    pub(crate) fn error_failure(error: irlume_common::Error) -> IrFailure {
+        match error {
+            irlume_common::Error::Preempted(_) => IrFailure::Cancelled,
+            irlume_common::Error::DeadlineExpired => IrFailure::DeadlineExpired,
+            irlume_common::Error::CameraBusy(_) => IrFailure::CameraBusy,
+            irlume_common::Error::DeliveredRate(_) => IrFailure::CameraRateRefused,
+            irlume_common::Error::Io(_) => IrFailure::CameraIoFailed,
+            irlume_common::Error::Hardware(_) => IrFailure::CameraHardwareFailed,
+            irlume_common::Error::NotAuthorized(_) => IrFailure::CameraAuthorizationRefused,
+            irlume_common::Error::Policy(_) => IrFailure::CameraPolicyRefused,
+            irlume_common::Error::Protocol(_) | irlume_common::Error::Tpm(_) => {
+                IrFailure::CameraCaptureFailed
+            }
+        }
+    }
+
+    // Classify only typed evidence. Never parse or serialize error messages, owner
+    // details, paths, or rate payloads. A lease's short acquisition timeout is not
+    // the authentication deadline; active() still gives caller expiry precedence.
+    pub(crate) fn lease_error_failure(error: lease::CameraLeaseError) -> IrFailure {
+        match error {
+            lease::CameraLeaseError::DeadlineExpired { .. } => IrFailure::CameraLeaseTimeout,
+            _ => IrFailure::CameraLeaseRefused,
+        }
+    }
+
+    pub(crate) fn active(
+        control: &CaptureControl,
+        deadline: Option<Instant>,
+    ) -> Result<(), IrFailure> {
+        control.check().map_err(error_failure)?;
+        if deadline.is_some_and(|deadline| Instant::now() >= deadline) {
+            return Err(IrFailure::DeadlineExpired);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn valid_frame_shape(
+        width: u32,
+        height: u32,
+        len: usize,
+        raw_len: Option<usize>,
+    ) -> bool {
+        width > 0
+            && height > 0
+            && usize::try_from(width)
+                .ok()
+                .and_then(|w| usize::try_from(height).ok().and_then(|h| w.checked_mul(h)))
+                .is_some_and(|n| n == len && raw_len.is_none_or(|raw| raw == n))
+    }
+
+    pub(crate) fn gate_policy(
+        signals: &Signals,
+        pad: Option<irlume_common::Result<f32>>,
+        enr: &Enrollment,
+    ) -> Result<(), IrFailure> {
+        if signals.ir_face.is_none() {
+            return Err(IrFailure::NoFace);
+        }
+        if signals
+            .ir_face
+            .is_some_and(|face| !face.score.is_finite() || !(0.0..=1.0).contains(&face.score))
+            || !signals.ir_face_brightness.is_finite()
+            || !(0.0..=255.0).contains(&signals.ir_face_brightness)
+            || !signals.ir_center_edge_ratio.is_finite()
+            || !signals.ir_ambient.is_finite()
+            || signals
+                .ir_saturated_frac
+                .is_some_and(|v| !v.is_finite() || !(0.0..=1.0).contains(&v))
+        {
+            return Err(IrFailure::InvalidFrame);
+        }
+        if LivenessGate::new().evaluate_ir_only(signals).0 != Verdict::Live {
+            return Err(IrFailure::LivenessRefused);
+        }
+        match pad {
+            None => return Err(IrFailure::PadUnavailable),
+            Some(Ok(p)) if p.is_finite() && (0.0..=1.0).contains(&p) => {
+                if p >= IR_PAD_THRESHOLD {
+                    return Err(IrFailure::PadRefused);
+                }
+            }
+            Some(_) => return Err(IrFailure::PadInvalid),
+        }
+        if enr
+            .ir_center_edge_ratio_floor()
+            .is_some_and(|floor| !floor.is_finite() || signals.ir_center_edge_ratio < floor)
+        {
+            return Err(IrFailure::LivenessRefused);
+        }
+        Ok(())
+    }
+
+    pub(crate) trait AssessmentStages {
+        type Captured;
+        type Detected;
+        type Aligned;
+        type Embedded;
+        fn preflight(&mut self) -> Result<(), IrFailure>;
+        fn capture(
+            &mut self,
+            control: &CaptureControl,
+            deadline: Option<Instant>,
+        ) -> Result<Self::Captured, IrFailure>;
+        fn detect(&mut self, captured: Self::Captured) -> Result<Self::Detected, IrFailure>;
+        fn signals(&self, detected: &Self::Detected) -> Signals;
+        fn pad(&mut self, detected: &Self::Detected) -> Result<PadEvidence, IrFailure>;
+        fn align(&mut self, detected: Self::Detected) -> Result<Self::Aligned, IrFailure>;
+        fn embed(&mut self, aligned: Self::Aligned) -> Result<Self::Embedded, IrFailure>;
+        fn adapt(&mut self, embedded: Self::Embedded) -> Result<Vec<f32>, IrFailure>;
+        fn identify(&mut self, probe: &[f32]) -> IrMatch;
+    }
+
+    fn millis(start: Instant) -> u64 {
+        u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX)
+    }
+    fn timed<T>(slot: &mut Option<u64>, operation: impl FnOnce() -> T) -> T {
+        let start = Instant::now();
+        let result = operation();
+        *slot = Some(millis(start));
+        result
+    }
+
+    pub(crate) struct AssessmentRun {
+        pub(crate) result: Result<IrAssessment, IrFailure>,
+        pub(crate) observations: Option<Signals>,
+        pub(crate) elapsed_ms: u64,
+        pub(crate) capture_ms: Option<u64>,
+        pub(crate) detection_ms: Option<u64>,
+        pub(crate) pad_ms: Option<u64>,
+        pub(crate) identity_ms: Option<u64>,
+        #[cfg(feature = "ir-only-evaluation")]
+        pub(crate) capture_stages_ms: std::collections::BTreeMap<&'static str, Option<u64>>,
+        #[cfg(feature = "ir-only-evaluation")]
+        pub(crate) rate_fill_failure: Option<irlume_camera::RateFillFailure>,
+    }
+
+    /// Collect checked IR evidence. This function never grants or classifies a match.
+    pub(crate) fn assess_stages(
+        stages: &mut impl AssessmentStages,
+        control: &CaptureControl,
+        deadline: Option<Instant>,
+    ) -> AssessmentRun {
+        let start = Instant::now();
+        let mut capture_ms = None;
+        let mut detection_ms = None;
+        let mut pad_ms = None;
+        let mut identity_ms = None;
+        let mut observations = None;
+        #[cfg(feature = "ir-only-evaluation")]
+        let timings = irlume_camera::CaptureTimings::default();
+        #[cfg(feature = "ir-only-evaluation")]
+        let timed_control = control.clone().with_capture_timings(Some(timings.clone()));
+        #[cfg(feature = "ir-only-evaluation")]
+        let control = &timed_control;
+        let result = (|| {
+            active(control, deadline)?;
+            let ready = stages.preflight();
+            active(control, deadline)?;
+            ready?;
+            let captured = timed(&mut capture_ms, || stages.capture(control, deadline));
+            active(control, deadline)?;
+            let captured = captured?;
+            let detected = timed(&mut detection_ms, || stages.detect(captured));
+            active(control, deadline)?;
+            let detected = detected?;
+            let signals = stages.signals(&detected);
+            observations = Some(signals.clone());
+            let pad = timed(&mut pad_ms, || stages.pad(&detected));
+            active(control, deadline)?;
+            let pad = pad?;
+            timed(&mut identity_ms, || {
+                let aligned = stages.align(detected);
+                active(control, deadline)?;
+                let embedded = stages.embed(aligned?);
+                active(control, deadline)?;
+                let probe = stages.adapt(embedded?);
+                active(control, deadline)?;
+                let matched = stages.identify(&probe?);
+                active(control, deadline)?;
+                Ok(IrAssessment {
+                    matched,
+                    signals,
+                    pad,
+                })
+            })
+        })();
+        AssessmentRun {
+            result: active(control, deadline).and(result),
+            observations,
+            elapsed_ms: millis(start),
+            capture_ms,
+            detection_ms,
+            pad_ms,
+            identity_ms,
+            #[cfg(feature = "ir-only-evaluation")]
+            capture_stages_ms: timings.snapshot(),
+            #[cfg(feature = "ir-only-evaluation")]
+            rate_fill_failure: timings.rate_fill_failure(),
+        }
+    }
+    pub(crate) struct DetectedIr {
+        pixels: Vec<u8>,
+        width: u32,
+        height: u32,
+        face: Detection,
+        signals: Signals,
+    }
+
+    impl DetectedIr {
+        pub(crate) fn signals(&self) -> Signals {
+            self.signals.clone()
+        }
+        fn view(&self) -> align::RgbView<'_> {
+            align::RgbView {
+                data: &self.pixels,
+                width: self.width,
+                height: self.height,
+            }
+        }
+    }
+
+    pub(crate) struct IrInference<'a> {
+        pub(crate) engine: &'a mut Engine,
+        pub(crate) enrollment: &'a Enrollment,
+    }
+
+    impl IrInference<'_> {
+        pub(crate) fn detect(
+            &mut self,
+            (ir, stats): (irlume_camera::Frame, irlume_camera::IrCaptureStats),
+        ) -> Result<DetectedIr, IrFailure> {
+            if ir.spectrum != irlume_camera::Spectrum::Ir
+                || ir.provenance().stream_role() != irlume_camera::contracts::StreamRole::Ir
+                || !ir.provenance().is_continuous()
+                || !valid_frame_shape(
+                    ir.width,
+                    ir.height,
+                    ir.data.len(),
+                    stats.saturation_frame.as_ref().map(Vec::len),
+                )
+            {
+                return Err(IrFailure::InvalidFrame);
+            }
+            let pixels = irlume_camera::grey_to_rgb(&ir.data);
+            let view = align::RgbView {
+                data: &pixels,
+                width: ir.width,
+                height: ir.height,
+            };
+            let detection = self.engine.det.detect(&view);
+            let faces = detection.map_err(|_| IrFailure::InferenceFailed)?;
+            let face = top_detection(&faces).ok_or(IrFailure::NoFace)?;
+            if !face.score.is_finite()
+                || !(0.0..=1.0).contains(&face.score)
+                || face.bbox.iter().any(|v| !v.is_finite())
+                || face.bbox[2] <= face.bbox[0]
+                || face.bbox[3] <= face.bbox[1]
+                || face
+                    .landmarks
+                    .iter()
+                    .any(|(x, y)| !x.is_finite() || !y.is_finite())
+            {
+                return Err(IrFailure::InvalidFrame);
+            }
+            let raw = stats.saturation_frame.as_deref().unwrap_or(&ir.data);
+            // RGB-only fields remain unused defaults. This object is consumed ONLY
+            // by the IR-only gate, and contains no synthetic RGB scene brightness.
+            let signals = Signals {
+                ir_face: Some(irlume_liveness::FaceBox {
+                    cx: (face.bbox[0] + face.bbox[2]) / 2.0 / ir.width as f32,
+                    cy: (face.bbox[1] + face.bbox[3]) / 2.0 / ir.height as f32,
+                    score: face.score,
+                }),
+                ir_face_brightness: mean_in_bbox(&ir.data, ir.width, ir.height, &face.bbox),
+                ir_center_edge_ratio: center_edge_ratio(&ir.data, ir.width, ir.height, &face.bbox),
+                ir_eye_glint: eye_glint_of(
+                    raw,
+                    ir.width,
+                    ir.height,
+                    Some(&face.landmarks),
+                    stats.white_level,
+                ),
+                ir_ambient: stats.ambient_mean,
+                ir_ceiling_known: stats.white_level.is_some(),
+                face_frac: face_frac_of(Some(&face.bbox), ir.width),
+                ir_saturated_frac: saturated_frac_of(
+                    raw,
+                    ir.width,
+                    ir.height,
+                    Some(&face.bbox),
+                    stats.white_level,
+                ),
+                ir_persistent_saturated_frac: stats.persistent_saturated_frac,
+                ..Default::default()
+            };
+
+            Ok(DetectedIr {
+                pixels,
+                width: ir.width,
+                height: ir.height,
+                face: face.clone(),
+                signals,
+            })
+        }
+
+        pub(crate) fn pad(&mut self, detected: &DetectedIr) -> Result<PadEvidence, IrFailure> {
+            let pad = self
+                .engine
+                .pad_ir
+                .as_mut()
+                .map(|pad| pad.p_fake(&detected.view(), &detected.face.bbox));
+            let evidence = match &pad {
+                Some(Ok(score)) => PadEvidence::Score(*score),
+                Some(Err(_)) => PadEvidence::InferenceFailed,
+                None => PadEvidence::Unavailable,
+            };
+            gate_policy(&detected.signals, pad, self.enrollment)?;
+            Ok(evidence)
+        }
+
+        pub(crate) fn align(&mut self, detected: DetectedIr) -> Result<Vec<u8>, IrFailure> {
+            align::align_to_arcface(&detected.view(), &detected.face.landmarks)
+                .map_err(|_| IrFailure::InferenceFailed)
+        }
+
+        pub(crate) fn embed(&mut self, aligned: Vec<u8>) -> Result<Vec<f32>, IrFailure> {
+            self.engine
+                .emb
+                .embed(&aligned)
+                .map(|raw| raw.to_vec())
+                .map_err(|_| IrFailure::InferenceFailed)
+        }
+
+        pub(crate) fn adapt(&mut self, embedded: Vec<f32>) -> Result<Vec<f32>, IrFailure> {
+            let probe = match &mut self.engine.ir_adapter {
+                Some(adapter) => adapter
+                    .apply(&embedded)
+                    .map_err(|_| IrFailure::InferenceFailed)?,
+                None => embedded,
+            };
+            if probe.len() != EMBED_DIM || probe.iter().any(|v| !v.is_finite()) {
+                return Err(IrFailure::InferenceFailed);
+            }
+            Ok(probe)
+        }
+
+        pub(crate) fn identify(&self, probe: &[f32]) -> IrMatch {
+            self.engine.ir_match(self.enrollment, probe)
+        }
+    }
+}
+pub(super) use pipeline::*;
+
+fn readiness_refusal(readiness: irlume_common::IrOnlyReadiness) -> Outcome {
+    use irlume_common::IrOnlyReadiness as Ready;
+    let reason = match readiness {
+        Ready::TargetUnavailable => "configured IR target unavailable; use your password",
+        Ready::BindingUnavailable => {
+            "IR enrollment has no camera binding; add fresh scans or use your password"
+        }
+        Ready::BindingMismatch => {
+            "IR camera differs from enrollment; re-enroll on this camera or use your password"
+        }
+        Ready::ModelsUnavailable => "required IR model is unavailable; use your password",
+        Ready::PadUnavailable => "required IR PAD model is unavailable; use your password",
+        Ready::EnrollmentUnavailable => "IR enrollment is unavailable; enroll or use your password",
+        Ready::IncompatibleEnrollment => {
+            "IR enrollment is incompatible with this pipeline; add fresh scans or use your password"
+        }
+        _ => "experimental IR prerequisites are unavailable; use your password",
+    };
+    Outcome::deny(OutcomeKind::SetupUnavailable, reason)
+}
+
+impl Engine {
+    /// Require an explicitly configured adapter for experimental IR assessment.
+    /// An absent optional default adapter still selects the existing raw space.
+    pub fn with_ir_adapter_required(mut self, required: bool) -> Self {
+        self.ir_adapter_required = required;
+        self
+    }
+
+    fn ir_model_readiness(
+        &self,
+        target: &irlume_camera::IrCaptureTarget,
+    ) -> Option<irlume_common::IrOnlyReadiness> {
+        model_readiness(
+            selected_ir_available(target.endpoint()) && target.validate().is_ok(),
+            self.ir_adapter_required,
+            self.has_ir_adapter(),
+            self.has_pad_ir(),
+        )
+    }
+
+    fn ir_enrollment_readiness(
+        &self,
+        enrollment: &irlume_core::storage::Enrollment,
+        target: &irlume_camera::IrCaptureTarget,
+    ) -> irlume_common::IrOnlyReadiness {
+        enrollment_readiness(
+            enrollment,
+            target.identity(),
+            self.ir_match(enrollment, &[0.0; EMBED_DIM]).n_templates,
+        )
+    }
+
+    // Retain the existing helper lifetime rule: a cancelled/expired caller
+    // drains the loader before returning. No camera or lease is held here.
+    fn load_ir_enrollment(
+        &self,
+        user: &str,
+        window: AuthenticationWindow,
+        read_only: bool,
+    ) -> irlume_common::Result<Option<irlume_core::storage::Enrollment>> {
+        self.check_authentication_completion(window)?;
+        let (sender, receiver) = std::sync::mpsc::channel();
+        let user = user.to_string();
+        std::thread::Builder::new()
+            .name("irlume-ir-enrollment".into())
+            .spawn(move || {
+                let loaded = if read_only {
+                    irlume_core::storage::load_read_only(&user)
+                } else {
+                    irlume_core::storage::load(&user)
+                };
+                let _ = sender.send(loaded);
+            })
+            .map_err(|_| irlume_common::Error::Io("enrollment loader unavailable".into()))?;
+        let mut loader = PendingEnrollmentLoad {
+            receiver: Some(receiver),
+        };
+        let loaded = loop {
+            self.check_authentication_completion(window)?;
+            let wait = window
+                .remaining()
+                .unwrap_or(std::time::Duration::from_millis(50))
+                .min(std::time::Duration::from_millis(50));
+            let received = loader
+                .receiver
+                .as_ref()
+                .expect("owned loader receiver")
+                .recv_timeout(wait);
+            if matches!(received, Err(std::sync::mpsc::RecvTimeoutError::Timeout)) {
+                continue;
+            }
+            break resolve_loader(received);
+        };
+        loader.receiver.take();
+        self.check_authentication_completion(window)?;
+        match loaded {
+            Ok(enrollment) => Ok(Some(enrollment)),
+            Err(LoaderExit::NotEnrolled) => Ok(None),
+            Err(LoaderExit::Fallback(error)) => Err(error),
+        }
+    }
+
+    /// Check experimental IR prerequisites without opening video nodes or
+    /// changing enrollment. Template-key unseal may be needed for protected data.
+    /// Readiness does not establish capture latency, identity or qualification.
+    pub fn ir_only_preflight(&self, user: &str) -> irlume_common::IrOnlyReadiness {
+        use irlume_common::IrOnlyReadiness as Ready;
+        let window = AuthenticationWindow::new(GRACE_WINDOW_MS);
+        let target = match irlume_camera::configured_ir_target() {
+            Ok(target) => target,
+            Err(_) => return Ready::TargetUnavailable,
+        };
+        if let Some(refusal) = self.ir_model_readiness(&target) {
+            return refusal;
+        }
+        let enrollment = match self.load_ir_enrollment(user, window, true) {
+            Ok(Some(enrollment)) => enrollment,
+            _ => return Ready::EnrollmentUnavailable,
+        };
+        if self.check_authentication_completion(window).is_err() {
+            return Ready::Unavailable;
+        }
+        self.ir_enrollment_readiness(&enrollment, &target)
+    }
+
+    pub(super) fn authenticate_ir_in_window(
+        &mut self,
+        user: &str,
+        window: AuthenticationWindow,
+        diagnostics: &dyn irlume_common::diagnostics::DiagnosticSink,
+    ) -> irlume_common::Result<Outcome> {
+        use irlume_common::IrOnlyReadiness as Ready;
+        self.check_request_active()?;
+        let target = match irlume_camera::configured_ir_target() {
+            Ok(target) => target,
+            Err(_) => return Ok(readiness_refusal(Ready::TargetUnavailable)),
+        };
+        if let Some(refusal) = self.ir_model_readiness(&target) {
+            return Ok(readiness_refusal(refusal));
+        }
+        let enrollment = match self.load_ir_enrollment(user, window, false)? {
+            Some(enrollment) => enrollment,
+            None => return Ok(readiness_refusal(Ready::EnrollmentUnavailable)),
+        };
+        let readiness = self.ir_enrollment_readiness(&enrollment, &target);
+        if readiness != Ready::ReadyForExperimentalAttempt {
+            return Ok(readiness_refusal(readiness));
+        }
+        self.check_request_active()?;
+        let operation = match lease::acquire_camera_operation(
+            &target.lease_endpoints(),
+            lease::CameraOperationKind::Authentication,
+            window
+                .remaining()
+                .unwrap_or(std::time::Duration::from_secs(2))
+                .min(std::time::Duration::from_secs(2)),
+        ) {
+            Ok(operation) => operation,
+            Err(error) => {
+                self.check_request_active()?;
+                return Ok(refusal_outcome(lease_error_failure(error)));
+            }
+        };
+        let mut costliest = std::time::Duration::ZERO;
+        self.authentication_attempt_loop_with(
+            window.deadline,
+            window.milliseconds,
+            &mut costliest,
+            |engine| {
+                (
+                    engine.authenticate_ir_target_attempt(
+                        &enrollment,
+                        &target,
+                        &operation,
+                        diagnostics,
+                    ),
+                    false,
+                )
+            },
+            std::time::Instant::now,
+        )
+        .0
+    }
+
+    fn authenticate_ir_target_attempt(
+        &mut self,
+        enrollment: &irlume_core::storage::Enrollment,
+        target: &irlume_camera::IrCaptureTarget,
+        operation: &lease::CameraOperationSession,
+        diagnostics: &dyn irlume_common::diagnostics::DiagnosticSink,
+    ) -> irlume_common::Result<Outcome> {
+        let control = self.capture_control();
+        let deadline = self.authentication_deadline;
+        let adapter = self.has_ir_adapter();
+        let run = assess_stages(
+            &mut TargetStages {
+                inference: IrInference {
+                    engine: self,
+                    enrollment,
+                },
+                target,
+                operation,
+            },
+            &control,
+            deadline,
+        );
+        self.last_attempt_facts = AttemptFacts::from_ir_signals(run.observations.as_ref());
+        use irlume_common::diagnostics::{TraceEventKind, TraceStage};
+        for (stage, millis) in [
+            (TraceStage::IrCapture, run.capture_ms),
+            (TraceStage::Detection, run.detection_ms),
+            (TraceStage::Liveness, run.pad_ms),
+            (TraceStage::Matching, run.identity_ms),
+        ] {
+            if let Some(millis) = millis {
+                diagnostics.emit_trace(TraceEventKind::StageTiming {
+                    stage,
+                    elapsed_us: millis.saturating_mul(1000),
+                });
+            }
+        }
+        irlume_common::dlog!("experimental IR assessment elapsed {}ms", run.elapsed_ms);
+        self.check_request_active()?;
+        let outcome = match run.result {
+            Ok(assessment) => assessed_outcome(&assessment, enrollment, adapter),
+            Err(IrFailure::Cancelled) => {
+                return Err(irlume_common::Error::Preempted(
+                    "authentication cancelled".into(),
+                ))
+            }
+            Err(IrFailure::DeadlineExpired) => return Err(irlume_common::Error::DeadlineExpired),
+            Err(failure) => refusal_outcome(failure),
+        };
+        self.check_request_active()?;
+        Ok(outcome)
+    }
+}
+
+struct TargetStages<'a> {
+    inference: IrInference<'a>,
+    target: &'a irlume_camera::IrCaptureTarget,
+    operation: &'a lease::CameraOperationSession,
+}
+impl AssessmentStages for TargetStages<'_> {
+    type Captured = (irlume_camera::Frame, irlume_camera::IrCaptureStats);
+    type Detected = DetectedIr;
+    type Aligned = Vec<u8>;
+    type Embedded = Vec<f32>;
+    fn preflight(&mut self) -> Result<(), IrFailure> {
+        Ok(())
+    }
+    fn capture(
+        &mut self,
+        control: &irlume_camera::CaptureControl,
+        deadline: Option<std::time::Instant>,
+    ) -> Result<Self::Captured, IrFailure> {
+        active(control, deadline)?;
+        let captured = self
+            .target
+            .capture_with_stats_and_control(self.operation, control)
+            .map_err(error_failure);
+        active(control, deadline)?;
+        captured
+    }
+    fn detect(&mut self, captured: Self::Captured) -> Result<DetectedIr, IrFailure> {
+        self.inference.detect(captured)
+    }
+    fn signals(&self, detected: &DetectedIr) -> Signals {
+        detected.signals()
+    }
+    fn pad(&mut self, detected: &DetectedIr) -> Result<PadEvidence, IrFailure> {
+        self.inference.pad(detected)
+    }
+    fn align(&mut self, detected: DetectedIr) -> Result<Vec<u8>, IrFailure> {
+        self.inference.align(detected)
+    }
+    fn embed(&mut self, aligned: Vec<u8>) -> Result<Vec<f32>, IrFailure> {
+        self.inference.embed(aligned)
+    }
+    fn adapt(&mut self, embedded: Vec<f32>) -> Result<Vec<f32>, IrFailure> {
+        self.inference.adapt(embedded)
+    }
+    fn identify(&mut self, probe: &[f32]) -> IrMatch {
+        self.inference.identify(probe)
+    }
+}

--- a/crates/irlume-auth/src/ir_only_evaluation.rs
+++ b/crates/irlume-auth/src/ir_only_evaluation.rs
@@ -1,0 +1,1314 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! Experimental IR evidence evaluation, isolated from authentication policy.
+//! A candidate is never authentication and must not be used to release credentials.
+
+use super::ir_assessment::{self, AssessmentStages, DetectedIr, IrFailure, IrInference};
+use super::*;
+use irlume_camera::CaptureControl;
+use irlume_core::storage::Enrollment;
+use std::time::{Duration, Instant};
+
+/// Bounded diagnostic categories; none authorizes any action.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Category {
+    CandidateMatch,
+    IdentityMismatch,
+    NoFace,
+    LivenessRefused,
+    PadUnavailable,
+    PadInvalid,
+    PadRefused,
+    IncompatibleEnrollment,
+    InvalidFrame,
+    InferenceFailed,
+    CameraUnavailable,
+    CameraBusy,
+    CameraRateRefused,
+    CameraLeaseTimeout,
+    CameraLeaseRefused,
+    CameraIoFailed,
+    CameraHardwareFailed,
+    CameraRateFillFailed(irlume_camera::RateFillFailure),
+    CameraAuthorizationRefused,
+    CameraPolicyRefused,
+    CameraCaptureFailed,
+
+    Cancelled,
+    DeadlineExpired,
+    InvalidRequest,
+    Ready,
+    EnrollmentUnavailable,
+    ModelsUnavailable,
+    RootRequired,
+}
+
+impl Category {
+    fn with_rate_fill_failure(self, failure: Option<irlume_camera::RateFillFailure>) -> Self {
+        match (self, failure) {
+            (Self::CameraHardwareFailed, Some(failure)) => Self::CameraRateFillFailed(failure),
+            _ => self,
+        }
+    }
+
+    /// Stable metadata-only wire label.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::CandidateMatch => "candidate_match",
+            Self::IdentityMismatch => "identity_mismatch",
+            Self::NoFace => "no_face",
+            Self::LivenessRefused => "liveness_refused",
+            Self::PadUnavailable => "pad_unavailable",
+            Self::PadInvalid => "pad_invalid",
+            Self::PadRefused => "pad_refused",
+            Self::IncompatibleEnrollment => "incompatible_enrollment",
+            Self::InvalidFrame => "invalid_frame",
+            Self::InferenceFailed => "inference_failed",
+            Self::CameraUnavailable => "camera_unavailable",
+            Self::CameraBusy => "camera_busy",
+            Self::CameraRateRefused => "camera_rate_refused",
+            Self::CameraLeaseTimeout => "camera_lease_timeout",
+            Self::CameraLeaseRefused => "camera_lease_refused",
+            Self::CameraIoFailed => "camera_io_failed",
+            Self::CameraHardwareFailed => "camera_hardware_failed",
+            Self::CameraRateFillFailed(failure) => failure.as_str(),
+            Self::CameraAuthorizationRefused => "camera_authorization_refused",
+            Self::CameraPolicyRefused => "camera_policy_refused",
+            Self::CameraCaptureFailed => "camera_capture_failed",
+
+            Self::Cancelled => "cancelled",
+            Self::DeadlineExpired => "deadline_expired",
+            Self::InvalidRequest => "invalid_request",
+            Self::Ready => "ready",
+            Self::EnrollmentUnavailable => "enrollment_unavailable",
+            Self::ModelsUnavailable => "models_unavailable",
+            Self::RootRequired => "root_required",
+        }
+    }
+}
+
+/// Bounded evidence identifying which existing identity predicate accepted.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IdentityAcceptance {
+    BestTemplate,
+    Centroid,
+    Both,
+}
+
+impl IdentityAcceptance {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::BestTemplate => "best_template",
+            Self::Centroid => "centroid",
+            Self::Both => "both",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct IdentityResult {
+    category: Category,
+    acceptance: Option<IdentityAcceptance>,
+}
+
+/// Only category and elapsed times, never names, images, embeddings or scores.
+#[derive(Debug)]
+pub struct Report {
+    pub category: Category,
+    pub identity_acceptance: Option<IdentityAcceptance>,
+    pub elapsed_ms: u64,
+    pub capture_ms: Option<u64>,
+    pub detection_ms: Option<u64>,
+    pub pad_ms: Option<u64>,
+    pub identity_ms: Option<u64>,
+    pub capture_stages_ms: std::collections::BTreeMap<&'static str, Option<u64>>,
+}
+
+impl Report {
+    /// Construct a report for a pre-capture refusal or preflight result.
+    pub fn new(category: Category) -> Self {
+        Self {
+            category,
+            identity_acceptance: None,
+            elapsed_ms: 0,
+            capture_ms: None,
+            detection_ms: None,
+            pad_ms: None,
+            identity_ms: None,
+            capture_stages_ms: irlume_camera::CaptureTimings::default().snapshot(),
+        }
+    }
+
+    /// Serialize the fixed, non-granting diagnostic record.
+    pub fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({ "schema": 4, "operation": "ir_only_evaluation",
+            "authentication_granted": false, "category": self.category.as_str(),
+            "identity_acceptance": self.identity_acceptance.map(IdentityAcceptance::as_str),
+            "elapsed_ms": self.elapsed_ms, "capture_ms": self.capture_ms,
+            "detection_ms": self.detection_ms, "pad_ms": self.pad_ms, "identity_ms": self.identity_ms,
+            "capture_stages_ms": self.capture_stages_ms })
+    }
+}
+
+/// Accept a finite, bounded cooperative camera/inference budget.
+#[must_use]
+pub fn valid_budget(budget: Duration) -> bool {
+    (Duration::from_millis(100)..=Duration::from_secs(30)).contains(&budget)
+}
+
+impl From<IrFailure> for Category {
+    fn from(failure: IrFailure) -> Self {
+        match failure {
+            IrFailure::NoFace => Self::NoFace,
+            IrFailure::LivenessRefused => Self::LivenessRefused,
+            IrFailure::PadUnavailable => Self::PadUnavailable,
+            IrFailure::PadInvalid => Self::PadInvalid,
+            IrFailure::PadRefused => Self::PadRefused,
+            IrFailure::IncompatibleEnrollment => Self::IncompatibleEnrollment,
+            IrFailure::InvalidFrame => Self::InvalidFrame,
+            IrFailure::InferenceFailed => Self::InferenceFailed,
+            IrFailure::CameraUnavailable => Self::CameraUnavailable,
+            IrFailure::CameraBusy => Self::CameraBusy,
+            IrFailure::CameraRateRefused => Self::CameraRateRefused,
+            IrFailure::CameraLeaseTimeout => Self::CameraLeaseTimeout,
+            IrFailure::CameraLeaseRefused => Self::CameraLeaseRefused,
+            IrFailure::CameraIoFailed => Self::CameraIoFailed,
+            IrFailure::CameraHardwareFailed => Self::CameraHardwareFailed,
+            IrFailure::CameraAuthorizationRefused => Self::CameraAuthorizationRefused,
+            IrFailure::CameraPolicyRefused => Self::CameraPolicyRefused,
+            IrFailure::CameraCaptureFailed => Self::CameraCaptureFailed,
+            IrFailure::Cancelled => Self::Cancelled,
+            IrFailure::DeadlineExpired => Self::DeadlineExpired,
+            IrFailure::InvalidRequest => Self::InvalidRequest,
+        }
+    }
+}
+
+#[cfg(test)]
+fn active(control: &CaptureControl, deadline: Instant) -> Result<(), Category> {
+    ir_assessment::active(control, Some(deadline)).map_err(Into::into)
+}
+
+#[cfg(test)]
+fn error_category(error: irlume_common::Error) -> Category {
+    ir_assessment::error_failure(error).into()
+}
+
+#[cfg(test)]
+fn lease_error_category(error: lease::CameraLeaseError) -> Category {
+    ir_assessment::lease_error_failure(error).into()
+}
+
+fn capture_selected_ir<T>(
+    endpoint: &str,
+    control: &CaptureControl,
+    deadline: Instant,
+    capture: impl FnOnce(&str, &CaptureControl) -> Result<T, IrFailure>,
+) -> Result<T, IrFailure> {
+    ir_assessment::active(control, Some(deadline))?;
+    // Preserve the caller's cancellation AND any earlier deadline while adding
+    // our mandatory local budget. Original check classifies expiry accurately
+    // after the driver returns, even though the callback is a boolean signal.
+    let original = control.clone();
+    let bounded = CaptureControl::new(
+        irlume_camera::no_progress(),
+        std::sync::Arc::new(move || original.check().is_err()),
+    )
+    .with_deadline(Some(deadline))
+    .with_capture_timings(control.capture_timings());
+    let captured = capture(endpoint, &bounded);
+    ir_assessment::active(control, Some(deadline))?;
+    captured
+}
+
+#[cfg(test)]
+use ir_assessment::valid_frame_shape;
+
+#[cfg(test)]
+fn gate_policy(
+    signals: &Signals,
+    pad: Option<irlume_common::Result<f32>>,
+    enr: &Enrollment,
+) -> Result<(), Category> {
+    ir_assessment::gate_policy(signals, pad, enr).map_err(Into::into)
+}
+
+fn identity_category(matched: IrMatch, profiles: usize, adapter: bool) -> IdentityResult {
+    if matched.n_templates == 0 {
+        return IdentityResult {
+            category: Category::IncompatibleEnrollment,
+            acceptance: None,
+        };
+    }
+    let (best, centroid) =
+        ir_assessment::IdentityThresholds::new(matched.n_templates, profiles, adapter)
+            .arms(&matched);
+    let acceptance = match (best, centroid) {
+        (true, true) => Some(IdentityAcceptance::Both),
+        (true, false) => Some(IdentityAcceptance::BestTemplate),
+        (false, true) => Some(IdentityAcceptance::Centroid),
+        (false, false) => None,
+    };
+    IdentityResult {
+        category: if acceptance.is_some() {
+            Category::CandidateMatch
+        } else {
+            Category::IdentityMismatch
+        },
+        acceptance,
+    }
+}
+
+fn evaluate_stages(
+    stages: &mut impl AssessmentStages,
+    control: &CaptureControl,
+    budget: Duration,
+    profiles: usize,
+    adapter: bool,
+) -> Report {
+    if !valid_budget(budget) {
+        return Report::new(Category::InvalidRequest);
+    }
+    let start = Instant::now();
+    let run = ir_assessment::assess_stages(stages, control, Some(start + budget));
+    let identity = run
+        .result
+        .map(|assessment| identity_category(assessment.matched, profiles, adapter));
+    let identity = ir_assessment::active(control, Some(start + budget)).and(identity);
+    let (category, identity_acceptance) = match identity {
+        Ok(identity) => (identity.category, identity.acceptance),
+        Err(failure) => (
+            Category::from(failure).with_rate_fill_failure(run.rate_fill_failure),
+            None,
+        ),
+    };
+    Report {
+        category,
+        identity_acceptance,
+        elapsed_ms: run.elapsed_ms,
+        capture_ms: run.capture_ms,
+        detection_ms: run.detection_ms,
+        pad_ms: run.pad_ms,
+        identity_ms: run.identity_ms,
+        capture_stages_ms: run.capture_stages_ms,
+    }
+}
+
+impl Engine {
+    /// Camera-free readiness check. Does not probe, capture or change enrollment.
+    /// Models and protected enrollment must already have been loaded by the caller.
+    pub fn ir_only_evaluation_preflight(&self, enr: &Enrollment) -> Category {
+        self.evaluation_target(enr)
+            .map_or_else(Into::into, |_| Category::Ready)
+    }
+
+    fn evaluation_target(
+        &self,
+        enr: &Enrollment,
+    ) -> Result<irlume_camera::IrCaptureTarget, IrFailure> {
+        let target =
+            irlume_camera::configured_ir_target().map_err(|_| IrFailure::CameraUnavailable)?;
+        let selected =
+            std::fs::canonicalize(&self.ir_dev).map_err(|_| IrFailure::CameraUnavailable)?;
+        if selected != std::path::Path::new(target.endpoint()) {
+            return Err(IrFailure::CameraUnavailable);
+        }
+        self.evaluation_preflight(enr)?;
+        Ok(target)
+    }
+
+    fn evaluation_preflight(&self, enr: &Enrollment) -> Result<(), IrFailure> {
+        if irlume_common::dbglog::on() {
+            return Err(IrFailure::InvalidRequest);
+        }
+        if !self.ir_available || self.ir_dev == self.rgb_dev {
+            return Err(IrFailure::CameraUnavailable);
+        }
+        if enr
+            .camera_binding
+            .as_ref()
+            .and_then(|b| b.ir.as_ref())
+            .is_some_and(|want| irlume_camera::device_identity(&self.ir_dev).as_ref() != Some(want))
+        {
+            return Err(IrFailure::CameraUnavailable);
+        }
+        if !self.has_pad_ir() {
+            return Err(IrFailure::PadUnavailable);
+        }
+        if self.ir_match(enr, &[0.0; EMBED_DIM]).n_templates == 0 {
+            return Err(IrFailure::IncompatibleEnrollment);
+        }
+        Ok(())
+    }
+
+    /// Evaluate one IR-only presentation. Never calls authentication, PAM, grants,
+    /// credential release, dual-camera assessment, or a production scene gate.
+    ///
+    /// `budget` must be 100ms..=30s. Cancellation/deadline checks surround capture
+    /// and every inference stage, including final reporting. Driver/model calls
+    /// are cooperative: a blocked call may return after the nominal deadline.
+    /// Capture uses the configured, sysfs-validated IR image and exact metadata
+    /// companion with a Diagnostics lease and pinned, authorized emitter path.
+    /// Unsupported or changed topology refuses without fallback discovery.
+    /// No retry or explicit RGB capture occurs in this operation.
+    pub fn evaluate_ir_only(
+        &mut self,
+        enr: &Enrollment,
+        control: &CaptureControl,
+        budget: Duration,
+    ) -> Report {
+        let adapter = self.ir_adapter.is_some();
+        evaluate_stages(
+            &mut IrStages {
+                inference: IrInference {
+                    engine: self,
+                    enrollment: enr,
+                },
+                target: None,
+            },
+            control,
+            budget,
+            enr.profiles.len(),
+            adapter,
+        )
+    }
+}
+
+struct IrStages<'a> {
+    inference: IrInference<'a>,
+    target: Option<irlume_camera::IrCaptureTarget>,
+}
+
+impl AssessmentStages for IrStages<'_> {
+    type Captured = (irlume_camera::Frame, irlume_camera::IrCaptureStats);
+    type Detected = DetectedIr;
+    type Aligned = Vec<u8>;
+    type Embedded = Vec<f32>;
+    fn preflight(&mut self) -> Result<(), IrFailure> {
+        self.target = Some(
+            self.inference
+                .engine
+                .evaluation_target(self.inference.enrollment)?,
+        );
+        Ok(())
+    }
+    fn capture(
+        &mut self,
+        control: &CaptureControl,
+        deadline: Option<Instant>,
+    ) -> Result<Self::Captured, IrFailure> {
+        let deadline = deadline.ok_or(IrFailure::InvalidRequest)?;
+        let target = self.target.as_ref().ok_or(IrFailure::InvalidRequest)?;
+        capture_selected_ir(target.endpoint(), control, deadline, |_, bounded| {
+            let timeout = deadline
+                .saturating_duration_since(Instant::now())
+                .min(Duration::from_millis(100));
+            let operation = lease::acquire_camera_operation(
+                &target.lease_endpoints(),
+                lease::CameraOperationKind::Diagnostics,
+                timeout,
+            )
+            .map_err(ir_assessment::lease_error_failure)?;
+            bounded.check().map_err(ir_assessment::error_failure)?;
+            target
+                .capture_with_stats_and_control(&operation, bounded)
+                .map_err(ir_assessment::error_failure)
+        })
+    }
+
+    fn detect(&mut self, captured: Self::Captured) -> Result<DetectedIr, IrFailure> {
+        self.inference.detect(captured)
+    }
+    fn signals(&self, detected: &DetectedIr) -> Signals {
+        detected.signals()
+    }
+    fn pad(&mut self, detected: &DetectedIr) -> Result<PadEvidence, IrFailure> {
+        self.inference.pad(detected)
+    }
+    fn align(&mut self, detected: DetectedIr) -> Result<Vec<u8>, IrFailure> {
+        self.inference.align(detected)
+    }
+    fn embed(&mut self, aligned: Vec<u8>) -> Result<Vec<f32>, IrFailure> {
+        self.inference.embed(aligned)
+    }
+    fn adapt(&mut self, embedded: Vec<f32>) -> Result<Vec<f32>, IrFailure> {
+        self.inference.adapt(embedded)
+    }
+    fn identify(&mut self, probe: &[f32]) -> IrMatch {
+        self.inference.identify(probe)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn ir_only_evaluation_teardown_schema_has_exact_unreached_fields() {
+        let record = super::Report::new(super::Category::InvalidRequest).to_json();
+        assert_eq!(record["schema"], 4);
+        assert!(record["identity_acceptance"].is_null());
+        for label in [
+            "image_stop",
+            "metadata_streamoff",
+            "metadata_buffers",
+            "metadata_format",
+            "metadata_close",
+            "emitter_restore",
+        ] {
+            assert!(record["capture_stages_ms"]
+                .as_object()
+                .unwrap()
+                .contains_key(label));
+            assert!(record["capture_stages_ms"][label].is_null());
+        }
+        assert_eq!(record["capture_stages_ms"].as_object().unwrap().len(), 15);
+    }
+
+    #[test]
+    fn capture_selected_keeps_timings_on_error_and_still_observes_cancellation() {
+        let signal = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let observed = signal.clone();
+        let control = irlume_camera::CaptureControl::new(
+            irlume_camera::no_progress(),
+            std::sync::Arc::new(move || observed.load(std::sync::atomic::Ordering::Acquire)),
+        )
+        .with_capture_timings(Some(irlume_camera::CaptureTimings::default()));
+        let result: Result<(), super::IrFailure> = super::capture_selected_ir(
+            "unused endpoint",
+            &control,
+            std::time::Instant::now() + std::time::Duration::from_secs(1),
+            |_, bounded| {
+                assert!(bounded.capture_timings().is_some());
+                signal.store(true, std::sync::atomic::Ordering::Release);
+                assert!(bounded.check().is_err());
+                Err(super::IrFailure::CameraIoFailed)
+            },
+        );
+        assert_eq!(result, Err(super::IrFailure::Cancelled));
+    }
+    #[test]
+    fn ir_only_evaluation_stage_schema_preserves_unreached_stages() {
+        let record = super::Report::new(super::Category::InvalidRequest).to_json();
+        assert_eq!(record["schema"], 4);
+        assert!(record["identity_acceptance"].is_null());
+        let stages = record["capture_stages_ms"]
+            .as_object()
+            .expect("fixed timings");
+        assert_eq!(stages.len(), 15);
+        assert!(stages.values().all(serde_json::Value::is_null));
+        assert_eq!(record["authentication_granted"], false);
+    }
+    use super::*;
+    use irlume_core::storage::{FaceProfile, FaceScan, LEGACY_RECOGNIZER_SPACE};
+
+    fn policy(
+        signals: &Signals,
+        pad: Option<irlume_common::Result<f32>>,
+        enr: &Enrollment,
+        probe: &[f32],
+        adapter: bool,
+        space: &str,
+        embed_space: &str,
+    ) -> Category {
+        if let Err(category) = gate_policy(signals, pad, enr) {
+            return category;
+        }
+        if probe.len() != EMBED_DIM || probe.iter().any(|v| !v.is_finite()) {
+            return Category::InferenceFailed;
+        }
+        identity_category(
+            ir_match_in(space, embed_space, adapter, enr, probe),
+            enr.profiles.len(),
+            adapter,
+        )
+        .category
+    }
+    fn genuine() -> (Signals, Enrollment, Vec<f32>) {
+        let mut probe = vec![0.0; EMBED_DIM];
+        probe[0] = 1.0;
+        let signals = Signals {
+            ir_face: Some(irlume_liveness::FaceBox {
+                cx: 0.5,
+                cy: 0.5,
+                score: 0.99,
+            }),
+            ir_face_brightness: 100.0,
+            ir_center_edge_ratio: 1.5,
+            ir_ceiling_known: true,
+            ir_saturated_frac: Some(0.0),
+            ..Default::default()
+        };
+        let mut enr = Enrollment::new("private-user");
+        enr.profiles.push(FaceProfile {
+            name: "private-profile".into(),
+            ir_calib: None,
+            ir_calibs: Default::default(),
+            scans: vec![FaceScan {
+                name: "private-scan".into(),
+                rgb: probe.clone(),
+                ir: Some(probe.clone()),
+                ir_space: Some("raw".into()),
+                embed_space: None,
+                ir_center_edge_ratio: 0.0,
+                ir_brightness: 0.0,
+                pitch: 0.0,
+            }],
+        });
+        (signals, enr, probe)
+    }
+
+    fn evaluate(
+        signals: &Signals,
+        pad: Option<irlume_common::Result<f32>>,
+        enr: &Enrollment,
+        probe: &[f32],
+    ) -> Category {
+        policy(
+            signals,
+            pad,
+            enr,
+            probe,
+            false,
+            "raw",
+            LEGACY_RECOGNIZER_SPACE,
+        )
+    }
+
+    #[test]
+    fn ir_only_evaluation_missing_pad_cannot_match() {
+        let (s, e, p) = genuine();
+        assert_eq!(evaluate(&s, None, &e, &p), Category::PadUnavailable);
+    }
+
+    #[test]
+    fn ir_only_evaluation_invalid_pad_cannot_match() {
+        let (s, e, p) = genuine();
+        for value in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY, -0.01, 1.01] {
+            assert_eq!(evaluate(&s, Some(Ok(value)), &e, &p), Category::PadInvalid);
+        }
+        assert_eq!(
+            evaluate(
+                &s,
+                Some(Err(irlume_common::Error::Hardware(
+                    "private failure".into()
+                ))),
+                &e,
+                &p
+            ),
+            Category::PadInvalid
+        );
+    }
+
+    #[test]
+    fn ir_only_evaluation_spoof_pad_and_failed_gate_refuse() {
+        let (mut s, e, p) = genuine();
+        assert_eq!(evaluate(&s, Some(Ok(0.9)), &e, &p), Category::PadRefused);
+        s.ir_center_edge_ratio = 0.5;
+        assert_eq!(
+            evaluate(&s, Some(Ok(0.0)), &e, &p),
+            Category::LivenessRefused
+        );
+        s.ir_face = None;
+        assert_eq!(evaluate(&s, Some(Ok(0.0)), &e, &p), Category::NoFace);
+    }
+
+    #[test]
+    fn ir_only_evaluation_compatible_identity_is_required() {
+        let (s, mut e, mut p) = genuine();
+        assert_eq!(
+            evaluate(&s, Some(Ok(0.0)), &e, &p),
+            Category::CandidateMatch
+        );
+        p.swap(0, 1);
+        assert_eq!(
+            evaluate(&s, Some(Ok(0.0)), &e, &p),
+            Category::IdentityMismatch
+        );
+        e.profiles[0].scans[0].ir_space = None;
+        assert_eq!(
+            evaluate(&s, Some(Ok(0.0)), &e, &p),
+            Category::IncompatibleEnrollment
+        );
+    }
+    #[test]
+    fn ir_only_evaluation_cancellation_prevents_camera_access() {
+        let control =
+            CaptureControl::new(irlume_camera::no_progress(), std::sync::Arc::new(|| true));
+        let result = capture_selected_ir(
+            "/dev/video-selected-ir",
+            &control,
+            Instant::now() + Duration::from_secs(1),
+            |_, _| {
+                panic!("cancelled request reached camera boundary");
+                #[allow(unreachable_code)]
+                Ok(())
+            },
+        );
+        assert_eq!(result, Err(IrFailure::Cancelled));
+    }
+
+    #[test]
+    fn ir_only_evaluation_capture_uses_only_selected_ir_and_preserves_caller_expiry() {
+        let control = CaptureControl::with_progress(irlume_camera::no_progress())
+            .with_deadline(Some(Instant::now()));
+        assert_eq!(
+            capture_selected_ir(
+                "/dev/video-selected-ir",
+                &control,
+                Instant::now() + Duration::from_secs(1),
+                |endpoint, bounded| {
+                    assert_eq!(endpoint, "/dev/video-selected-ir");
+                    bounded.check().map_err(|_| IrFailure::DeadlineExpired)
+                }
+            ),
+            Err(IrFailure::DeadlineExpired)
+        );
+        let control = CaptureControl::with_progress(irlume_camera::no_progress());
+        assert_eq!(
+            capture_selected_ir(
+                "/dev/video-selected-ir",
+                &control,
+                Instant::now() + Duration::from_secs(1),
+                |endpoint, _| {
+                    assert_eq!(endpoint, "/dev/video-selected-ir");
+                    Ok(7)
+                }
+            ),
+            Ok(7)
+        );
+    }
+
+    #[test]
+    fn ir_only_evaluation_late_cancellation_and_expiry_override_candidate() {
+        let control =
+            CaptureControl::new(irlume_camera::no_progress(), std::sync::Arc::new(|| true));
+        assert_eq!(
+            active(&control, Instant::now() + Duration::from_secs(1)),
+            Err(Category::Cancelled)
+        );
+        let control = CaptureControl::with_progress(irlume_camera::no_progress());
+        assert_eq!(
+            active(&control, Instant::now()),
+            Err(Category::DeadlineExpired)
+        );
+    }
+
+    #[test]
+    fn ir_only_evaluation_malformed_frame_is_refused() {
+        for (w, h, n, raw) in [
+            (0, 4, 0, None),
+            (4, 0, 0, None),
+            (4, 4, 15, None),
+            (4, 4, 16, Some(15)),
+            (u32::MAX, u32::MAX, 0, None),
+        ] {
+            assert!(!valid_frame_shape(w, h, n, raw));
+        }
+        assert!(valid_frame_shape(4, 4, 16, Some(16)));
+    }
+
+    #[test]
+    fn ir_only_evaluation_enrolled_falloff_floor_is_enforced() {
+        let (s, mut e, p) = genuine();
+        e.profiles[0].scans[0].ir_center_edge_ratio = 2.4;
+        let scan = e.profiles[0].scans[0].clone();
+        e.profiles[0].scans.push(scan);
+        assert_eq!(
+            evaluate(&s, Some(Ok(0.0)), &e, &p),
+            Category::LivenessRefused
+        );
+    }
+
+    #[test]
+    fn ir_only_evaluation_foreign_recognizer_and_dimension_refuse() {
+        let (s, mut e, p) = genuine();
+        e.profiles[0].scans[0].embed_space = Some("embed:foreign".into());
+        assert_eq!(
+            evaluate(&s, Some(Ok(0.0)), &e, &p),
+            Category::IncompatibleEnrollment
+        );
+        e.profiles[0].scans[0].embed_space = None;
+        e.profiles[0].scans[0].ir = Some(vec![1.0]);
+        assert_eq!(
+            evaluate(&s, Some(Ok(0.0)), &e, &p),
+            Category::IncompatibleEnrollment
+        );
+    }
+
+    #[test]
+    fn ir_only_evaluation_centroid_arm_uses_profile_count_and_finite_scores() {
+        let matched = |score| IrMatch {
+            best: 0.0,
+            best_who: "private".into(),
+            n_templates: 30,
+            centroid: Some((score, "private".into())),
+        };
+        assert_eq!(
+            identity_category(matched(0.65), 1, false).category,
+            Category::CandidateMatch
+        );
+        assert_eq!(
+            identity_category(matched(0.1), 1, false).category,
+            Category::IdentityMismatch
+        );
+        assert_eq!(
+            identity_category(matched(f32::INFINITY), 1, false).category,
+            Category::IdentityMismatch
+        );
+    }
+
+    #[test]
+    fn ir_only_evaluation_reports_each_identity_acceptance_truth_table_arm() {
+        let base = irlume_core::IR_DARK_MATCH_THRESHOLD;
+        let templates = 30;
+        let profiles = 2;
+        let best_threshold = irlume_core::scaled_threshold(base, templates);
+        let centroid_threshold = irlume_core::scaled_threshold(base, profiles);
+        let matched = |best, centroid| IrMatch {
+            best,
+            best_who: "private".into(),
+            n_templates: templates,
+            centroid: Some((centroid, "private".into())),
+        };
+        for (best, centroid, category, acceptance, serialized) in [
+            (
+                best_threshold - 0.01,
+                centroid_threshold - 0.01,
+                Category::IdentityMismatch,
+                None,
+                serde_json::Value::Null,
+            ),
+            (
+                best_threshold + 0.01,
+                centroid_threshold - 0.01,
+                Category::CandidateMatch,
+                Some(IdentityAcceptance::BestTemplate),
+                serde_json::json!("best_template"),
+            ),
+            (
+                best_threshold - 0.01,
+                centroid_threshold + 0.01,
+                Category::CandidateMatch,
+                Some(IdentityAcceptance::Centroid),
+                serde_json::json!("centroid"),
+            ),
+            (
+                best_threshold + 0.01,
+                centroid_threshold + 0.01,
+                Category::CandidateMatch,
+                Some(IdentityAcceptance::Both),
+                serde_json::json!("both"),
+            ),
+        ] {
+            let result = identity_category(matched(best, centroid), profiles, false);
+            assert_eq!(result.category, category);
+            assert_eq!(result.acceptance, acceptance);
+            let mut report = Report::new(result.category);
+            report.identity_acceptance = result.acceptance;
+            assert_eq!(report.to_json()["identity_acceptance"], serialized);
+        }
+    }
+
+    #[test]
+    fn ir_only_evaluation_identity_acceptance_uses_adapter_threshold_and_compatibility() {
+        let base = irlume_core::IR_ADAPTED_MATCH_THRESHOLD;
+        let templates = 3;
+        let profiles = 2;
+        let result = identity_category(
+            IrMatch {
+                best: irlume_core::scaled_threshold(base, templates),
+                best_who: "private".into(),
+                n_templates: templates,
+                centroid: Some((
+                    irlume_core::scaled_threshold(base, profiles),
+                    "private".into(),
+                )),
+            },
+            profiles,
+            true,
+        );
+        assert_eq!(result.acceptance, Some(IdentityAcceptance::Both));
+        let incompatible = identity_category(
+            IrMatch {
+                best: f32::INFINITY,
+                best_who: "private".into(),
+                n_templates: 0,
+                centroid: Some((f32::NAN, "private".into())),
+            },
+            profiles,
+            true,
+        );
+        assert_eq!(incompatible.category, Category::IncompatibleEnrollment);
+        assert_eq!(incompatible.acceptance, None);
+    }
+
+    #[test]
+    fn ir_only_evaluation_rate_fill_detail_refines_only_hardware_refusal() {
+        use irlume_camera::RateFillFailure;
+        let detail = Some(RateFillFailure::TimestampNonIncreasing);
+        let refined =
+            Category::from(IrFailure::CameraHardwareFailed).with_rate_fill_failure(detail);
+        let json = Report::new(refined).to_json();
+        assert_eq!(
+            json["category"],
+            "camera_rate_fill_timestamp_non_increasing"
+        );
+        assert_eq!(json["authentication_granted"], false);
+        assert!(json["identity_acceptance"].is_null());
+        assert!(json["detection_ms"].is_null());
+        assert_eq!(
+            Category::CameraHardwareFailed.with_rate_fill_failure(None),
+            Category::CameraHardwareFailed
+        );
+        for unchanged in [
+            Category::Cancelled,
+            Category::DeadlineExpired,
+            Category::CameraBusy,
+            Category::CameraRateRefused,
+            Category::CameraIoFailed,
+            Category::Ready,
+            Category::CandidateMatch,
+            Category::IdentityMismatch,
+        ] {
+            assert_eq!(unchanged.with_rate_fill_failure(detail), unchanged);
+        }
+    }
+
+    #[test]
+    fn ir_only_evaluation_json_has_only_fixed_categories_and_nullable_timings() {
+        let report = Report::new(Category::InvalidRequest);
+        assert_eq!(
+            report.to_json(),
+            serde_json::json!({ "schema": 4, "operation": "ir_only_evaluation",
+            "authentication_granted": false, "category": "invalid_request", "elapsed_ms": 0,
+            "identity_acceptance": null,
+            "capture_ms": null, "detection_ms": null, "pad_ms": null, "identity_ms": null,
+            "capture_stages_ms": irlume_camera::CaptureTimings::default().snapshot() })
+        );
+    }
+
+    #[test]
+    fn ir_only_evaluation_nonfinite_identity_scores_never_accept() {
+        for score in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let best = identity_category(
+                IrMatch {
+                    best: score,
+                    best_who: "private".into(),
+                    n_templates: 1,
+                    centroid: None,
+                },
+                1,
+                false,
+            );
+            assert_eq!(best.category, Category::IdentityMismatch);
+            assert_eq!(best.acceptance, None);
+            let centroid = identity_category(
+                IrMatch {
+                    best: 0.0,
+                    best_who: "private".into(),
+                    n_templates: 1,
+                    centroid: Some((score, "private".into())),
+                },
+                1,
+                false,
+            );
+            assert_eq!(centroid.category, Category::IdentityMismatch);
+            assert_eq!(centroid.acceptance, None);
+        }
+    }
+    #[test]
+    fn capture_failure_categories_preserve_types_without_disclosing_messages() {
+        use irlume_common::Error;
+        for (error, want) in [
+            (
+                Error::CameraBusy("private device holder".into()),
+                "camera_busy",
+            ),
+            (Error::Io("private io path".into()), "camera_io_failed"),
+            (
+                Error::Hardware("camera busy is only prose".into()),
+                "camera_hardware_failed",
+            ),
+            (
+                Error::NotAuthorized("private user".into()),
+                "camera_authorization_refused",
+            ),
+            (
+                Error::Policy("private policy".into()),
+                "camera_policy_refused",
+            ),
+            (
+                Error::Protocol("private protocol".into()),
+                "camera_capture_failed",
+            ),
+            (
+                Error::Tpm("private TPM detail".into()),
+                "camera_capture_failed",
+            ),
+            (Error::Preempted("private cancellation".into()), "cancelled"),
+            (Error::DeadlineExpired, "deadline_expired"),
+        ] {
+            let json = Report::new(error_category(error)).to_json();
+            assert_eq!(
+                json,
+                serde_json::json!({
+                    "schema": 4, "operation": "ir_only_evaluation",
+                    "authentication_granted": false, "category": want,
+                    "identity_acceptance": null,
+                    "elapsed_ms": 0, "capture_ms": null, "detection_ms": null,
+                    "pad_ms": null, "identity_ms": null,
+                    "capture_stages_ms": irlume_camera::CaptureTimings::default().snapshot()
+                })
+            );
+        }
+    }
+
+    #[test]
+    fn capture_lease_timeout_is_not_the_authentication_deadline() {
+        use lease::CameraLeaseError as E;
+        for (error, want) in [
+            (
+                E::DeadlineExpired {
+                    current_owner: None,
+                },
+                "camera_lease_timeout",
+            ),
+            (
+                E::DeadlineExpired {
+                    current_owner: Some(lease::CameraOperationKind::Diagnostics),
+                },
+                "camera_lease_timeout",
+            ),
+            (E::Stale, "camera_lease_refused"),
+            (E::UnknownEndpoint, "camera_lease_refused"),
+            (E::Poisoned, "camera_lease_refused"),
+            (
+                E::InvalidEndpoint("private path".into()),
+                "camera_lease_refused",
+            ),
+        ] {
+            let json = Report::new(lease_error_category(error)).to_json();
+            assert_eq!(json["category"], want);
+            assert_eq!(json["authentication_granted"], false);
+            assert!(!json.to_string().contains("private"));
+            assert_eq!(json.as_object().unwrap().len(), 11);
+        }
+    }
+
+    #[test]
+    fn capture_rate_refusal_does_not_serialize_the_evidence_payload() {
+        let evidence = irlume_common::CameraStreamRateEvidence {
+            role: "private role".into(),
+            requested_num: 1,
+            requested_den: 15,
+            accepted_num: 1,
+            accepted_den: 15,
+            floor_num: 15,
+            floor_den: 1,
+            tolerance_percent: 98,
+            window_count: 30,
+            window_span_us: 3_000_000,
+            delivered_num: 10,
+            delivered_den: 1,
+            meets_floor: false,
+            sequence_gap: 0,
+            cumulative_drops: 0,
+            clock: "private clock".into(),
+            source: "private source".into(),
+            latest_timestamp_us: 123_456_789,
+            stream_epoch: 1,
+        };
+        let json = Report::new(error_category(irlume_common::Error::DeliveredRate(
+            Box::new(evidence),
+        )))
+        .to_json();
+        assert_eq!(json["category"], "camera_rate_refused");
+        assert_eq!(json["authentication_granted"], false);
+        assert_eq!(json.as_object().unwrap().len(), 11);
+        assert!(!json.to_string().contains("private"));
+        assert!(!json.to_string().contains("123456789"));
+    }
+
+    #[test]
+    fn capture_failure_stops_inference_and_cancellation_still_takes_precedence() {
+        for category in [
+            IrFailure::CameraBusy,
+            IrFailure::CameraRateRefused,
+            IrFailure::CameraLeaseTimeout,
+            IrFailure::CameraLeaseRefused,
+            IrFailure::CameraIoFailed,
+            IrFailure::CameraHardwareFailed,
+            IrFailure::CameraAuthorizationRefused,
+            IrFailure::CameraPolicyRefused,
+            IrFailure::CameraCaptureFailed,
+        ] {
+            for cancel in [false, true] {
+                let signal = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+                let observed = signal.clone();
+                let control = CaptureControl::new(
+                    irlume_camera::no_progress(),
+                    std::sync::Arc::new(move || {
+                        observed.load(std::sync::atomic::Ordering::Acquire)
+                    }),
+                );
+                let mut stages = InterruptStages {
+                    stop_at: if cancel { "capture" } else { "" },
+                    expire: false,
+                    capture_failure: Some(category),
+                    signal,
+                    reached: Vec::new(),
+                };
+                let report =
+                    evaluate_stages(&mut stages, &control, Duration::from_secs(1), 1, false);
+                assert_eq!(
+                    report.category,
+                    if cancel {
+                        Category::Cancelled
+                    } else {
+                        category.into()
+                    }
+                );
+                assert!(report.capture_ms.is_some());
+                assert_eq!(
+                    (report.detection_ms, report.pad_ms, report.identity_ms),
+                    (None, None, None)
+                );
+                assert_eq!(stages.reached, ["preflight", "capture"]);
+                assert_eq!(report.to_json()["authentication_granted"], false);
+            }
+        }
+    }
+
+    struct InterruptStages {
+        stop_at: &'static str,
+        expire: bool,
+        capture_failure: Option<IrFailure>,
+        signal: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        reached: Vec<&'static str>,
+    }
+    impl InterruptStages {
+        fn step(&mut self, label: &'static str) {
+            self.reached.push(label);
+            if label == self.stop_at {
+                if self.expire {
+                    std::thread::sleep(Duration::from_millis(110));
+                } else {
+                    self.signal
+                        .store(true, std::sync::atomic::Ordering::Release);
+                }
+            }
+        }
+    }
+    impl AssessmentStages for InterruptStages {
+        type Captured = ();
+        type Detected = ();
+        type Aligned = ();
+        type Embedded = ();
+        fn preflight(&mut self) -> Result<(), IrFailure> {
+            self.step("preflight");
+            Ok(())
+        }
+        fn capture(&mut self, _: &CaptureControl, _: Option<Instant>) -> Result<(), IrFailure> {
+            self.step("capture");
+            if let Some(category) = self.capture_failure {
+                Err(category)
+            } else {
+                Ok(())
+            }
+        }
+        fn detect(&mut self, _: ()) -> Result<(), IrFailure> {
+            self.step("detect");
+            Ok(())
+        }
+        fn signals(&self, _: &()) -> Signals {
+            Signals::default()
+        }
+        fn pad(&mut self, _: &()) -> Result<PadEvidence, IrFailure> {
+            self.step("pad");
+            Ok(PadEvidence::Score(0.1))
+        }
+        fn align(&mut self, _: ()) -> Result<(), IrFailure> {
+            self.step("align");
+            Ok(())
+        }
+        fn embed(&mut self, _: ()) -> Result<(), IrFailure> {
+            self.step("embed");
+            Ok(())
+        }
+        fn adapt(&mut self, _: ()) -> Result<Vec<f32>, IrFailure> {
+            self.step("adapt");
+            Ok(vec![0.0; EMBED_DIM])
+        }
+        fn identify(&mut self, _: &[f32]) -> IrMatch {
+            self.step("identify");
+            IrMatch {
+                best: 1.0,
+                best_who: "synthetic".into(),
+                n_templates: 1,
+                centroid: None,
+            }
+        }
+    }
+
+    #[test]
+    fn ir_only_evaluation_orchestrator_stops_after_every_cancelled_stage() {
+        use std::sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        };
+        for stage in [
+            "preflight",
+            "capture",
+            "detect",
+            "pad",
+            "align",
+            "embed",
+            "adapt",
+            "identify",
+        ] {
+            let signal = Arc::new(AtomicBool::new(false));
+            let observed = Arc::clone(&signal);
+            let control = CaptureControl::new(
+                irlume_camera::no_progress(),
+                Arc::new(move || observed.load(Ordering::Acquire)),
+            );
+            let mut stages = InterruptStages {
+                stop_at: stage,
+                expire: false,
+                capture_failure: None,
+                signal,
+                reached: Vec::new(),
+            };
+            let report = evaluate_stages(&mut stages, &control, Duration::from_secs(1), 1, false);
+            assert_eq!(report.category, Category::Cancelled, "late stage {stage}");
+            assert_eq!(report.identity_acceptance, None, "late stage {stage}");
+            assert_eq!(
+                stages.reached.last(),
+                Some(&stage),
+                "work continued after cancellation"
+            );
+        }
+    }
+
+    #[test]
+    fn ir_only_evaluation_orchestrator_stops_after_expired_inference_stages() {
+        for stage in ["detect", "pad", "embed", "identify"] {
+            let control = CaptureControl::with_progress(irlume_camera::no_progress());
+            let mut stages = InterruptStages {
+                stop_at: stage,
+                expire: true,
+                capture_failure: None,
+                signal: Default::default(),
+                reached: Vec::new(),
+            };
+            let report =
+                evaluate_stages(&mut stages, &control, Duration::from_millis(100), 1, false);
+            assert_eq!(
+                report.category,
+                Category::DeadlineExpired,
+                "late stage {stage}"
+            );
+            assert_eq!(report.identity_acceptance, None, "late stage {stage}");
+            assert_eq!(
+                stages.reached.last(),
+                Some(&stage),
+                "work continued after expiry"
+            );
+        }
+    }
+
+    #[test]
+    fn ir_only_evaluation_completed_candidate_retains_acceptance_arm() {
+        let control = CaptureControl::with_progress(irlume_camera::no_progress());
+        let mut stages = InterruptStages {
+            stop_at: "",
+            expire: false,
+            capture_failure: None,
+            signal: Default::default(),
+            reached: Vec::new(),
+        };
+        let report = evaluate_stages(&mut stages, &control, Duration::from_secs(1), 1, false);
+        assert_eq!(report.category, Category::CandidateMatch);
+        assert_eq!(
+            report.identity_acceptance,
+            Some(IdentityAcceptance::BestTemplate)
+        );
+        assert_eq!(report.to_json()["identity_acceptance"], "best_template");
+    }
+
+    #[test]
+    fn ir_only_evaluation_failed_capture_does_not_report_unrun_detection() {
+        let control = CaptureControl::with_progress(irlume_camera::no_progress());
+        let mut stages = InterruptStages {
+            stop_at: "",
+            expire: false,
+            capture_failure: Some(IrFailure::CameraUnavailable),
+            signal: Default::default(),
+            reached: Vec::new(),
+        };
+        let report = evaluate_stages(&mut stages, &control, Duration::from_secs(1), 1, false);
+        assert_eq!(report.category, Category::CameraUnavailable);
+        assert!(report.capture_ms.is_some());
+        assert_eq!(
+            (report.detection_ms, report.pad_ms, report.identity_ms),
+            (None, None, None)
+        );
+        assert_eq!(stages.reached, ["preflight", "capture"]);
+    }
+
+    #[test]
+    fn ir_only_evaluation_orchestrator_validates_budget_before_any_work() {
+        let control = CaptureControl::with_progress(irlume_camera::no_progress());
+        for budget in [
+            Duration::ZERO,
+            Duration::from_millis(99),
+            Duration::from_millis(30001),
+            Duration::MAX,
+        ] {
+            let mut stages = InterruptStages {
+                stop_at: "",
+                expire: false,
+                capture_failure: None,
+                signal: Default::default(),
+                reached: Vec::new(),
+            };
+            let report = evaluate_stages(&mut stages, &control, budget, 1, false);
+            assert_eq!(report.category, Category::InvalidRequest);
+            assert!(stages.reached.is_empty());
+        }
+    }
+
+    #[test]
+    fn ir_only_evaluation_orchestrator_completes_only_after_all_stages() {
+        let control = CaptureControl::with_progress(irlume_camera::no_progress());
+        let mut stages = InterruptStages {
+            stop_at: "",
+            expire: false,
+            capture_failure: None,
+            signal: Default::default(),
+            reached: Vec::new(),
+        };
+        let report = evaluate_stages(&mut stages, &control, Duration::from_secs(1), 1, false);
+        assert_eq!(report.category, Category::CandidateMatch);
+        assert_eq!(
+            stages.reached,
+            [
+                "preflight",
+                "capture",
+                "detect",
+                "pad",
+                "align",
+                "embed",
+                "adapt",
+                "identify"
+            ]
+        );
+        assert!(
+            report.capture_ms.is_some()
+                && report.detection_ms.is_some()
+                && report.pad_ms.is_some()
+                && report.identity_ms.is_some()
+        );
+        assert_eq!(report.to_json()["authentication_granted"], false);
+    }
+}

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -8,6 +8,12 @@
 //! and run the liveness gate on the cross-spectrum signals → on Live, match the
 //! embedding against the user's enrolled templates at the fixed threshold.
 
+mod ir_assessment;
+
+/// Non-granting developer IR evaluation; absent from normal builds.
+#[cfg(feature = "ir-only-evaluation")]
+pub mod ir_only_evaluation;
+
 use irlume_liveness::{LivenessGate, Signals, Verdict};
 use irlume_vision::{align, Adapter, Detection, Embedder, Landmarks5, EMBED_DIM};
 
@@ -28,6 +34,8 @@ pub use irlume_camera::{
 /// devices without depending on the camera crate directly. See
 /// [`irlume_camera::select_pair`].
 pub use irlume_camera::{capabilities, device_identity, select_pair, select_rgb};
+/// Resolve explicitly configured devices without camera discovery or image opens.
+pub use irlume_camera::{configured_ir_target, configured_pair_no_probe};
 /// IR-emitter auto-setup (integrated linux-enable-ir-emitter), re-exported for
 /// the daemon. See [`irlume_camera::setup_ir_emitter`].
 pub use irlume_camera::{
@@ -45,6 +53,7 @@ pub struct Engine {
     emb: Embedder,
     /// Optional IR domain-adaptation MLP (applied to IR embeddings in the dark).
     ir_adapter: Option<Adapter>,
+    ir_adapter_required: bool,
     /// Embedding space IR probes (and new IR scans) live in: `"raw"` without an
     /// adapter, else `"adapter:<sha256 prefix>"` of the loaded adapter file.
     /// Stored on every new scan and matched against at verify, so an adapter
@@ -109,6 +118,9 @@ pub struct Engine {
     /// never mid-inference: stopping an operation is a scheduling decision, not
     /// a way to abandon a device or a session.
     stop_requested: Option<std::sync::Arc<dyn Fn() -> bool + Send + Sync>>,
+    /// This request was abandoned, independently of higher-priority queued work.
+    request_cancelled: Option<std::sync::Arc<dyn Fn() -> bool + Send + Sync>>,
+    authentication_deadline: Option<std::time::Instant>,
 }
 
 /// The rescue-slot detector (cascade stage 2): the shipped short-range
@@ -180,6 +192,8 @@ pub struct Assessment {
 
 // An unfinished assessment cannot enter the public identity-admission boundary.
 // Its identity inputs carry actual detected faces, not placeholder embeddings.
+mod authentication_window;
+pub use authentication_window::AuthenticationWindow;
 mod grouped_auth;
 
 struct DeferredAssessment<I> {
@@ -376,11 +390,30 @@ struct AttemptFacts {
     glint: Option<f32>,
     ir_bright: f32,
     persistent_ir_source_overwhelms: bool,
+    ir_only: bool,
 }
 
 impl AttemptFacts {
+    fn from_ir_signals(signals: Option<&Signals>) -> Self {
+        signals.map_or(
+            Self {
+                ir_only: true,
+                ..Self::default()
+            },
+            |signals| Self {
+                ir_only: true,
+                face_frac: signals.face_frac,
+                glint: signals.ir_eye_glint,
+                ir_bright: signals.ir_face_brightness,
+                persistent_ir_source_overwhelms: signals.persistent_ir_source_overwhelms(),
+                ..Self::default()
+            },
+        )
+    }
+
     fn from_assessment(a: &Assessment) -> Self {
         Self {
+            ir_only: false,
             rgb_face: a.signals.rgb_face.map(|f| (f.cx, f.cy)),
             face_frac: a.signals.face_frac,
             yaw_asym: a.signals.head_yaw_asym,
@@ -448,16 +481,24 @@ fn auth_attempt_situation(kind: OutcomeKind, f: &AttemptFacts) -> AttemptSituati
 /// measure must not appear as one that was.
 fn attempt_situation_line(kind: OutcomeKind, score: f32, f: &AttemptFacts) -> String {
     format!(
-        "attempt: {}; face_frac={:.2} yaw={:.2} glint={} ir_bright={:.0} rgb_bright={:.0} \
+        "attempt: {}; face_frac={:.2} yaw={} glint={} ir_bright={:.0} rgb_bright={} \
          score={:.2}",
         attempt_situation_label(auth_attempt_situation(kind, f)),
         f.face_frac,
-        f.yaw_asym,
+        if f.ir_only {
+            "n/a".into()
+        } else {
+            format!("{:.2}", f.yaw_asym)
+        },
         f.glint
             .map(|g| format!("{g:.2}"))
             .unwrap_or_else(|| "n/a".into()),
         f.ir_bright,
-        f.rgb_face_brightness,
+        if f.ir_only {
+            "n/a".into()
+        } else {
+            format!("{:.0}", f.rgb_face_brightness)
+        },
         score,
     )
 }
@@ -692,8 +733,12 @@ pub const IR_PAD_THRESHOLD: f32 = 0.9;
 /// settling before it gives up to the password (~15s, roughly 10 capture
 /// attempts at ~1.1-1.5s each). It retries ONLY presence failures (no matcher
 /// ran), so a longer window costs no false-accept resistance. Override with
-/// `IRLUME_GRACE_MS` (0 = legacy one-shot).
+/// `IRLUME_GRACE_MS` (0 = legacy one-shot; maximum 60,000 ms).
 pub const GRACE_WINDOW_MS: u64 = 15000;
+// Bound development overrides so a typo cannot defer password fallback for
+// an effectively unlimited presence window. This is an operator policy bound,
+// not a latency target; ordinary service defaults remain substantially shorter.
+const MAX_GRACE_OVERRIDE_MS: u64 = 60_000;
 /// Shorter window for `sudo` (and `su`): at a terminal the user is already
 /// looking at the screen, so a match lands on the first attempt; if they look
 /// away they want a quick drop to the password prompt, not a long freeze.
@@ -855,7 +900,7 @@ fn pair_admitted_sequentially(skew: std::time::Duration, paired: bool) -> bool {
 }
 
 /// Grace window for a given PAM service. `IRLUME_GRACE_MS` overrides everything
-/// (testing); otherwise sudo/su and polkit get the short window (the user is
+/// (testing, 0..=60,000 ms); otherwise sudo/su and polkit get the short window (the user is
 /// already at the machine, and the KDE polkit agent re-runs the stack up to 3
 /// times on failure, so a long window would just hold its dialog busy) and
 /// every login/lock service (and an unknown/absent service) gets the full
@@ -863,7 +908,8 @@ fn pair_admitted_sequentially(skew: std::time::Duration, paired: bool) -> bool {
 fn grace_window_ms(service: Option<&str>) -> u64 {
     if let Some(v) = std::env::var("IRLUME_GRACE_MS")
         .ok()
-        .and_then(|v| v.parse().ok())
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|v| *v <= MAX_GRACE_OVERRIDE_MS)
     {
         return v;
     }
@@ -897,7 +943,8 @@ pub enum AuthenticationPurpose {
 impl AuthenticationPurpose {
     /// The purpose a plain [`Engine::authenticate`] runs under: consent-class
     /// services (polkit) get [`Self::AppConsent`], everything else [`Self::Verify`].
-    fn for_service(service: Option<&str>) -> Self {
+    /// Use app consent for privileged services and verification otherwise.
+    pub fn for_service(service: Option<&str>) -> Self {
         if matches!(
             service.and_then(irlume_common::pam_service::classify),
             Some(irlume_common::pam_service::ServiceKind::AppConsent)
@@ -913,13 +960,25 @@ impl AuthenticationPurpose {
 /// [`Engine::authenticate_for_with_diagnostics`].
 type EnrollmentLoad = irlume_common::Result<Option<irlume_core::storage::Enrollment>>;
 
+/// Own an in-flight enrollment helper until setup consumes its result. Declared
+/// before camera owners so early exits drop those owners before draining it.
+struct PendingEnrollmentLoad {
+    receiver: Option<std::sync::mpsc::Receiver<EnrollmentLoad>>,
+}
+
+impl Drop for PendingEnrollmentLoad {
+    fn drop(&mut self) {
+        finish_loader(&mut self.receiver);
+    }
+}
+
 /// Wait out a still-running deferred enrollment load on an early exit, so the
 /// user-state flock and the TPM are free before this request returns. An
 /// immediate retry (decline, then a fallback attempt) would otherwise block
 /// on the orphaned loader's locks — the one way this overlap could make a
 /// retry SLOWER than the serial load it replaced. The exits that can still be
-/// waiting are rare deny/error paths (camera-lease
-/// failure); the post-watch exits arrive seconds after the spawn, by which
+/// waiting include cancellation during setup and camera-lease failure;
+/// the post-watch exits arrive seconds after the spawn, by which
 /// time the load has long finished.
 fn finish_loader(loader: &mut Option<std::sync::mpsc::Receiver<EnrollmentLoad>>) {
     if let Some(rx) = loader.take() {
@@ -1100,8 +1159,19 @@ fn ir_match_in(
         n_templates: 0,
         centroid: None,
     };
+    // Older custom adapters could store arbitrary vector magnitudes.
+    // Normalize both sides in memory; a corrected new probe alone
+    // would still let an oversized historical template inflate its dot product.
+    let adapted_probe = adapter_loaded
+        .then(|| align::normalize_embedding(probe))
+        .flatten();
+    let scoring_probe = if adapter_loaded {
+        adapted_probe.as_deref()
+    } else {
+        Some(probe)
+    };
     for p in &enr.profiles {
-        let tmpls: Vec<&[f32]> = p
+        let tmpls: Vec<std::borrow::Cow<'_, [f32]>> = p
             .scans
             .iter()
             .filter_map(|s| {
@@ -1122,13 +1192,25 @@ fn ir_match_in(
                 }
                 // Before tagging, both raw and adapted IR shipped. An absent
                 // tag cannot establish either space, even at the same width.
-                (s.ir_space.as_deref() == Some(space)).then_some(ir.as_slice())
+                if s.ir_space.as_deref() != Some(space) {
+                    return None;
+                }
+                if adapter_loaded {
+                    align::normalize_embedding(ir).map(std::borrow::Cow::Owned)
+                } else {
+                    Some(std::borrow::Cow::Borrowed(ir.as_slice()))
+                }
             })
             .collect();
         if tmpls.is_empty() {
             continue;
         }
         m.n_templates += tmpls.len();
+        // Diagnostic preflight uses a zero probe to count eligible templates.
+        // Retain that count, but invalid adapted probes never produce scores.
+        let Some(probe) = scoring_probe else {
+            continue;
+        };
         // The calibration for THIS recognizer: a profile can hold scans (and
         // calibrations) from several, and applying one model's calibration to
         // another's templates puts uninterpretable numbers into the matcher
@@ -1175,6 +1257,103 @@ fn ir_match_in(
         }
     }
     m
+}
+
+#[cfg(test)]
+mod adapter_match_tests {
+    use super::*;
+    use irlume_core::storage::{Enrollment, FaceProfile, FaceScan, LEGACY_RECOGNIZER_SPACE};
+
+    fn enrollment(template: Vec<f32>) -> Enrollment {
+        let mut enr = Enrollment::new("synthetic");
+        enr.profiles.push(FaceProfile {
+            name: "synthetic".into(),
+            scans: vec![FaceScan {
+                name: "synthetic".into(),
+                rgb: vec![],
+                ir: Some(template),
+                ir_space: Some("adapter-test".into()),
+                embed_space: None,
+                ir_center_edge_ratio: 0.0,
+                ir_brightness: 0.0,
+                pitch: 0.0,
+            }],
+            ir_calib: None,
+            ir_calibs: Default::default(),
+        });
+        enr
+    }
+
+    fn match_adapted(enr: &Enrollment, probe: &[f32]) -> IrMatch {
+        ir_match_in("adapter-test", LEGACY_RECOGNIZER_SPACE, true, enr, probe)
+    }
+
+    fn direction(cosine: f32, scale: f32) -> Vec<f32> {
+        let mut v = vec![0.0; EMBED_DIM];
+        v[0] = cosine * scale;
+        v[1] = (1.0 - cosine * cosine).sqrt() * scale;
+        v
+    }
+
+    #[test]
+    fn adapter_match_historical_scaling_cannot_inflate_similarity() {
+        for template_scale in [1.0, 10.0] {
+            for probe_scale in [1.0, 10.0] {
+                let enr = enrollment(direction(0.2, template_scale));
+                let result = match_adapted(&enr, &direction(1.0, probe_scale));
+                assert!((result.best - 0.2).abs() < 1e-6);
+                assert_eq!(result.n_templates, 1);
+                assert!(result.centroid.is_none());
+            }
+        }
+    }
+
+    #[test]
+    fn adapter_match_invalid_probe_retains_preflight_count_without_scores() {
+        let enr = enrollment(direction(1.0, 1.0));
+        for invalid in [0.0, f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let result = match_adapted(&enr, &vec![invalid; EMBED_DIM]);
+            assert_eq!(result.n_templates, 1);
+            assert_eq!(result.best, f32::NEG_INFINITY);
+            assert!(result.best_who.is_empty());
+            assert!(result.centroid.is_none());
+        }
+    }
+
+    #[test]
+    fn adapter_match_invalid_templates_are_not_eligible() {
+        let probe = direction(1.0, 1.0);
+        for invalid in [0.0, f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let result = match_adapted(&enrollment(vec![invalid; EMBED_DIM]), &probe);
+            assert_eq!(result.n_templates, 0);
+            assert_eq!(result.best, f32::NEG_INFINITY);
+        }
+    }
+
+    #[test]
+    fn adapter_match_unit_vectors_preserve_threshold_neighborhood() {
+        // Numerical compatibility near the policy boundary, not qualification.
+        let threshold = irlume_core::IR_ADAPTED_MATCH_THRESHOLD;
+        for expected in [threshold - 2e-5, threshold + 2e-5] {
+            let result = match_adapted(&enrollment(direction(expected, 1.0)), &direction(1.0, 1.0));
+            assert!((result.best - expected).abs() < 1e-6);
+            assert_eq!(result.best >= threshold, expected >= threshold);
+        }
+    }
+
+    #[test]
+    fn adapter_match_retains_dimension_and_space_filters() {
+        let probe = direction(1.0, 1.0);
+        let mut enr = enrollment(probe.clone());
+        enr.profiles[0].scans[0].ir_space = Some("different-adapter".into());
+        assert_eq!(match_adapted(&enr, &probe).n_templates, 0);
+        enr.profiles[0].scans[0].ir_space = Some("adapter-test".into());
+        enr.profiles[0].scans[0].embed_space = Some("different-recognizer".into());
+        assert_eq!(match_adapted(&enr, &probe).n_templates, 0);
+        enr.profiles[0].scans[0].embed_space = None;
+        enr.profiles[0].scans[0].ir.as_mut().unwrap().pop();
+        assert_eq!(match_adapted(&enr, &probe).n_templates, 0);
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1471,6 +1650,30 @@ impl From<irlume_common::Error> for CapturePathError {
     fn from(error: irlume_common::Error) -> Self {
         Self::Other(error)
     }
+}
+
+fn concurrent_setup_error(
+    mode: Option<&CaptureModeSelection>,
+    diagnostics: &dyn irlume_common::diagnostics::DiagnosticSink,
+    reason: RuntimeDegradation,
+    error: irlume_common::Error,
+) -> CapturePathError {
+    if matches!(
+        error,
+        irlume_common::Error::Preempted(_) | irlume_common::Error::DeadlineExpired
+    ) {
+        return CapturePathError::Other(error);
+    }
+    irlume_common::dlog!("concurrent assessment setup failed ({reason:?}): {error}");
+    emit_capture_fallback(reason, diagnostics);
+    if let Some(selection) = mode {
+        if pair_rate_failure_is_degradation(selection) {
+            if let Some(key) = selection.runtime_key.as_deref() {
+                trip_runtime_capture_health(key, reason);
+            }
+        }
+    }
+    CapturePathError::ConcurrentPair(error)
 }
 
 fn unavailable_capture_mode_selection() -> CaptureModeSelection {
@@ -2400,6 +2603,53 @@ mod capture_mode_switch_tests {
     }
 
     #[test]
+    fn capture_cancellation_does_not_emit_or_record_camera_degradation() {
+        let sink = RecordingSink::default();
+        let mut mode = unavailable_capture_mode_selection();
+        mode.sequential = false;
+        mode.source = STORED_CAPTURE_MODE_SOURCE;
+        mode.runtime_key = Some("cancelled-setup-regression".into());
+        reset_runtime_capture_health("cancelled-setup-regression");
+        for reason in [
+            RuntimeDegradation::PairArmFailure,
+            RuntimeDegradation::PairRateEstablishmentFailure,
+        ] {
+            let error = concurrent_setup_error(
+                Some(&mode),
+                &sink,
+                reason,
+                irlume_common::Error::Preempted("cancelled".into()),
+            );
+            assert!(matches!(
+                error,
+                CapturePathError::Other(irlume_common::Error::Preempted(_))
+            ));
+            assert!(sink.events().is_empty());
+            assert!(with_runtime_capture_health(
+                |health| health.degradation("cancelled-setup-regression")
+            )
+            .is_none());
+            assert!(!mode.is_sequential());
+        }
+        let error = concurrent_setup_error(
+            Some(&mode),
+            &sink,
+            RuntimeDegradation::PairArmFailure,
+            irlume_common::Error::Hardware("genuine camera failure".into()),
+        );
+        assert!(matches!(error, CapturePathError::ConcurrentPair(_)));
+        assert!(
+            !sink.events().is_empty(),
+            "real hardware failures retain fallback reporting"
+        );
+        assert!(with_runtime_capture_health(
+            |health| health.degradation("cancelled-setup-regression")
+        )
+        .is_some());
+        reset_runtime_capture_health("cancelled-setup-regression");
+    }
+
+    #[test]
     fn runtime_degradation_is_process_local_and_exact_context_scoped() {
         let mut health = RuntimeCaptureHealth::default();
         let qualified = (false, STORED_CAPTURE_MODE_SOURCE);
@@ -2878,6 +3128,7 @@ impl Engine {
             det: Detector::load_from_file(det_path)?,
             emb: Embedder::load_from_memory(model.bytes())?,
             ir_adapter: None,
+            ir_adapter_required: false,
             ir_space: "raw".into(),
             embed_space,
             rgb_threshold: irlume_core::RGB_MATCH_THRESHOLD,
@@ -2899,6 +3150,8 @@ impl Engine {
             // `with_devices`, so `IRLUME_FORCE_NO_IR=1` still outranks it.
             ir_available: selected_ir_available(irlume_camera::DEFAULT_IR_DEVICE),
             stop_requested: None,
+            request_cancelled: None,
+            authentication_deadline: None,
             last_attempt_facts: AttemptFacts::default(),
             last_attempt_situation: None,
         })
@@ -2914,6 +3167,85 @@ impl Engine {
         self.stop_requested = Some(signal);
     }
 
+    /// Supply cancellation of the current request, separately from scheduler
+    /// preemption. Authentication ignores queued work but honors its own client
+    /// leaving at safe boundaries; no driver or inference call is interrupted.
+    pub fn set_request_cancel_signal(
+        &mut self,
+        signal: std::sync::Arc<dyn Fn() -> bool + Send + Sync>,
+    ) {
+        self.request_cancelled = Some(signal);
+    }
+
+    /// Check the retained authentication window and the current client's signal
+    /// after the engine has returned, including around credential preparation.
+    ///
+    /// # Errors
+    /// Returns cancellation or expiry without admitting a response.
+    pub fn check_authentication_completion(
+        &self,
+        window: AuthenticationWindow,
+    ) -> irlume_common::Result<()> {
+        if self
+            .request_cancelled
+            .as_ref()
+            .is_some_and(|signal| signal())
+        {
+            return Err(irlume_common::Error::Preempted(
+                "authentication cancelled".into(),
+            ));
+        }
+        window.check()
+    }
+
+    fn check_request_cancelled(&mut self) -> irlume_common::Result<()> {
+        if self
+            .request_cancelled
+            .as_ref()
+            .is_some_and(|signal| signal())
+        {
+            self.vit_scores.clear();
+            self.last_attempt_situation = None;
+            return Err(irlume_common::Error::Preempted(
+                "authentication cancelled".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn check_request_active(&mut self) -> irlume_common::Result<()> {
+        self.check_request_cancelled()?;
+        if self
+            .authentication_deadline
+            .is_some_and(|deadline| std::time::Instant::now() >= deadline)
+        {
+            self.vit_scores.clear();
+            self.last_attempt_situation = Some(AttemptSituation::TimedOut);
+            return Err(irlume_common::Error::DeadlineExpired);
+        }
+        Ok(())
+    }
+
+    /// Completed refusals retain their established accounting classification.
+    /// Expiry prevents granting, not recording evidence already obtained.
+    fn check_completed_attempt(
+        &mut self,
+        result: &irlume_common::Result<Outcome>,
+    ) -> irlume_common::Result<()> {
+        if result.as_ref().is_ok_and(|outcome| !outcome.granted) {
+            self.check_request_cancelled()?;
+            if self
+                .authentication_deadline
+                .is_some_and(|deadline| std::time::Instant::now() >= deadline)
+            {
+                self.vit_scores.clear();
+            }
+            Ok(())
+        } else {
+            self.check_request_active()
+        }
+    }
+
     /// True when something has asked this operation to stop.
     fn should_stop(&self) -> bool {
         self.stop_requested.as_ref().is_some_and(|f| f())
@@ -2927,10 +3259,11 @@ impl Engine {
     /// window arbitrarily, and a window of healthy no-face captures followed
     /// by one frameless capture chain summed past `WatchdogSec` with no
     /// progress reported anywhere between (#336). The answer itself is
-    /// deliberately dropped: only a queued authentication raises it, and
+    /// deliberately dropped: a queued authentication also raises it, and
     /// cutting a RUNNING authentication's grace window for a queued one would
     /// hand the first user a password prompt whenever a polkit verify races
     /// the lock screen. Enrolment keeps honoring it via [`Self::should_stop`].
+    /// Authentication checks its separate request-cancellation signal instead.
     fn note_capture_boundary(&self) {
         let _ = self.should_stop();
     }
@@ -2942,7 +3275,8 @@ impl Engine {
     /// frameless camera reporting each returned dequeue window never looks
     /// wedged, while a driver call that never returns still does. The yield
     /// answer is dropped for the boundary's reason too, and one more: this
-    /// fires INSIDE a capture, where nothing can safely stop anyway. Owned
+    /// fires inside a capture. Request cancellation is checked separately by
+    /// `CaptureControl` at returned-frame boundaries. Owned
     /// (`Arc`) so the concurrent capture pair can carry it across scoped
     /// threads without borrowing the engine.
     fn capture_progress(&self) -> irlume_camera::Progress {
@@ -2955,6 +3289,15 @@ impl Engine {
             }
             None => irlume_camera::no_progress(),
         }
+    }
+
+    fn capture_control(&self) -> irlume_camera::CaptureControl {
+        let progress = self.capture_progress();
+        let control = match &self.request_cancelled {
+            Some(cancelled) => irlume_camera::CaptureControl::new(progress, cancelled.clone()),
+            None => irlume_camera::CaptureControl::with_progress(progress),
+        };
+        control.with_deadline(self.authentication_deadline)
     }
 
     /// Assurance tier from the hardware: `Secure` with a real RGB+IR camera,
@@ -3527,10 +3870,11 @@ impl Engine {
         &mut self,
         diagnostics: &dyn irlume_common::diagnostics::DiagnosticSink,
     ) -> irlume_common::Result<Assessment> {
+        self.check_request_active()?;
         let capture_started = std::time::Instant::now();
-        let rgb = irlume_camera::capture_rgb_denoised_with_progress(
+        let rgb = irlume_camera::capture_rgb_denoised_with_control(
             &self.rgb_dev,
-            &self.capture_progress(),
+            &self.capture_control(),
         )?;
         if let Some(event) = irlume_camera::diagnostic_stream_evidence(&rgb) {
             diagnostics.emit_trace(event);
@@ -3544,6 +3888,7 @@ impl Engine {
             width: rgb.width,
             height: rgb.height,
         };
+        self.check_request_active()?;
         let detection_started = std::time::Instant::now();
         let rgb_faces = self.det.detect(&rgb_view)?;
         let rgb_top = top_detection(&rgb_faces).cloned();
@@ -3614,6 +3959,7 @@ impl Engine {
         // the one measured defence against the life-size print (the 2026-06-30
         // breach species; IR face-presence does not exist here). Same deny-only
         // 5-median contract as the cross-spectrum path.
+        self.check_request_active()?;
         let rgb_pad = match (verdict, rgb_top.as_ref(), self.vit_pad.as_mut()) {
             (Verdict::Live, Some(_), None) => PadEvidence::Unavailable,
             (Verdict::Live, Some(f), Some(pad)) => match pad.p_spoof(&rgb_view, &f.bbox) {
@@ -3626,6 +3972,7 @@ impl Engine {
             },
             _ => PadEvidence::NotApplicable,
         };
+        self.check_request_active()?;
         let (verdict, reason) = match rgb_pad {
             PadEvidence::Score(p) => {
                 irlume_common::dlog!("pad-vit(rgb-only): p_spoof {p:.3}");
@@ -3643,6 +3990,7 @@ impl Engine {
             }
             _ => (verdict, reason),
         };
+        self.check_request_active()?;
         let embedding = match &rgb_top {
             Some(f) => Some(
                 self.emb
@@ -3650,6 +3998,7 @@ impl Engine {
             ),
             None => None,
         };
+        self.check_request_active()?;
         Ok(Assessment {
             verdict,
             reason,
@@ -3686,23 +4035,12 @@ impl Engine {
         operation: &irlume_camera::lease::CameraOperationSession,
         diagnostics: &dyn irlume_common::diagnostics::DiagnosticSink,
     ) -> Result<Assessment, CapturePathError> {
-        let setup_error = |reason, error| {
-            irlume_common::dlog!("concurrent assessment setup failed ({reason:?}): {error}");
-            emit_capture_fallback(reason, diagnostics);
-            if let Some(selection) = mode {
-                if pair_rate_failure_is_degradation(selection) {
-                    if let Some(key) = selection.runtime_key.as_deref() {
-                        trip_runtime_capture_health(key, reason);
-                    }
-                }
-            }
-            CapturePathError::ConcurrentPair(error)
-        };
-        let progress = self.capture_progress();
+        let setup_error = |reason, error| concurrent_setup_error(mode, diagnostics, reason, error);
+        let control = self.capture_control();
         let started = std::time::Instant::now();
         let pair = arm_pair_transactionally(
-            || rgb.session_with_progress(&progress),
-            || ir.session_for_pair_with_progress(&progress),
+            || rgb.session_with_control(&control),
+            || ir.session_for_pair_with_control(&control),
         );
         diagnostics.emit_trace(irlume_common::diagnostics::TraceEventKind::StageTiming {
             stage: irlume_common::diagnostics::TraceStage::StreamArm,
@@ -3815,6 +4153,10 @@ impl Engine {
         ) -> (irlume_common::Result<irlume_camera::Frame>, bool) {
             match rgb_s.denoised() {
                 Ok(f) => (Ok(f), false),
+                Err(
+                    e
+                    @ (irlume_common::Error::Preempted(_) | irlume_common::Error::DeadlineExpired),
+                ) => (Err(e), false),
                 Err(e) => {
                     irlume_common::dlog!(
                         "assess: held rgb stream broke ({e}); recovering it in place"
@@ -3836,6 +4178,10 @@ impl Engine {
         ) {
             match ir_s.capture_with_stats() {
                 Ok(f) => (Ok(f), false),
+                Err(
+                    e
+                    @ (irlume_common::Error::Preempted(_) | irlume_common::Error::DeadlineExpired),
+                ) => (Err(e), false),
                 Err(e) => {
                     irlume_common::dlog!(
                         "assess: held ir stream broke ({e}); recovering it in place"
@@ -3848,7 +4194,7 @@ impl Engine {
         let held_sessions = held.is_some();
         // Every one-shot capture below carries the per-window heartbeat
         // (#336); held sessions already carry theirs from `capture_scans`.
-        let progress = self.capture_progress();
+        let control = self.capture_control();
         let (mut rgb_res, mut rgb_ms, mut ir_res, mut ir_ms, recovered_side) =
             if let Some((rgb_s, ir_s)) = held {
                 if sequential {
@@ -3910,8 +4256,7 @@ impl Engine {
                 }
             } else if sequential {
                 let t = std::time::Instant::now();
-                let rgb =
-                    irlume_camera::capture_rgb_denoised_with_progress(&self.rgb_dev, &progress);
+                let rgb = irlume_camera::capture_rgb_denoised_with_control(&self.rgb_dev, &control);
                 let rgb_ms = t.elapsed().as_millis();
                 // Match the old short-circuit: don't fire the IR emitter after an
                 // RGB fault (privacy switch, missing node); the shared retry below
@@ -3920,26 +4265,26 @@ impl Engine {
                     (rgb, rgb_ms, Ok(None), 0, false)
                 } else {
                     let t = std::time::Instant::now();
-                    let ir = irlume_camera::capture_ir_sequential_with_stats_and_progress(
+                    let ir = irlume_camera::capture_ir_sequential_with_stats_and_control(
                         &self.ir_dev,
-                        &progress,
+                        &control,
                     );
                     (rgb, rgb_ms, ir.map(Some), t.elapsed().as_millis(), false)
                 }
             } else {
                 std::thread::scope(|s| {
                     let ir_dev = self.ir_dev.clone();
-                    let ir_progress = progress.clone();
+                    let ir_control = control.clone();
                     let ir_thread = s.spawn(move || {
                         let t = std::time::Instant::now();
                         let captured = Self::run_camera_operation(operation, || {
-                            irlume_camera::capture_ir_with_stats_and_progress(&ir_dev, &ir_progress)
+                            irlume_camera::capture_ir_with_stats_and_control(&ir_dev, &ir_control)
                         });
                         (captured, t.elapsed().as_millis())
                     });
                     let t = std::time::Instant::now();
                     let rgb =
-                        irlume_camera::capture_rgb_denoised_with_progress(&self.rgb_dev, &progress);
+                        irlume_camera::capture_rgb_denoised_with_control(&self.rgb_dev, &control);
                     let rgb_ms = t.elapsed().as_millis();
                     let (ir, ir_ms) = ir_thread.join().unwrap_or_else(|_| {
                         (
@@ -3952,6 +4297,25 @@ impl Engine {
                     (rgb, rgb_ms, ir.map(Some), ir_ms, false)
                 })
             };
+        self.check_request_active()?;
+        for error in [rgb_res.as_ref().err(), ir_res.as_ref().err()]
+            .into_iter()
+            .flatten()
+        {
+            if matches!(
+                error,
+                irlume_common::Error::Preempted(_) | irlume_common::Error::DeadlineExpired
+            ) {
+                self.vit_scores.clear();
+                self.last_attempt_situation = None;
+                return Err(if matches!(error, irlume_common::Error::DeadlineExpired) {
+                    irlume_common::Error::DeadlineExpired
+                } else {
+                    irlume_common::Error::Preempted("camera capture cancelled".into())
+                }
+                .into());
+            }
+        }
         emit_trace_stage_ms(
             diagnostics,
             irlume_common::diagnostics::TraceStage::RgbCapture,
@@ -4040,17 +4404,15 @@ impl Engine {
             let (fresh_rgb, fresh_ir) = capture_pair_sequentially(
                 || {
                     let started = std::time::Instant::now();
-                    let frame = irlume_camera::capture_rgb_denoised_with_progress(
-                        &self.rgb_dev,
-                        &progress,
-                    )?;
+                    let frame =
+                        irlume_camera::capture_rgb_denoised_with_control(&self.rgb_dev, &control)?;
                     Ok((frame, started.elapsed().as_millis()))
                 },
                 || {
                     let started = std::time::Instant::now();
-                    let frame = irlume_camera::capture_ir_sequential_with_stats_and_progress(
+                    let frame = irlume_camera::capture_ir_sequential_with_stats_and_control(
                         &self.ir_dev,
-                        &progress,
+                        &control,
                     )?;
                     Ok((frame, started.elapsed().as_millis()))
                 },
@@ -4142,7 +4504,7 @@ impl Engine {
                     }
                 );
                 rgb_hard_retried = true;
-                irlume_camera::capture_rgb_denoised_with_progress(&self.rgb_dev, &progress)?
+                irlume_camera::capture_rgb_denoised_with_control(&self.rgb_dev, &control)?
             }
             Err(e) => return Err(e.into()),
         };
@@ -4153,10 +4515,10 @@ impl Engine {
         // but capture alone rather than unwrap to stay panic-free.
         let (ir, ir_stats) = match ir_res {
             Ok(Some(f)) => f,
-            Ok(None) => irlume_camera::capture_ir_with_stats_and_progress(&self.ir_dev, &progress)?,
+            Ok(None) => irlume_camera::capture_ir_with_stats_and_control(&self.ir_dev, &control)?,
             Err(e) if !held_sessions && !pair_sequential_retried => {
                 irlume_common::dlog!("assess: ir capture retry (concurrent failed: {e})");
-                irlume_camera::capture_ir_with_stats_and_progress(&self.ir_dev, &progress)?
+                irlume_camera::capture_ir_with_stats_and_control(&self.ir_dev, &control)?
             }
             Err(e) => return Err(e.into()),
         };
@@ -4184,12 +4546,27 @@ impl Engine {
         rgb_ms: Option<u128>,
         diagnostics: &dyn irlume_common::diagnostics::DiagnosticSink,
     ) -> irlume_common::Result<(Vec<Detection>, Option<Detection>)> {
+        self.detect_rgb_assessment_view(
+            &align::RgbView {
+                data: &rgb.data,
+                width: rgb.width,
+                height: rgb.height,
+            },
+            rgb_ms,
+            diagnostics,
+        )
+    }
+
+    fn detect_rgb_assessment_view(
+        &mut self,
+        rgb: &align::RgbView<'_>,
+        rgb_ms: Option<u128>,
+        diagnostics: &dyn irlume_common::diagnostics::DiagnosticSink,
+    ) -> irlume_common::Result<(Vec<Detection>, Option<Detection>)> {
+        self.check_request_active()?;
         let rgb_detection_started = std::time::Instant::now();
-        let rgb_faces = self.det.detect(&align::RgbView {
-            data: &rgb.data,
-            width: rgb.width,
-            height: rgb.height,
-        })?;
+        let rgb_faces = self.det.detect(rgb)?;
+        self.check_request_active()?;
         diagnostics.emit_trace(irlume_common::diagnostics::TraceEventKind::StageTiming {
             stage: irlume_common::diagnostics::TraceStage::Detection,
             elapsed_us: u64::try_from(rgb_detection_started.elapsed().as_micros())
@@ -4206,16 +4583,10 @@ impl Engine {
             rgb_top.as_ref().map(|f| f.score).unwrap_or(0.0)
         );
         if rgb_top.is_none() {
-            rgb_top = self.rescue_detect(
-                &align::RgbView {
-                    data: &rgb.data,
-                    width: rgb.width,
-                    height: rgb.height,
-                },
-                "rgb",
-            );
+            rgb_top = self.rescue_detect(rgb, "rgb");
         }
 
+        self.check_request_active()?;
         Ok((rgb_faces, rgb_top))
     }
 
@@ -4227,6 +4598,7 @@ impl Engine {
         (mut rgb_faces, mut rgb_top): (Vec<Detection>, Option<Detection>),
         context: PairAssessmentContext<'_>,
     ) -> Result<DeferredAssessment<PairIdentity>, CapturePathError> {
+        self.check_request_active()?;
         let PairAssessmentContext {
             sequential,
             pair_sequential_retried,
@@ -4235,7 +4607,7 @@ impl Engine {
             ir_ms,
             diagnostics,
         } = context;
-        let progress = self.capture_progress();
+        let control = self.capture_control();
         let ir_grey_rgb = irlume_camera::grey_to_rgb(&ir.data);
         let ir_view = align::RgbView {
             data: &ir_grey_rgb,
@@ -4244,6 +4616,7 @@ impl Engine {
         };
         let ir_detection_started = std::time::Instant::now();
         let ir_faces = self.det.detect(&ir_view)?;
+        self.check_request_active()?;
         diagnostics.emit_trace(irlume_common::diagnostics::TraceEventKind::StageTiming {
             stage: irlume_common::diagnostics::TraceStage::Detection,
             elapsed_us: u64::try_from(ir_detection_started.elapsed().as_micros())
@@ -4269,6 +4642,7 @@ impl Engine {
             };
             ir_top = self.rescue_detect(&iv, "ir");
         }
+        self.check_request_active()?;
 
         // Cross-spectrum self-heal for overlapped-capture RGB dimming. Some
         // Hello modules (measured: NexiGo N930W) starve the RGB stream when
@@ -4288,7 +4662,7 @@ impl Engine {
             irlume_common::dlog!(
                 "assess: RGB has no face but IR does; recapturing RGB alone (dim overlapped frame?)"
             );
-            rgb = irlume_camera::capture_rgb_denoised_with_progress(&self.rgb_dev, &progress)?;
+            rgb = irlume_camera::capture_rgb_denoised_with_control(&self.rgb_dev, &control)?;
             rgb_faces = self.det.detect(&align::RgbView {
                 data: &rgb.data,
                 width: rgb.width,
@@ -4521,6 +4895,7 @@ impl Engine {
         // Shipped IR PAD cue (ADR-0013, default-on), deny-only on the lit IR
         // frame. Scored even when the gate did not say Live so the dark path
         // can reuse it below.
+        self.check_request_active()?;
         let ir_pad = match (ir_top.as_ref(), self.pad_ir.as_mut()) {
             (Some(_), None) => PadEvidence::Unavailable,
             (Some(f), Some(pad)) => match pad.p_fake(&ir_view, &f.bbox) {
@@ -4533,6 +4908,7 @@ impl Engine {
             },
             (None, _) => PadEvidence::NotApplicable,
         };
+        self.check_request_active()?;
         let shipped_ir_fake = match ir_pad {
             PadEvidence::Score(p) => Some(p),
             _ => None,
@@ -4554,6 +4930,7 @@ impl Engine {
         // deny-only cues never need to run on frames that already deny, and
         // the 268ms N100 inference is not free (the plan: consent-watch-
         // pipelined, Live frames only).
+        self.check_request_active()?;
         let rgb_pad = match (verdict, rgb_top.as_ref(), self.vit_pad.as_mut()) {
             (Verdict::Live, Some(_), None) => PadEvidence::Unavailable,
             (Verdict::Live, Some(f), Some(pad)) => {
@@ -4576,6 +4953,7 @@ impl Engine {
             }
             _ => PadEvidence::NotApplicable,
         };
+        self.check_request_active()?;
         let (verdict, reason) = match rgb_pad {
             PadEvidence::Score(p) => {
                 irlume_common::dlog!("pad-vit: p_spoof {p:.3}");
@@ -4652,6 +5030,7 @@ impl Engine {
             mut assessment,
             identity: (rgb, ir),
         } = evidence;
+        self.check_request_active()?;
         let started = std::time::Instant::now();
         assessment.embedding = match rgb {
             Some(image) => {
@@ -4665,6 +5044,7 @@ impl Engine {
             }
             None => None,
         };
+        self.check_request_active()?;
         let rgb_embedding_ms = started.elapsed().as_millis();
         let started = std::time::Instant::now();
         assessment.ir_embedding = match ir {
@@ -4683,6 +5063,7 @@ impl Engine {
             }
             None => None,
         };
+        self.check_request_active()?;
         irlume_common::dlog!(
             "[assessment-stage] embeddings: rgb={rgb_embedding_ms}ms ir={}ms",
             started.elapsed().as_millis()
@@ -4767,14 +5148,96 @@ impl Engine {
         purpose: AuthenticationPurpose,
         diagnostics: &dyn irlume_common::diagnostics::DiagnosticSink,
     ) -> irlume_common::Result<Outcome> {
+        self.authenticate_for_in_window(
+            user,
+            service,
+            purpose,
+            AuthenticationWindow::for_service(service),
+            diagnostics,
+        )
+    }
+
+    /// Authenticate within a caller-owned window retained for final response admission.
+    ///
+    /// # Errors
+    /// Returns capture, model, cancellation or deadline errors without granting.
+    pub fn authenticate_for_in_window(
+        &mut self,
+        user: &str,
+        service: Option<&str>,
+        purpose: AuthenticationPurpose,
+        window: AuthenticationWindow,
+        diagnostics: &dyn irlume_common::diagnostics::DiagnosticSink,
+    ) -> irlume_common::Result<Outcome> {
+        self.last_attempt_situation = None;
+        if let Err(error) = self.check_authentication_completion(window) {
+            if matches!(error, irlume_common::Error::DeadlineExpired) {
+                self.last_attempt_situation = Some(AttemptSituation::TimedOut);
+            }
+            return Err(error);
+        }
+        let policy = irlume_common::config::observe_face_sensor_policy().resolve()?;
+        self.authenticate_for_in_window_with_policy(
+            user,
+            service,
+            purpose,
+            window,
+            policy,
+            diagnostics,
+        )
+    }
+
+    /// Authenticate using the caller's already resolved sensor policy snapshot.
+    ///
+    /// # Errors
+    /// Returns capture, model, cancellation or deadline errors without granting.
+    pub fn authenticate_for_in_window_with_policy(
+        &mut self,
+        user: &str,
+        service: Option<&str>,
+        purpose: AuthenticationPurpose,
+        window: AuthenticationWindow,
+        policy: irlume_common::config::FaceSensorPolicy,
+        diagnostics: &dyn irlume_common::diagnostics::DiagnosticSink,
+    ) -> irlume_common::Result<Outcome> {
+        let previous =
+            std::mem::replace(&mut self.authentication_deadline, window.capture_deadline());
+        let scope = authentication_window::Scope {
+            engine: self,
+            previous,
+        };
+        let result = scope.engine.authenticate_in_window_inner(
+            user,
+            service,
+            purpose,
+            window,
+            policy,
+            diagnostics,
+        );
+        // Covers setup and cleanup paths that return before the retry loop.
+        scope.engine.check_completed_attempt(&result)?;
+        result
+    }
+
+    fn authenticate_in_window_inner(
+        &mut self,
+        user: &str,
+        service: Option<&str>,
+        purpose: AuthenticationPurpose,
+        window: AuthenticationWindow,
+        policy: irlume_common::config::FaceSensorPolicy,
+        diagnostics: &dyn irlume_common::diagnostics::DiagnosticSink,
+    ) -> irlume_common::Result<Outcome> {
         // The daemon reuses this engine across requests. Setup refusals and
         // errors can return before the attempt loop publishes a new situation.
         self.last_attempt_situation = None;
         // Fresh ViT PAD vote ring per authentication: votes must not mix
         // presentations across requests (ADR-0013 protocol).
         self.vit_scores.clear();
-        let window = grace_window_ms(service);
-        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(window);
+        self.check_request_active()?;
+        let request_window = window;
+        let deadline = window.deadline;
+        let window = window.milliseconds;
         // Fingerprint mode: face is disabled so pam_fprintd drives; never engage
         // the camera, decline so the PAM stack cascades to fingerprint/password.
         if irlume_core::policy::method().face_disabled() {
@@ -4782,6 +5245,9 @@ impl Engine {
                 OutcomeKind::OtherDeny,
                 "face disabled (fingerprint mode)",
             ));
+        }
+        if policy == irlume_common::config::FaceSensorPolicy::IrOnlyExperimental {
+            return self.authenticate_ir_in_window(user, request_window, diagnostics);
         }
         // Load enrollment once per authentication, not once per retry. The key
         // is dropped inside load; only the decrypted Enrollment stays in memory
@@ -4793,37 +5259,39 @@ impl Engine {
         // that hardware error can precede enrollment-dependent denials. Both
         // paths retain password fallback; a loader panic maps to an error.
         let load_started = std::time::Instant::now();
-        let mut loader = match irlume_core::storage::store_is_encrypted(user)? {
-            // No file at all: the instant deny, before anything else wakes.
-            None => {
-                return Ok(Outcome::deny(
-                    OutcomeKind::SetupUnavailable,
-                    format!("'{user}' is not enrolled"),
-                ));
-            }
-            // Plaintext: cheap JSON load, synchronous, old precedence.
-            Some(false) => None,
-            // Encrypted: the TPM unseal is the expensive part — defer it
-            // into the overlap window. A channel, not a JoinHandle: the
-            // receiver can wait with a timeout at the join (a wedged unseal
-            // must not pin the camera lease past the auth deadline), and a
-            // dropped sender reports a loader panic as a disconnect.
-            Some(true) => Some({
-                let loader_user = user.to_string();
-                let (tx, rx) = std::sync::mpsc::channel::<EnrollmentLoad>();
-                std::thread::Builder::new()
-                    .name("irlume-enrollment-load".into())
-                    .spawn(move || {
-                        let _ = tx.send(irlume_core::storage::load(&loader_user));
-                    })
-                    .map_err(|e| irlume_common::Error::Io(e.to_string()))?;
-                rx
-            }),
+        let mut loader = PendingEnrollmentLoad {
+            receiver: match irlume_core::storage::store_is_encrypted(user)? {
+                // No file at all: the instant deny, before anything else wakes.
+                None => {
+                    return Ok(Outcome::deny(
+                        OutcomeKind::SetupUnavailable,
+                        format!("'{user}' is not enrolled"),
+                    ));
+                }
+                // Plaintext: cheap JSON load, synchronous, old precedence.
+                Some(false) => None,
+                // Encrypted: the TPM unseal is the expensive part — defer it
+                // into the overlap window. A channel, not a JoinHandle: the
+                // receiver can wait with a timeout at the join (a wedged unseal
+                // must not pin the camera lease past the auth deadline), and a
+                // dropped sender reports a loader panic as a disconnect.
+                Some(true) => Some({
+                    let loader_user = user.to_string();
+                    let (tx, rx) = std::sync::mpsc::channel::<EnrollmentLoad>();
+                    std::thread::Builder::new()
+                        .name("irlume-enrollment-load".into())
+                        .spawn(move || {
+                            let _ = tx.send(irlume_core::storage::load(&loader_user));
+                        })
+                        .map_err(|e| irlume_common::Error::Io(e.to_string()))?;
+                    rx
+                }),
+            },
         };
         // The synchronous-path enrollment (plaintext stores). The encrypted
         // path resolves `enr` at the join below, after camera setup.
-        let loader_was_async = loader.is_some();
-        let sync_enr = if loader.is_none() {
+        let loader_was_async = loader.receiver.is_some();
+        let sync_enr = if loader.receiver.is_none() {
             match irlume_core::storage::load(user)? {
                 Some(enr) => match self.enrollment_policy_refusal(user, &enr) {
                     Some(outcome) => return Ok(outcome),
@@ -4849,14 +5317,20 @@ impl Engine {
         // capture frame through the final grace-window retry.  Keeping this
         // lease across sequential fallbacks is deliberate: otherwise another
         // operation can interleave between captures and matching.
+        self.check_request_active()?;
         let camera_operation = match irlume_camera::lease::acquire_camera_operation(
             &endpoints,
             irlume_camera::lease::CameraOperationKind::Authentication,
-            std::time::Duration::from_secs(2),
+            self.authentication_deadline
+                .map_or(std::time::Duration::from_secs(2), |deadline| {
+                    deadline
+                        .saturating_duration_since(std::time::Instant::now())
+                        .min(std::time::Duration::from_secs(2))
+                }),
         ) {
             Ok(op) => op,
             Err(error) => {
-                finish_loader(&mut loader);
+                finish_loader(&mut loader.receiver);
                 return Err(irlume_common::Error::Hardware(error.to_string()));
             }
         };
@@ -4864,6 +5338,7 @@ impl Engine {
         // Keep negotiated camera handles for this request. Each assessment
         // creates and drops its own streams, so loader/inference/retry delays
         // cannot overflow queues retained from an earlier capture.
+        self.check_request_active()?;
         let camera_open_started = std::time::Instant::now();
         let resolved_cams = match (
             camera_operation.open_rgb(&rgb_dev),
@@ -4872,6 +5347,7 @@ impl Engine {
             (Ok(rgb), Ok(ir)) => Some((rgb, ir)),
             _ => None,
         };
+        self.check_request_active()?;
         diagnostics.emit_trace(irlume_common::diagnostics::TraceEventKind::StageTiming {
             stage: irlume_common::diagnostics::TraceStage::CameraOpen,
             elapsed_us: u64::try_from(camera_open_started.elapsed().as_micros())
@@ -4909,7 +5385,7 @@ impl Engine {
         // Resolve enrollment before streaming. A loader wait can exceed a
         // camera queue's capacity; no stream may be armed across this wait.
         // The wait remains bounded by the authentication deadline.
-        let enr = match loader.take() {
+        let enr = match loader.receiver.take() {
             Some(rx) => {
                 let remaining = deadline.saturating_duration_since(std::time::Instant::now());
                 match resolve_loader(rx.recv_timeout(remaining)) {
@@ -5121,9 +5597,20 @@ impl Engine {
         // retry can be slower than the attempt before it. Each concurrent
         // attempt now includes fresh stream arming and rate establishment.
         loop {
+            if let Err(error) = self.check_request_active() {
+                return (Err(error), false);
+            }
+            if window != 0 && now() >= deadline {
+                self.vit_scores.clear();
+                self.last_attempt_situation = Some(AttemptSituation::TimedOut);
+                return (Err(irlume_common::Error::DeadlineExpired), false);
+            }
             attempt += 1;
             let attempt_started = now();
             let (attempt_result, held_pair_failed) = capture_attempt(self);
+            if let Err(error) = self.check_completed_attempt(&attempt_result) {
+                return (Err(error), false);
+            }
             *costliest_attempt = (*costliest_attempt).max(now().duration_since(attempt_started));
             let out = match attempt_result {
                 Ok(out) => out,
@@ -5151,6 +5638,11 @@ impl Engine {
                 self.last_attempt_situation = None;
             }
             let expired = now() >= deadline;
+            if window != 0 && expired && out.granted {
+                self.vit_scores.clear();
+                self.last_attempt_situation = Some(AttemptSituation::TimedOut);
+                return (Err(irlume_common::Error::DeadlineExpired), false);
+            }
             let retry_wont_fit = !expired
                 && presence_retryable(&out)
                 && deadline.saturating_duration_since(now()) < *costliest_attempt;
@@ -5347,13 +5839,11 @@ impl Engine {
                      IR-identity arms only, ADR-0014)"
                 );
             }
-            // Stage-2 lighting-adaptive fusion: RGB recognition missed (poor ambient
-            // light or a marginal angle). If we also captured an IR face and the user
-            // enrolled IR templates, fuse the two CALIBRATED scores, each weighted by
-            // its modality's capture quality; a marginal RGB + marginal IR can jointly
-            // grant while FMR stays bounded (an impostor must fool BOTH at once). The
-            // cross-spectrum liveness gate + per-user IR floor already passed above.
-            // This is the bright→RGB / dark→IR / dim→FUSE story.
+            // Stage-2 brightness-weighted fusion adds an acceptance arm after the
+            // RGB-primary path did not grant. Its fixed sigmoid scores are not
+            // established as calibrated probabilities for the current pipeline;
+            // see irlume_core::fusion for provenance and full-rule FMR limits.
+            // The liveness/PAD gates and per-user IR ratio floor passed above.
             // SEQUENTIAL-SCHEDULE PAIRS DO NOT FUSE (ADR-0014): the fusion
             // floor only requires IR to clear FUSION_MIN_PER_MODALITY_PROB
             // (~0.35 Platt-equivalent cosine) — a presence bar, not an
@@ -5361,14 +5851,14 @@ impl Engine {
             // fused grant. On a temporally split capture that reopens the
             // swap window; such pairs grant only through the IR-fallback and
             // centroid arms below, which carry identity thresholds.
-            // With a third-party recognizer the whole IR side is unmeasured
-            // (thresholds AND the fusion Platt calibration are shipped-model
-            // measurements), so a marginal RGB miss ends here: password.
+            // IR score-space compatibility is checked by ir_match below. That
+            // compatibility does not establish probability calibration for these
+            // legacy sigmoid coefficients, including with a third-party recognizer.
             if let Some(ir_probe) = a.ir_embedding.as_ref() {
                 let m = self.ir_match(enr, ir_probe);
                 if m.n_templates > 0 {
                     let (ir_score, ir_who) = (m.best, m.best_who.clone());
-                    // (a) calibrated quality-weighted fusion: the dim/mixed-light path.
+                    // (a) brightness-weighted score fusion: the dim/mixed-light path.
                     let f = irlume_core::fusion::fuse(
                         irlume_core::fusion::rgb_genuine_prob(score),
                         irlume_core::fusion::rgb_quality_weight(a.signals.rgb_face_brightness),
@@ -5579,18 +6069,15 @@ impl Engine {
                     "dark liveness: IR PAD cue flags a spoof; use your password",
                 ));
             }
-            let ir_base = if self.ir_adapter.is_some() {
-                irlume_core::IR_ADAPTED_MATCH_THRESHOLD
-            } else {
-                // SecureDark stage 2 (ADR-0016): the pure-dark grant carries
-                // no RGB evidence at all, so its bar is the STRICTER dark
-                // constant (0.635: deployment-shaped OR-arm FAR 1.24e-4 on
-                // CBSR; live dark-session genuine min 0.884 vs the 0.685
-                // effective bar), never looser than the dim-light fallback
-                // that at least saw an RGB face.
-                irlume_core::IR_DARK_MATCH_THRESHOLD
-            };
-            let ir_thr = irlume_core::scaled_threshold(ir_base, m.n_templates);
+            // SecureDark's stricter raw base and adapter base are shared with
+            // explicit IR evidence; gates and scene routing remain independent.
+            let thresholds = ir_assessment::IdentityThresholds::new(
+                m.n_templates,
+                enr.profiles.len(),
+                self.ir_adapter.is_some(),
+            );
+            let (best_matches, centroid_matches) = thresholds.arms(&m);
+            let ir_thr = thresholds.best;
             let (score, who) = (m.best, m.best_who.clone());
             irlume_common::dlog!(
                 "match(ir/dark): best {score:.3} vs thr {ir_thr:.3} ({} scans, adapter={}, calib_centroid={:?})",
@@ -5603,25 +6090,25 @@ impl Engine {
                 irlume_common::diagnostics::TraceMetric::MatchCosine,
                 score,
                 ir_thr,
-                score >= ir_thr,
+                best_matches,
             );
             // Grant on best-of-N at the scaled threshold, or on the
             // calibrated centroid at the base threshold (no best-of-N FAR
             // inflation; the prototype-validated mean-template protocol).
-            if score >= ir_thr {
+            if best_matches {
                 return Ok(Outcome::grant(score, format!("match: {who} (ir/dark)")));
             }
             if let Some((cs, cwho)) = &m.centroid {
-                let cthr = irlume_core::scaled_threshold(ir_base, enr.profiles.len());
+                let cthr = thresholds.centroid;
                 irlume_common::dlog!("match(ir/dark centroid): {cs:.3} vs thr {cthr:.3}");
                 emit_trace_match(
                     diagnostics,
                     irlume_common::diagnostics::TraceMetric::MatchCosine,
                     *cs,
                     cthr,
-                    *cs >= cthr,
+                    centroid_matches,
                 );
-                if *cs >= cthr {
+                if centroid_matches {
                     return Ok(Outcome::grant(
                         *cs,
                         format!("match: {cwho} (ir/dark, calibrated centroid)"),
@@ -9326,6 +9813,15 @@ mod tests {
         // 0 = legacy one-shot.
         std::env::set_var("IRLUME_GRACE_MS", "0");
         assert_eq!(grace_window_ms(None), 0);
+        // The development window is bounded; excessive durations must not
+        // hold a password fallback indefinitely.
+        std::env::set_var("IRLUME_GRACE_MS", "60000");
+        assert_eq!(grace_window_ms(None), 60000);
+        for excessive in ["60001", "18446744073709551615"] {
+            std::env::set_var("IRLUME_GRACE_MS", excessive);
+            assert_eq!(grace_window_ms(Some("sudo")), SUDO_GRACE_WINDOW_MS);
+            assert_eq!(grace_window_ms(None), GRACE_WINDOW_MS);
+        }
         // Unparseable values fall back to the service table.
         std::env::set_var("IRLUME_GRACE_MS", "abc");
         assert_eq!(grace_window_ms(Some("sudo")), SUDO_GRACE_WINDOW_MS);
@@ -10381,12 +10877,16 @@ mod engine_tests {
         std::fs::create_dir_all(&dir).unwrap();
         std::env::set_var("IRLUME_STATE_DIR", &dir);
         std::env::set_var("IRLUME_METHOD_CONF", dir.join("no-method-conf"));
+        // Authentication now reads the sensor policy too. Keep tests independent
+        // of the host's protected settings and retain the default-dual fixture.
+        std::env::set_var("IRLUME_CONFIG_DIR", &dir);
         dir
     }
 
     fn teardown_sandbox(dir: &std::path::Path) {
         std::env::remove_var("IRLUME_STATE_DIR");
         std::env::remove_var("IRLUME_METHOD_CONF");
+        std::env::remove_var("IRLUME_CONFIG_DIR");
         let _ = std::fs::remove_dir_all(dir);
     }
 
@@ -10630,6 +11130,251 @@ mod engine_tests {
     }
 
     #[test]
+    fn authentication_budget_discards_late_grants_and_skips_expired_work() {
+        let _guard = env_guard();
+        let mut state = shared();
+        for already_expired in [false, true] {
+            let start = std::time::Instant::now();
+            let deadline = start + std::time::Duration::from_secs(15);
+            let clock = std::cell::Cell::new(if already_expired { deadline } else { start });
+            let mut calls = 0;
+            let mut cost = std::time::Duration::ZERO;
+            let (result, fallback) = state.engine.authentication_attempt_loop_with(
+                deadline,
+                15_000,
+                &mut cost,
+                |_| {
+                    calls += 1;
+                    clock.set(deadline);
+                    (Ok(Outcome::grant(1.0, "synthetic late match")), false)
+                },
+                || clock.get(),
+            );
+            assert!(
+                !result.as_ref().is_ok_and(|out| out.granted),
+                "expired match must never grant"
+            );
+            assert_eq!(
+                calls,
+                usize::from(!already_expired),
+                "expired entry must not start capture"
+            );
+            assert!(!fallback, "expiry cannot spend another camera attempt");
+        }
+    }
+
+    #[test]
+    fn authentication_budget_scope_restores_reusable_engine_after_expiry() {
+        let _guard = env_guard();
+        let mut state = shared();
+        let expired = AuthenticationWindow {
+            deadline: std::time::Instant::now(),
+            milliseconds: 15_000,
+        };
+        let result = state.engine.authenticate_for_in_window(
+            "expired-before-setup",
+            Some("kde"),
+            AuthenticationPurpose::Verify,
+            expired,
+            &(),
+        );
+        assert!(matches!(result, Err(irlume_common::Error::DeadlineExpired)));
+        assert!(state.engine.authentication_deadline.is_none());
+        assert!(
+            state.engine.capture_control().check().is_ok(),
+            "next operation must not inherit expiry"
+        );
+        assert_eq!(
+            state.engine.last_attempt_situation_label(),
+            Some("timed out")
+        );
+    }
+
+    #[test]
+    fn invalid_sensor_policy_refuses_before_enrollment_or_camera_setup() {
+        let _guard = env_guard();
+        let mut state = shared();
+        let dir = state_sandbox("invalid-sensor-policy");
+        let old_config = std::env::var_os("IRLUME_CONFIG_DIR");
+        std::env::set_var("IRLUME_CONFIG_DIR", &dir);
+        let mut refused = Vec::new();
+        for contents in [
+            b"face_sensor_policy=typo\n".as_slice(),
+            b"face_sensor_policy ir-only-experimental\n".as_slice(),
+            b"\xff".as_slice(),
+        ] {
+            std::fs::write(dir.join("settings.conf"), contents).unwrap();
+            refused.push(matches!(
+                state.engine.authenticate_for_in_window(
+                    "not-enrolled-synthetic-account",
+                    Some("kde"),
+                    AuthenticationPurpose::Verify,
+                    AuthenticationWindow::new(15_000),
+                    &(),
+                ),
+                Err(irlume_common::Error::Policy(_))
+            ));
+        }
+        match old_config {
+            Some(value) => std::env::set_var("IRLUME_CONFIG_DIR", value),
+            None => std::env::remove_var("IRLUME_CONFIG_DIR"),
+        }
+        teardown_sandbox(&dir);
+        assert_eq!(refused, [true, true, true]);
+        assert!(state.engine.authentication_deadline.is_none());
+    }
+
+    #[test]
+    fn authentication_budget_reaches_capture_and_inference_boundaries() {
+        let _guard = env_guard();
+        let mut state = shared();
+        let previous = state
+            .engine
+            .authentication_deadline
+            .replace(std::time::Instant::now());
+        let scope = authentication_window::Scope {
+            engine: &mut state.engine,
+            previous,
+        };
+        let capture = scope.engine.capture_control().check();
+        let pixels = vec![0; 640 * 480 * 3];
+        let view = align::RgbView {
+            data: &pixels,
+            width: 640,
+            height: 480,
+        };
+        let inference = scope.engine.detect_rgb_assessment_view(&view, Some(0), &());
+        assert!(matches!(
+            capture,
+            Err(irlume_common::Error::DeadlineExpired)
+        ));
+        assert!(matches!(
+            inference,
+            Err(irlume_common::Error::DeadlineExpired)
+        ));
+        drop(scope);
+        assert!(state.engine.capture_control().check().is_ok());
+    }
+
+    #[test]
+    fn captured_ir_policy_ignores_later_config_changes_and_never_falls_back_to_rgb() {
+        let _guard = env_guard();
+        let mut state = shared();
+        let dir = state_sandbox("captured-ir-policy");
+        let old_config = std::env::var_os("IRLUME_CONFIG_DIR");
+        let old_rgb = std::env::var_os("IRLUME_RGB_DEVICE");
+        let old_ir = std::env::var_os("IRLUME_IR_DEVICE");
+        std::env::set_var("IRLUME_CONFIG_DIR", &dir);
+        std::env::set_var("IRLUME_RGB_DEVICE", "/dev/irlume-test-none-rgb");
+        std::env::set_var("IRLUME_IR_DEVICE", "/dev/irlume-test-none-ir");
+        std::fs::write(
+            dir.join("settings.conf"),
+            "face_sensor_policy=ir-only-experimental\n",
+        )
+        .unwrap();
+        let captured = irlume_common::config::observe_face_sensor_policy()
+            .resolve()
+            .unwrap();
+        std::fs::write(
+            dir.join("settings.conf"),
+            "face_sensor_policy=invalid-after-capture\n",
+        )
+        .unwrap();
+        let mut outcomes = Vec::new();
+        for purpose in [
+            AuthenticationPurpose::Verify,
+            AuthenticationPurpose::CredentialRelease,
+        ] {
+            outcomes.push(state.engine.authenticate_for_in_window_with_policy(
+                "synthetic-unenrolled",
+                Some("kde"),
+                purpose,
+                AuthenticationWindow::new(0),
+                captured,
+                &(),
+            ));
+        }
+        for (key, old) in [
+            ("IRLUME_CONFIG_DIR", old_config),
+            ("IRLUME_RGB_DEVICE", old_rgb),
+            ("IRLUME_IR_DEVICE", old_ir),
+        ] {
+            match old {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
+        }
+        teardown_sandbox(&dir);
+        for outcome in outcomes {
+            let outcome = outcome.unwrap();
+            assert!(!outcome.granted);
+            assert_eq!(outcome.kind, OutcomeKind::SetupUnavailable);
+            assert!(outcome.reason.contains("configured IR target"));
+        }
+        assert!(state.engine.authentication_deadline.is_none());
+    }
+
+    #[test]
+    fn authentication_budget_preserves_completed_denials_with_live_scope() {
+        let _guard = env_guard();
+        let mut state = shared();
+        for kind in [
+            OutcomeKind::BelowThreshold,
+            OutcomeKind::Spoof,
+            OutcomeKind::Uncertain,
+            OutcomeKind::DeadlineExpired,
+        ] {
+            let start = std::time::Instant::now();
+            let deadline = start + std::time::Duration::from_secs(15);
+            let clock = std::cell::Cell::new(start);
+            let mut cost = std::time::Duration::ZERO;
+            let (result, fallback) = state.engine.authentication_attempt_loop_with(
+                deadline,
+                15_000,
+                &mut cost,
+                |engine| {
+                    // Model a blocking attempt that produced its final denial
+                    // just as the real engine's scoped deadline elapsed.
+                    engine.authentication_deadline = Some(std::time::Instant::now());
+                    clock.set(deadline);
+                    (Ok(Outcome::deny(kind, "completed synthetic denial")), false)
+                },
+                || clock.get(),
+            );
+            state.engine.authentication_deadline = None;
+            assert!(
+                matches!(result, Ok(ref outcome) if outcome.kind == kind),
+                "completed evidence must retain accounting: {kind:?}: {result:?}"
+            );
+            assert!(!fallback);
+        }
+    }
+
+    #[test]
+    fn authentication_budget_zero_preserves_one_shot_match() {
+        let _guard = env_guard();
+        let mut state = shared();
+        let start = std::time::Instant::now();
+        let clock = std::cell::Cell::new(start);
+        let mut calls = 0;
+        let mut cost = std::time::Duration::ZERO;
+        let (result, fallback) = state.engine.authentication_attempt_loop_with(
+            start,
+            0,
+            &mut cost,
+            |_| {
+                calls += 1;
+                clock.set(start + std::time::Duration::from_secs(20));
+                (Ok(Outcome::grant(1.0, "synthetic one-shot match")), false)
+            },
+            || clock.get(),
+        );
+        assert!(result.unwrap().granted);
+        assert_eq!(calls, 1);
+        assert!(!fallback);
+    }
+
+    #[test]
     fn pending_pad_retry_loop_stops_when_second_slow_assessment_cannot_fit() {
         let _guard = env_guard();
         let mut s = shared();
@@ -10707,6 +11452,126 @@ mod engine_tests {
         assert_eq!(calls, 5);
         assert!(!out.granted);
         assert_eq!(out.kind, OutcomeKind::Spoof);
+    }
+
+    #[test]
+    fn request_cancellation_stops_auth_before_work_and_discards_late_outcomes() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        let _guard = env_guard();
+        let mut s = shared();
+        for already_cancelled in [true, false] {
+            let cancelled = std::sync::Arc::new(AtomicBool::new(already_cancelled));
+            let signal = std::sync::Arc::clone(&cancelled);
+            s.engine
+                .set_request_cancel_signal(std::sync::Arc::new(move || {
+                    signal.load(Ordering::SeqCst)
+                }));
+            let now = std::time::Instant::now();
+            let mut calls = 0;
+            let mut costliest = std::time::Duration::ZERO;
+            let (result, fallback) = s.engine.authentication_attempt_loop_with(
+                now + std::time::Duration::from_secs(15),
+                15_000,
+                &mut costliest,
+                |_| {
+                    calls += 1;
+                    cancelled.store(true, Ordering::SeqCst);
+                    (
+                        Ok(Outcome::grant(1.0, "synthetic match after disconnect")),
+                        false,
+                    )
+                },
+                || now,
+            );
+            s.engine.request_cancelled = None;
+            assert!(matches!(result, Err(irlume_common::Error::Preempted(_))));
+            assert!(
+                !fallback,
+                "cancellation cannot retry on another camera path"
+            );
+            assert_eq!(calls, usize::from(!already_cancelled));
+        }
+    }
+
+    #[test]
+    fn queued_authentication_yield_does_not_cancel_a_running_authentication() {
+        let _guard = env_guard();
+        let mut s = shared();
+        s.engine.set_stop_signal(std::sync::Arc::new(|| true));
+        let (outcome, calls, _) =
+            scripted_pad_retry(&mut s.engine, 15_000, 0, &[1_000; 5], 0.20, 0);
+        s.engine.stop_requested = None;
+        assert!(outcome.granted);
+        assert_eq!(
+            calls, 5,
+            "queued work must preserve the active authentication's retries"
+        );
+    }
+
+    #[test]
+    fn capture_cancellation_skips_rgb_detection_after_late_ir_cancel() {
+        let _guard = env_guard();
+        let mut state = shared();
+        state
+            .engine
+            .set_request_cancel_signal(std::sync::Arc::new(|| true));
+        // Synthetic pixels avoid manufacturing a trusted camera Frame. This is
+        // the real detection boundary used after both ordinary/fallback captures.
+        let pixels = vec![0; 640 * 480 * 3];
+        let view = align::RgbView {
+            data: &pixels,
+            width: 640,
+            height: 480,
+        };
+        let result = state.engine.detect_rgb_assessment_view(&view, Some(0), &());
+        state.engine.request_cancelled = None;
+        assert!(
+            matches!(result, Err(irlume_common::Error::Preempted(_))),
+            "a cancelled IR companion must prevent subsequent RGB inference"
+        );
+    }
+
+    #[test]
+    fn capture_cancellation_control_uses_request_signal_not_scheduler_yield() {
+        use std::sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        };
+        let _guard = env_guard();
+        let mut shared = shared();
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let signal = cancelled.clone();
+        shared.engine.set_stop_signal(Arc::new(|| true));
+        shared
+            .engine
+            .set_request_cancel_signal(Arc::new(move || signal.load(Ordering::SeqCst)));
+        let control = shared.engine.capture_control();
+        let queued_only = control.check();
+        cancelled.store(true, Ordering::SeqCst);
+        let cancelled_capture = irlume_camera::capture_rgb_denoised_with_control(NO_RGB, &control);
+        shared.engine.stop_requested = None;
+        shared.engine.request_cancelled = None;
+        assert!(
+            queued_only.is_ok(),
+            "queued work must not cancel camera frames"
+        );
+        assert!(
+            matches!(cancelled_capture, Err(irlume_common::Error::Preempted(_))),
+            "request cancellation must win before camera setup"
+        );
+    }
+
+    #[test]
+    fn request_cancellation_precedes_enrollment_and_camera_setup() {
+        let _guard = env_guard();
+        let mut s = shared();
+        let dir = state_sandbox("cancelled-before-setup");
+        s.engine
+            .set_request_cancel_signal(std::sync::Arc::new(|| true));
+        let result = s.engine.authenticate("cancelled-test", Some("kde"));
+        s.engine.request_cancelled = None;
+        teardown_sandbox(&dir);
+        assert!(matches!(result, Err(irlume_common::Error::Preempted(_))));
     }
 
     #[test]
@@ -11798,6 +12663,7 @@ mod engine_tests {
         // The #616 step 2 vocabulary: one stable label per failed-attempt
         // shape, the measured numbers alongside, never a threshold value.
         let frontal = AttemptFacts {
+            ir_only: false,
             rgb_face: Some((0.5, 0.5)),
             face_frac: 0.30,
             yaw_asym: 0.10,
@@ -11885,6 +12751,7 @@ mod engine_tests {
         // unmeasured glint (a railed peak measured nothing, #222), and no
         // threshold values anywhere in the line.
         let facts = AttemptFacts {
+            ir_only: false,
             rgb_face: None,
             face_frac: 0.0,
             yaw_asym: 0.10,
@@ -11905,6 +12772,7 @@ mod engine_tests {
         // The #617 lesson lives here too: a live person glancing sideways
         // produced a Spoof verdict; the situation names looking away.
         let turned = AttemptFacts {
+            ir_only: false,
             rgb_face: Some((0.5, 0.5)),
             face_frac: 0.30,
             yaw_asym: 0.52,
@@ -12642,6 +13510,49 @@ mod engine_tests {
         );
 
         teardown_sandbox(&dir);
+    }
+
+    #[test]
+    fn pending_enrollment_loader_is_drained_after_camera_owners_release() {
+        use std::sync::mpsc::{channel, RecvTimeoutError, Sender};
+        use std::time::Duration;
+        struct CameraOwner(Sender<&'static str>);
+        impl Drop for CameraOwner {
+            fn drop(&mut self) {
+                let _ = self.0.send("camera released");
+            }
+        }
+        let (loaded, loader) = channel::<EnrollmentLoad>();
+        let (events, observed) = channel();
+        let request = std::thread::spawn(move || {
+            {
+                let _pending = PendingEnrollmentLoad {
+                    receiver: Some(loader),
+                };
+                // Same ownership order as authentication setup. This models
+                // resource lifetime only; no camera or TPM is opened.
+                let _camera = CameraOwner(events.clone());
+            }
+            events.send("request returned").unwrap();
+        });
+        assert_eq!(
+            observed.recv_timeout(Duration::from_secs(5)).unwrap(),
+            "camera released"
+        );
+        let early_return = observed.recv_timeout(Duration::from_millis(100));
+        // Unblock and join even when the assertion will fail: no fixture helper
+        // may escape this test on a regression.
+        let delivered = loaded.send(Ok(None));
+        request.join().unwrap();
+        assert!(
+            matches!(early_return, Err(RecvTimeoutError::Timeout)),
+            "request returned while its loader still owned work: {early_return:?}"
+        );
+        assert!(delivered.is_ok(), "request abandoned its enrollment helper");
+        assert_eq!(
+            observed.recv_timeout(Duration::from_secs(5)).unwrap(),
+            "request returned"
+        );
     }
 
     #[test]

--- a/crates/irlume-auth/tests/no_probe_on_the_auth_path.rs
+++ b/crates/irlume-auth/tests/no_probe_on_the_auth_path.rs
@@ -112,6 +112,8 @@ fn one_camera_operation_spans_camera_open_and_every_authentication_retry() {
         "authenticate_for must acquire exactly one operation"
     );
     assert!(acquire < open && open < retries);
+    let acquisition = &body[acquire..open];
+    assert!(acquisition.contains("self.authentication_deadline") && acquisition.contains("saturating_duration_since"), "the actual authentication lease must use its remaining window, not only a diagnostics/assessment helper");
     assert!(body.contains("&camera_operation"));
 
     let loop_start = text[end..]

--- a/crates/irlume-camera/Cargo.toml
+++ b/crates/irlume-camera/Cargo.toml
@@ -4,6 +4,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[features]
+default = []
+capture-timing = []
+
 [dependencies]
 irlume-common.workspace = true
 serde.workspace = true

--- a/crates/irlume-camera/src/backend.rs
+++ b/crates/irlume-camera/src/backend.rs
@@ -305,7 +305,7 @@ pub(crate) fn open_ir(device: &str, lease: CameraLease) -> irlume_common::Result
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use std::sync::Mutex;
 
     use super::*;
@@ -338,6 +338,25 @@ mod tests {
                 ),
             ])
             .unwrap();
+    }
+
+    pub(crate) fn with_test_camera_operation<R>(
+        endpoint: &str,
+        work: impl FnOnce(&CameraOperationSession) -> R,
+    ) -> R {
+        let supervisor = Arc::new(CameraSupervisor::new(RecordingBackend {
+            calls: Arc::new(Mutex::new(Vec::new())),
+        }));
+        seed_test_endpoints(&supervisor, &[endpoint]);
+        let _installed = install_test_supervisor(supervisor.clone());
+        let operation = supervisor
+            .acquire_operation(
+                &[endpoint],
+                CameraOperationKind::Authentication,
+                Instant::now() + std::time::Duration::from_secs(1),
+            )
+            .unwrap();
+        work(&operation)
     }
 
     #[derive(Clone)]

--- a/crates/irlume-camera/src/capture_cancellation_tests.rs
+++ b/crates/irlume-camera/src/capture_cancellation_tests.rs
@@ -1,0 +1,135 @@
+use super::*;
+use std::sync::{atomic::{AtomicBool, AtomicUsize, Ordering}, Arc};
+
+struct CancellingFrames {
+    frames: QueuedContinuityFixture,
+    calls: Arc<AtomicUsize>,
+    cancelled: Arc<AtomicBool>,
+    cancel_on: usize,
+}
+
+impl ValidatedStream for CancellingFrames {
+    fn next_validated(&mut self) -> Result<(&[u8], frame_provenance::DequeuedBufferFacts), ValidatedDequeueError> {
+        let call = self.calls.fetch_add(1, Ordering::SeqCst) + 1;
+        if call == self.cancel_on {
+            self.cancelled.store(true, Ordering::SeqCst);
+        }
+        self.frames.next_validated()
+    }
+}
+
+fn fixture(cancel_on: usize) -> (TrackedStream<CancellingFrames>, Arc<AtomicUsize>, Arc<AtomicBool>) {
+    let original = rate_fill_fixture(contracts::StreamRole::Rgb, 100, 66_667);
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let calls = Arc::new(AtomicUsize::new(0));
+    let signal = cancelled.clone();
+    let mut stream = TrackedStream::new(CancellingFrames {
+        frames: original.stream.unwrap(), calls: calls.clone(), cancelled: cancelled.clone(), cancel_on,
+    }, original.rate_config);
+    stream.control = CaptureControl::new(no_progress(), Arc::new(move || signal.load(Ordering::SeqCst)));
+    (stream, calls, cancelled)
+}
+
+#[test]
+fn capture_cancellation_precedes_any_dequeue() {
+    let (mut stream, calls, cancelled) = fixture(usize::MAX);
+    cancelled.store(true, Ordering::SeqCst);
+    let result = stream.next_discarded();
+    assert!(result.as_ref().is_err_and(capture_control::is_cancelled), "cancelled request must not dequeue");
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn capture_cancellation_stops_rate_fill_at_the_returned_frame() {
+    let (mut stream, calls, _) = fixture(3);
+    let result = stream.fill_rate_evidence();
+    assert!(result.as_ref().is_err_and(capture_control::is_cancelled), "rate fill must stop after cancellation");
+    assert_eq!(calls.load(Ordering::SeqCst), 3);
+    assert!(!stream.rate_window.ready());
+    assert_eq!(stream.accounting().0, 2, "late frame must not contribute evidence");
+}
+
+#[test]
+fn capture_cancellation_discards_a_late_delivered_frame() {
+    let (mut stream, calls, _) = fixture(usize::MAX);
+    stream.fill_rate_evidence().unwrap();
+    let before = stream.accounting();
+    let cancel_on = calls.load(Ordering::SeqCst) + 1;
+    stream.stream.as_mut().unwrap().cancel_on = cancel_on;
+    let result = stream.next();
+    assert!(matches!(result, Err(DeliveryError::Io(ref error)) if capture_control::is_cancelled(error)), "late delivered frame must be discarded");
+    assert_eq!(stream.accounting(), before);
+    assert_eq!(calls.load(Ordering::SeqCst), cancel_on);
+}
+
+#[test]
+fn capture_cancellation_is_not_a_hardware_fault_or_driver_interrupt() {
+    let control = CaptureControl::new(no_progress(), Arc::new(|| true));
+    assert!(matches!(map_io("synthetic", control.check_io().unwrap_err()), Error::Preempted(_)));
+    assert!(matches!(map_io("synthetic", std::io::Error::from_raw_os_error(libc::EINTR)), Error::Hardware(_)));
+}
+
+#[test]
+fn capture_cancellation_does_not_poison_a_fresh_request() {
+    let (mut cancelled_stream, _, signal) = fixture(usize::MAX);
+    signal.store(true, Ordering::SeqCst);
+    let _ = cancelled_stream.next_discarded();
+    drop(cancelled_stream);
+    let (mut fresh, _, _) = fixture(usize::MAX);
+    assert!(fresh.next().is_ok(), "next request must establish and deliver normally");
+}
+
+#[test]
+fn capture_cancellation_stops_warmup_after_a_completed_timeout_and_heartbeat() {
+    struct SilentFrames(Arc<AtomicUsize>);
+    impl ValidatedStream for SilentFrames {
+        fn next_validated(&mut self) -> Result<(&[u8], frame_provenance::DequeuedBufferFacts), ValidatedDequeueError> {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            Err(ValidatedDequeueError::Io(std::io::ErrorKind::TimedOut.into()))
+        }
+    }
+    let calls = Arc::new(AtomicUsize::new(0));
+    let reports = Arc::new(AtomicUsize::new(0));
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let (mark, cancel) = (reports.clone(), cancelled.clone());
+    let progress: Progress = Arc::new(move || {
+        mark.fetch_add(1, Ordering::SeqCst);
+        cancel.store(true, Ordering::SeqCst);
+    });
+    let control = CaptureControl::new(progress, Arc::new(move || cancelled.load(Ordering::SeqCst)));
+    let mut stream = TrackedStream::new(SilentFrames(calls.clone()), test_rate_config(contracts::StreamRole::Rgb)).with_control(&control);
+    let result = warm_up_with("synthetic", || stream.next_discarded(), |_| {}, &control.progress);
+    assert!(matches!(result, Err(Error::Preempted(_))));
+    assert_eq!(calls.load(Ordering::SeqCst), 1, "cancelled warmup must not spend another driver window");
+    assert_eq!(reports.load(Ordering::SeqCst), 1, "completed timeout must still report watchdog progress");
+}
+
+#[test]
+fn capture_deadline_precedes_dequeue_and_is_not_a_hardware_fault() {
+    let (mut stream, calls, _) = fixture(usize::MAX);
+    stream.control = stream.control.clone().with_deadline(Some(std::time::Instant::now()));
+    let result = stream.next_discarded();
+    assert!(result.is_err(), "expired capture must not dequeue");
+    assert!(matches!(map_io("synthetic", result.unwrap_err()), Error::DeadlineExpired));
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+    assert!(matches!(map_io("synthetic", std::io::ErrorKind::TimedOut.into()), Error::Hardware(_)), "a real driver timeout must retain hardware handling");
+}
+
+#[test]
+fn capture_deadline_precedes_device_open_and_cancellation_keeps_precedence() {
+    let control = CaptureControl::with_progress(no_progress()).with_deadline(Some(std::time::Instant::now()));
+    let result = capture_rgb_denoised_with_control("/nonexistent/irlume-deadline-fixture", &control);
+    assert!(matches!(result, Err(Error::DeadlineExpired)));
+    let cancelled = CaptureControl::new(no_progress(), Arc::new(|| true)).with_deadline(Some(std::time::Instant::now()));
+    assert!(matches!(cancelled.check(), Err(Error::Preempted(_))));
+}
+
+#[test]
+fn capture_deadline_is_not_retried_as_a_driver_warmup_timeout() {
+    let control = CaptureControl::with_progress(no_progress()).with_deadline(Some(std::time::Instant::now()));
+    let (mut calls, mut sleeps) = (0, 0);
+    let result = warm_up_with("synthetic", || { calls += 1; control.check_io() }, |_| sleeps += 1, &control.progress);
+    assert!(matches!(result, Err(Error::DeadlineExpired)));
+    assert_eq!(calls, 1, "expired request must not be retried as a driver timeout");
+    assert_eq!(sleeps, 0);
+}

--- a/crates/irlume-camera/src/capture_control.rs
+++ b/crates/irlume-camera/src/capture_control.rs
@@ -1,0 +1,127 @@
+use crate::Progress;
+use irlume_common::{Error, Result};
+use std::sync::Arc;
+
+/// Watchdog reporting and cooperative cancellation for one camera request.
+///
+/// Cancellation is checked at returned driver-call boundaries. It never kills
+/// a thread or skips the stream/control owners' ordinary cleanup.
+#[derive(Clone)]
+pub struct CaptureControl {
+    pub(crate) progress: Progress,
+    cancelled: Option<Arc<dyn Fn() -> bool + Send + Sync>>,
+    deadline: Option<std::time::Instant>,
+    #[cfg(feature = "capture-timing")]
+    pub(crate) timings: Option<crate::CaptureTimings>,
+}
+
+impl CaptureControl {
+    /// Keep the existing watchdog behavior with cancellation disabled.
+    pub fn with_progress(progress: Progress) -> Self {
+        Self {
+            progress,
+            cancelled: None,
+            deadline: None,
+            #[cfg(feature = "capture-timing")]
+            timings: None,
+        }
+    }
+
+    /// Observe cancellation of this request, separately from scheduler yield.
+    pub fn new(progress: Progress, cancelled: Arc<dyn Fn() -> bool + Send + Sync>) -> Self {
+        Self {
+            progress,
+            cancelled: Some(cancelled),
+            deadline: None,
+            #[cfg(feature = "capture-timing")]
+            timings: None,
+        }
+    }
+
+    /// Attach request-local developer timing storage. Does not change control.
+    #[cfg(feature = "capture-timing")]
+    pub fn with_capture_timings(mut self, timings: Option<crate::CaptureTimings>) -> Self {
+        self.timings = timings;
+        self
+    }
+
+    /// Clone the optional developer timing handle for a bounded child operation.
+    #[cfg(feature = "capture-timing")]
+    pub fn capture_timings(&self) -> Option<crate::CaptureTimings> {
+        self.timings.clone()
+    }
+
+    /// Apply the authentication window to this capture.
+    pub fn with_deadline(mut self, deadline: Option<std::time::Instant>) -> Self {
+        self.deadline = deadline;
+        self
+    }
+
+    /// Check whether the request still wants camera work.
+    ///
+    /// # Errors
+    /// Returns [`Error::Preempted`] on cancellation or [`Error::DeadlineExpired`]
+    /// when the authentication window has ended.
+    pub fn check(&self) -> Result<()> {
+        self.check_io().map_err(|error| {
+            if is_expired(&error) {
+                Error::DeadlineExpired
+            } else {
+                Error::Preempted("camera capture cancelled".into())
+            }
+        })
+    }
+
+    pub(crate) fn check_io(&self) -> std::io::Result<()> {
+        if self.cancelled.as_ref().is_some_and(|signal| signal()) {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::Interrupted,
+                CaptureCancelled,
+            ))
+        } else if self
+            .deadline
+            .is_some_and(|deadline| std::time::Instant::now() >= deadline)
+        {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                CaptureExpired,
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[derive(Debug)]
+struct CaptureCancelled;
+
+impl std::fmt::Display for CaptureCancelled {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("camera capture cancelled")
+    }
+}
+
+impl std::error::Error for CaptureCancelled {}
+
+pub(crate) fn is_cancelled(error: &std::io::Error) -> bool {
+    error
+        .get_ref()
+        .is_some_and(|inner| inner.is::<CaptureCancelled>())
+}
+
+#[derive(Debug)]
+struct CaptureExpired;
+
+impl std::fmt::Display for CaptureExpired {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("authentication window expired")
+    }
+}
+
+impl std::error::Error for CaptureExpired {}
+
+pub(crate) fn is_expired(error: &std::io::Error) -> bool {
+    error
+        .get_ref()
+        .is_some_and(|inner| inner.is::<CaptureExpired>())
+}

--- a/crates/irlume-camera/src/capture_timing.rs
+++ b/crates/irlume-camera/src/capture_timing.rs
@@ -1,0 +1,585 @@
+//! Numeric and categorical developer measurements. No camera data or error payloads.
+
+/// Payload-free failure observed while establishing an IR startup rate window.
+/// Available only with developer capture timing; never an authentication result.
+#[cfg(feature = "capture-timing")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RateFillFailure {
+    IoPermissionDenied,
+    IoInvalidArgument,
+    IoDevice,
+    IoNoSpace,
+    IoTimeout,
+    IoOther,
+    BufferTimestamp,
+    BufferClock,
+    BufferSource,
+    BufferLayout,
+    TimestampNonIncreasing,
+    TimestampClock,
+    TimestampSource,
+    TimestampEpoch,
+    Sequence,
+    RateWindow,
+    PrivacyBoundary,
+    PrivacyEngaged,
+    PrivacyReadPermissionDenied,
+    PrivacyReadDevice,
+    PrivacyReadTimeout,
+    PrivacyReadBusy,
+    PrivacyReadOther,
+    LeaseBoundary,
+    StreamState,
+    ContinuityAlignment,
+    ContinuityAccounting,
+    IncompleteWindow,
+    MissingStream,
+    StoppedStream,
+    Other,
+}
+
+#[cfg(feature = "capture-timing")]
+impl RateFillFailure {
+    fn classify(error: &std::io::Error) -> Self {
+        use crate::frame_provenance::{
+            DequeuedBufferError as Buffer, SequenceTrackerError, TimestampTrackerError as Timestamp,
+        };
+        if let Some(inner) = error.get_ref() {
+            if let Some(error) = inner.downcast_ref::<Buffer>() {
+                return match error {
+                    Buffer::InvalidTimestamp { .. } => Self::BufferTimestamp,
+                    Buffer::UnsupportedTimestampClock(_) => Self::BufferClock,
+                    Buffer::UnsupportedTimestampSource(_) => Self::BufferSource,
+                    _ => Self::BufferLayout,
+                };
+            }
+            if let Some(error) = inner.downcast_ref::<Timestamp>() {
+                return match error {
+                    Timestamp::NonIncreasing { .. } => Self::TimestampNonIncreasing,
+                    Timestamp::UntrustedClock(_) | Timestamp::ClockChanged { .. } => {
+                        Self::TimestampClock
+                    }
+                    Timestamp::SourceChanged { .. } => Self::TimestampSource,
+                    _ => Self::TimestampEpoch,
+                };
+            }
+            if inner.is::<SequenceTrackerError>() {
+                return Self::Sequence;
+            }
+            if inner.is::<crate::rate_gate::RateWindowError>() {
+                return Self::RateWindow;
+            }
+            if let Some(refusal) = inner.downcast_ref::<crate::PrivacyBoundaryRefusal>() {
+                return match refusal.cause {
+                    None => Self::PrivacyBoundary,
+                    Some(crate::PrivacyBoundaryCause::Engaged) => Self::PrivacyEngaged,
+                    Some(crate::PrivacyBoundaryCause::ReadFailure { raw_errno, kind }) => {
+                        match raw_errno {
+                            Some(libc::EACCES | libc::EPERM) => Self::PrivacyReadPermissionDenied,
+                            Some(libc::EIO | libc::ENODEV) => Self::PrivacyReadDevice,
+                            Some(libc::ETIMEDOUT) => Self::PrivacyReadTimeout,
+                            Some(libc::EBUSY) => Self::PrivacyReadBusy,
+                            _ => match kind {
+                                std::io::ErrorKind::PermissionDenied => {
+                                    Self::PrivacyReadPermissionDenied
+                                }
+                                std::io::ErrorKind::TimedOut => Self::PrivacyReadTimeout,
+                                _ => Self::PrivacyReadOther,
+                            },
+                        }
+                    }
+                };
+            }
+            if inner.is::<crate::lease::CameraLeaseError>() {
+                return Self::LeaseBoundary;
+            }
+            if inner.is::<irlume_common::Error>() {
+                return Self::StreamState;
+            }
+            if let Some(error) = inner.downcast_ref::<crate::CaptureEvidenceError>() {
+                return match error {
+                    crate::CaptureEvidenceError::ContinuityAlignment => Self::ContinuityAlignment,
+                    crate::CaptureEvidenceError::ContinuityAccounting => Self::ContinuityAccounting,
+                    crate::CaptureEvidenceError::IncompleteWindow => Self::IncompleteWindow,
+                    crate::CaptureEvidenceError::MissingStream => Self::MissingStream,
+                    crate::CaptureEvidenceError::StoppedStream => Self::StoppedStream,
+                };
+            }
+        }
+        match error.raw_os_error() {
+            Some(libc::EACCES | libc::EPERM) => Self::IoPermissionDenied,
+            Some(libc::EINVAL) => Self::IoInvalidArgument,
+            Some(libc::EIO) => Self::IoDevice,
+            Some(libc::ENOSPC) => Self::IoNoSpace,
+            Some(libc::ETIMEDOUT) => Self::IoTimeout,
+            _ => match error.kind() {
+                std::io::ErrorKind::PermissionDenied => Self::IoPermissionDenied,
+                std::io::ErrorKind::TimedOut => Self::IoTimeout,
+                _ if error.get_ref().is_some() => Self::Other,
+                _ => Self::IoOther,
+            },
+        }
+    }
+
+    /// Fixed diagnostic refusal label, without driver strings or numeric values.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::IoPermissionDenied => "camera_rate_fill_io_permission_denied",
+            Self::IoInvalidArgument => "camera_rate_fill_io_invalid_argument",
+            Self::IoDevice => "camera_rate_fill_io_device",
+            Self::IoNoSpace => "camera_rate_fill_io_no_space",
+            Self::IoTimeout => "camera_rate_fill_io_timeout",
+            Self::IoOther => "camera_rate_fill_io_other",
+            Self::BufferTimestamp => "camera_rate_fill_buffer_timestamp",
+            Self::BufferClock => "camera_rate_fill_buffer_clock",
+            Self::BufferSource => "camera_rate_fill_buffer_source",
+            Self::BufferLayout => "camera_rate_fill_buffer_layout",
+            Self::TimestampNonIncreasing => "camera_rate_fill_timestamp_non_increasing",
+            Self::TimestampClock => "camera_rate_fill_timestamp_clock",
+            Self::TimestampSource => "camera_rate_fill_timestamp_source",
+            Self::TimestampEpoch => "camera_rate_fill_timestamp_epoch",
+            Self::Sequence => "camera_rate_fill_sequence",
+            Self::RateWindow => "camera_rate_fill_rate_window",
+            Self::PrivacyBoundary => "camera_rate_fill_privacy_boundary",
+            Self::PrivacyEngaged => "camera_rate_fill_privacy_engaged",
+            Self::PrivacyReadPermissionDenied => "camera_rate_fill_privacy_read_permission_denied",
+            Self::PrivacyReadDevice => "camera_rate_fill_privacy_read_device",
+            Self::PrivacyReadTimeout => "camera_rate_fill_privacy_read_timeout",
+            Self::PrivacyReadBusy => "camera_rate_fill_privacy_read_busy",
+            Self::PrivacyReadOther => "camera_rate_fill_privacy_read_other",
+            Self::LeaseBoundary => "camera_rate_fill_lease_boundary",
+            Self::StreamState => "camera_rate_fill_stream_state",
+            Self::ContinuityAlignment => "camera_rate_fill_continuity_alignment",
+            Self::ContinuityAccounting => "camera_rate_fill_continuity_accounting",
+            Self::IncompleteWindow => "camera_rate_fill_incomplete_window",
+            Self::MissingStream => "camera_rate_fill_missing_stream",
+            Self::StoppedStream => "camera_rate_fill_stopped_stream",
+            Self::Other => "camera_rate_fill_other",
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum Stage {
+    Open,
+    SessionSetup,
+    Buffers,
+    Metadata,
+    Emitter,
+    Warmup,
+    RateFill,
+    Frames,
+    SessionRelease,
+    ImageStop,
+    MetadataStreamoff,
+    MetadataBuffers,
+    MetadataFormat,
+    MetadataClose,
+    EmitterRestore,
+}
+
+#[cfg(feature = "capture-timing")]
+mod enabled {
+    use super::{RateFillFailure, Stage};
+    use std::{
+        collections::BTreeMap,
+        sync::{Arc, Mutex},
+        time::{Duration, Instant},
+    };
+
+    const LABELS: [&str; 15] = [
+        "open",
+        "session_setup",
+        "buffers",
+        "metadata",
+        "emitter",
+        "warmup",
+        "rate_fill",
+        "frames",
+        "session_release",
+        "image_stop",
+        "metadata_streamoff",
+        "metadata_buffers",
+        "metadata_format",
+        "metadata_close",
+        "emitter_restore",
+    ];
+
+    /// Per-operation fixed-size timing storage, enabled only for diagnostics.
+    /// Null means unreached. Nested stages overlap and must not be summed.
+    #[derive(Clone, Default, Debug)]
+    pub struct CaptureTimings(
+        Arc<Mutex<[Option<Duration>; 15]>>,
+        Arc<Mutex<Option<RateFillFailure>>>,
+    );
+
+    impl CaptureTimings {
+        /// First startup fill failure in this request, if one was observed.
+        pub fn rate_fill_failure(&self) -> Option<RateFillFailure> {
+            *self
+                .1
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+        }
+
+        pub(super) fn record_rate_fill_failure(&self, error: &std::io::Error) {
+            self.1
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .get_or_insert_with(|| RateFillFailure::classify(error));
+        }
+
+        /// Snapshot only fixed labels and elapsed milliseconds, including errors.
+        pub fn snapshot(&self) -> BTreeMap<&'static str, Option<u64>> {
+            let values = self
+                .0
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            LABELS
+                .into_iter()
+                .zip(
+                    values
+                        .iter()
+                        .map(|v| v.map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))),
+                )
+                .collect()
+        }
+
+        pub(super) fn start(&self, stage: Stage) -> Span {
+            Span {
+                timings: self.clone(),
+                stage,
+                start: Instant::now(),
+            }
+        }
+    }
+
+    pub(super) struct Span {
+        timings: CaptureTimings,
+        stage: Stage,
+        start: Instant,
+    }
+
+    impl Drop for Span {
+        fn drop(&mut self) {
+            let elapsed = self.start.elapsed();
+            let mut values = self
+                .timings
+                .0
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let slot = &mut values[self.stage as usize];
+            *slot = Some(slot.unwrap_or_default().saturating_add(elapsed));
+        }
+    }
+}
+
+#[cfg(feature = "capture-timing")]
+pub use enabled::CaptureTimings;
+
+pub(crate) struct Span {
+    #[cfg(feature = "capture-timing")]
+    _inner: Option<enabled::Span>,
+}
+
+/// A timing-only handle carried by cleanup owners. Zero-sized in normal builds.
+#[derive(Clone, Default)]
+pub(crate) struct Recorder {
+    #[cfg(feature = "capture-timing")]
+    timings: Option<CaptureTimings>,
+}
+
+impl Recorder {
+    pub(crate) fn from_control(control: &crate::CaptureControl) -> Self {
+        #[cfg(feature = "capture-timing")]
+        {
+            Self {
+                timings: control.capture_timings(),
+            }
+        }
+        #[cfg(not(feature = "capture-timing"))]
+        {
+            let _ = control;
+            Self {}
+        }
+    }
+
+    pub(crate) fn stage(&self, stage: Stage) -> Span {
+        #[cfg(feature = "capture-timing")]
+        {
+            Span {
+                _inner: self.timings.as_ref().map(|t| t.start(stage)),
+            }
+        }
+        #[cfg(not(feature = "capture-timing"))]
+        {
+            let _ = stage;
+            Span {}
+        }
+    }
+}
+
+impl crate::CaptureControl {
+    #[cfg(feature = "capture-timing")]
+    pub(crate) fn record_rate_fill_failure(&self, error: &std::io::Error) {
+        if let Some(timings) = &self.timings {
+            timings.record_rate_fill_failure(error);
+        }
+    }
+
+    pub(crate) fn stage(&self, stage: Stage) -> Span {
+        #[cfg(feature = "capture-timing")]
+        {
+            Span {
+                _inner: self.timings.as_ref().map(|t| t.start(stage)),
+            }
+        }
+        #[cfg(not(feature = "capture-timing"))]
+        {
+            let _ = stage;
+            Span {}
+        }
+    }
+}
+
+#[cfg(all(test, feature = "capture-timing"))]
+mod tests {
+    use super::*;
+    use crate::CaptureControl;
+
+    #[test]
+    fn privacy_observation_detail_preserves_refusal_and_private_payloads() {
+        use std::io::{Error, ErrorKind};
+        let cases = [
+            (Ok(Some(true)), "privacy_engaged"),
+            (
+                Err(Error::from_raw_os_error(libc::EACCES)),
+                "privacy_read_permission_denied",
+            ),
+            (
+                Err(Error::from_raw_os_error(libc::EPERM)),
+                "privacy_read_permission_denied",
+            ),
+            (
+                Err(Error::from_raw_os_error(libc::EIO)),
+                "privacy_read_device",
+            ),
+            (
+                Err(Error::from_raw_os_error(libc::ENODEV)),
+                "privacy_read_device",
+            ),
+            (
+                Err(Error::from_raw_os_error(libc::ETIMEDOUT)),
+                "privacy_read_timeout",
+            ),
+            (
+                Err(Error::new(ErrorKind::TimedOut, "private timeout payload")),
+                "privacy_read_timeout",
+            ),
+            (
+                Err(Error::from_raw_os_error(libc::EBUSY)),
+                "privacy_read_busy",
+            ),
+            (
+                Err(Error::other("private unsupported payload")),
+                "privacy_read_other",
+            ),
+        ];
+        for (observed, suffix) in cases {
+            let error = crate::privacy_capture_boundary(observed).unwrap_err();
+            assert_eq!(error.kind(), ErrorKind::Other);
+            assert!(crate::is_privacy_boundary_error(&error));
+            let prior_text = error.to_string();
+            let timings = CaptureTimings::default();
+            let control = crate::CaptureControl::with_progress(crate::no_progress())
+                .with_capture_timings(Some(timings.clone()));
+            control.record_rate_fill_failure(&error);
+            control.record_rate_fill_failure(&Error::other("later private error"));
+            assert_eq!(
+                timings.rate_fill_failure().unwrap().as_str(),
+                format!("camera_rate_fill_{suffix}")
+            );
+            assert_eq!(error.to_string(), prior_text);
+            assert!(!timings
+                .rate_fill_failure()
+                .unwrap()
+                .as_str()
+                .contains("payload"));
+        }
+        assert!(crate::privacy_capture_boundary(Ok(Some(false))).is_ok());
+        assert!(crate::privacy_capture_boundary(Ok(None)).is_ok());
+    }
+
+    #[test]
+    fn rate_fill_diagnostic_erases_typed_and_transport_payloads() {
+        use crate::frame_provenance::{
+            DequeuedBufferError as B, SequenceTrackerError as S, TimestampClock as C,
+            TimestampSource as T, TimestampTrackerError as E,
+        };
+        use std::io::Error;
+        let cases = [
+            (
+                Error::new(std::io::ErrorKind::TimedOut, "private VIDIOC_DQBUF payload"),
+                "io_timeout",
+            ),
+            (
+                Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    "private permission payload",
+                ),
+                "io_permission_denied",
+            ),
+            (
+                Error::from_raw_os_error(libc::EACCES),
+                "io_permission_denied",
+            ),
+            (
+                Error::from_raw_os_error(libc::EPERM),
+                "io_permission_denied",
+            ),
+            (
+                Error::from_raw_os_error(libc::EINVAL),
+                "io_invalid_argument",
+            ),
+            (Error::from_raw_os_error(libc::EIO), "io_device"),
+            (Error::from_raw_os_error(libc::ENOSPC), "io_no_space"),
+            (Error::from_raw_os_error(libc::ETIMEDOUT), "io_timeout"),
+            (Error::from_raw_os_error(libc::EINTR), "io_other"),
+            (
+                Error::other(B::InvalidTimestamp {
+                    seconds: 123456789,
+                    microseconds: 1000000,
+                }),
+                "buffer_timestamp",
+            ),
+            (
+                Error::other(B::UnsupportedTimestampClock(123456789)),
+                "buffer_clock",
+            ),
+            (
+                Error::other(B::UnsupportedTimestampSource(123456789)),
+                "buffer_source",
+            ),
+            (
+                Error::other(B::PayloadTooShort {
+                    bytes_used: 1,
+                    minimum: 123456789,
+                }),
+                "buffer_layout",
+            ),
+            (
+                Error::other(E::NonIncreasing {
+                    previous: 123456789,
+                    current: 1,
+                }),
+                "timestamp_non_increasing",
+            ),
+            (
+                Error::other(E::UntrustedClock(C::Unknown)),
+                "timestamp_clock",
+            ),
+            (
+                Error::other(E::ClockChanged {
+                    expected: C::Monotonic,
+                    actual: C::Copy,
+                }),
+                "timestamp_clock",
+            ),
+            (
+                Error::other(E::SourceChanged {
+                    expected: T::EndOfFrame,
+                    actual: T::StartOfExposure,
+                }),
+                "timestamp_source",
+            ),
+            (Error::other(E::EpochFailed), "timestamp_epoch"),
+            (Error::other(S::TrackerFailed), "sequence"),
+            (
+                Error::other(crate::rate_gate::RateWindowError::Overflow),
+                "rate_window",
+            ),
+            (
+                crate::privacy_boundary_error("private privacy payload 123456789".into()),
+                "privacy_boundary",
+            ),
+            (
+                Error::other(crate::lease::CameraLeaseError::InvalidEndpoint(
+                    "private endpoint 123456789".into(),
+                )),
+                "lease_boundary",
+            ),
+            (
+                Error::other(irlume_common::Error::Hardware(
+                    "private stream payload 123456789".into(),
+                )),
+                "stream_state",
+            ),
+            (
+                Error::other(crate::CaptureEvidenceError::StoppedStream),
+                "stopped_stream",
+            ),
+            (Error::other("private driver payload 123456789"), "other"),
+        ];
+        for (error, suffix) in cases {
+            let original = error.to_string();
+            let timings = CaptureTimings::default();
+            let control = CaptureControl::with_progress(crate::no_progress())
+                .with_capture_timings(Some(timings.clone()));
+            control.record_rate_fill_failure(&error);
+            // Later errors cannot obscure the originating failure in a request.
+            control.record_rate_fill_failure(&Error::other("later private payload"));
+            assert_eq!(
+                timings.rate_fill_failure().unwrap().as_str(),
+                format!("camera_rate_fill_{suffix}")
+            );
+            assert_eq!(error.to_string(), original);
+            let debug = format!("{timings:?}");
+            assert!(!debug.contains("private") && !debug.contains("123456789"));
+        }
+    }
+
+    #[test]
+    fn timing_keeps_early_error_and_nested_cleanup_without_payloads() {
+        let timings = CaptureTimings::default();
+        let control = CaptureControl::with_progress(crate::no_progress())
+            .with_capture_timings(Some(timings.clone()));
+        let fail = |reject: bool| -> Result<(), &'static str> {
+            let _setup = control.stage(Stage::SessionSetup);
+            let _warmup = control.stage(Stage::Warmup);
+            if reject {
+                return Err("private driver payload");
+            }
+            Ok(())
+        };
+        assert_eq!(fail(true), Err("private driver payload"));
+        let snapshot = timings.snapshot();
+        assert!(snapshot["session_setup"].is_some());
+        assert!(snapshot["warmup"].is_some());
+        assert!(snapshot["frames"].is_none());
+        assert_eq!(snapshot.len(), 15);
+        assert!(!serde_json::to_string(&snapshot)
+            .unwrap()
+            .contains("private"));
+    }
+
+    #[test]
+    fn timing_is_request_local_and_preserves_cancel_and_deadline() {
+        let first = CaptureTimings::default();
+        let second = CaptureTimings::default();
+        let control = CaptureControl::new(crate::no_progress(), std::sync::Arc::new(|| true))
+            .with_capture_timings(Some(first.clone()));
+        {
+            let _span = control.clone().stage(Stage::Open);
+        }
+        assert!(control.check().is_err());
+        assert!(first.snapshot()["open"].is_some());
+        assert!(second.snapshot().values().all(Option::is_none));
+        let expired = CaptureControl::with_progress(crate::no_progress())
+            .with_deadline(Some(std::time::Instant::now()))
+            .with_capture_timings(Some(second));
+        assert!(matches!(
+            expired.check(),
+            Err(irlume_common::Error::DeadlineExpired)
+        ));
+    }
+}

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -2296,11 +2296,20 @@ impl EmitterBackend for SentinelBackend {
 #[must_use = "dropping this immediately puts the control back and leaves the stream unlit"]
 pub struct StreamMode {
     backend: Box<dyn EmitterBackend + Send>,
+    timing: crate::capture_timing::Recorder,
 }
 
 impl StreamMode {
+    pub(crate) fn with_timing(mut self, timing: crate::capture_timing::Recorder) -> Self {
+        self.timing = timing;
+        self
+    }
+
     fn new(backend: Box<dyn EmitterBackend + Send>) -> Self {
-        StreamMode { backend }
+        StreamMode {
+            backend,
+            timing: crate::capture_timing::Recorder::default(),
+        }
     }
 
     /// A guard over nothing: no control was applied, so `Drop` writes nothing.
@@ -2346,6 +2355,9 @@ impl StreamMode {
     /// Put the control back now, rather than waiting for the drop.
     #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn restore(&mut self) -> std::result::Result<(), RestoreError> {
+        let _timing = self
+            .timing
+            .stage(crate::capture_timing::Stage::EmitterRestore);
         self.backend.restore()
     }
 
@@ -2356,6 +2368,9 @@ impl StreamMode {
 
 impl Drop for StreamMode {
     fn drop(&mut self) {
+        let _timing = self
+            .timing
+            .stage(crate::capture_timing::Stage::EmitterRestore);
         if let Err(e) = self.backend.restore() {
             // Not fatal, and not silent. The camera keeps a mode irlume chose,
             // which is exactly the state this type exists to prevent.
@@ -5063,6 +5078,23 @@ pub fn describe_units(device: &str) -> std::io::Result<Vec<String>> {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "capture-timing")]
+    #[test]
+    fn teardown_timing_records_failed_restore_without_error_payload() {
+        let events = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let timings = crate::CaptureTimings::default();
+        let control = crate::CaptureControl::with_progress(crate::no_progress())
+            .with_capture_timings(Some(timings.clone()));
+        let mut mode = super::StreamMode::test_failing_sentinel(events.clone())
+            .with_timing(crate::capture_timing::Recorder::from_control(&control));
+        assert!(mode.restore().is_err());
+        assert!(timings.snapshot()["emitter_restore"].is_some());
+        drop(mode);
+        assert_eq!(*events.lock().unwrap(), ["emitter-restore"]);
+        let output = serde_json::to_string(&timings.snapshot()).unwrap();
+        assert!(!output.contains("sentinel"));
+        assert!(!output.contains("failure"));
+    }
     #[test]
     fn set_cur_refuses_without_a_current_descriptor_bound_lease() {
         use std::os::fd::AsRawFd;

--- a/crates/irlume-camera/src/ir_metadata.rs
+++ b/crates/irlume-camera/src/ir_metadata.rs
@@ -464,11 +464,24 @@ pub(crate) struct IlluminationLog {
     /// changed for the next process to open this camera.
     restore_format: u32,
     streaming: bool,
+    timing: crate::capture_timing::Recorder,
     #[cfg(test)]
     sentinel_events: Option<std::sync::Arc<std::sync::Mutex<Vec<&'static str>>>>,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum MetadataSelection<'a> {
+    Discover,
+    Exact(&'a str),
+    Absent,
+}
+
 impl IlluminationLog {
+    pub(crate) fn with_timing(mut self, timing: crate::capture_timing::Recorder) -> Self {
+        self.timing = timing;
+        self
+    }
+
     /// Set up and start the metadata queue for the IR node at `ir_device`.
     ///
     /// Must be called before the image stream's first dequeue: uvcvideo
@@ -477,34 +490,71 @@ impl IlluminationLog {
     /// `None` means this camera cannot report illumination, which is a normal
     /// outcome and not an error.
     pub(crate) fn open(ir_device: &str) -> Option<Self> {
-        let node = metadata_node_for(ir_device)?;
+        Self::open_selected(ir_device, MetadataSelection::Discover)
+            .ok()
+            .flatten()
+    }
+
+    pub(crate) fn open_selected(
+        ir_device: &str,
+        selection: MetadataSelection<'_>,
+    ) -> Result<Option<Self>, String> {
+        Self::open_selected_with(ir_device, selection, metadata_node_for, Self::open_node)
+    }
+
+    fn open_selected_with<T>(
+        ir_device: &str,
+        selection: MetadataSelection<'_>,
+        discover: impl FnOnce(&str) -> Option<String>,
+        open: impl FnOnce(&str, &str) -> Result<T, String>,
+    ) -> Result<Option<T>, String> {
+        match selection {
+            MetadataSelection::Discover => {
+                let Some(node) = discover(ir_device) else {
+                    return Ok(None);
+                };
+                Ok(open(ir_device, &node).ok())
+            }
+            MetadataSelection::Absent => Ok(None),
+            MetadataSelection::Exact(node) => {
+                if std::env::var_os("IRLUME_NO_ILLUM_META").is_some_and(|v| v == "1") {
+                    return Err("required illumination metadata is disabled".into());
+                }
+                open(ir_device, node).map(Some)
+            }
+        }
+    }
+
+    fn open_node(ir_device: &str, node: &str) -> Result<Self, String> {
         // SAFETY: a NUL-terminated path built directly below.
-        let path = std::ffi::CString::new(node.as_bytes()).ok()?;
+        let path = std::ffi::CString::new(node.as_bytes())
+            .map_err(|_| "metadata node path contains NUL".to_string())?;
         #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
         let fd = unsafe { libc::open(path.as_ptr(), libc::O_RDWR | libc::O_NONBLOCK) };
         if fd < 0 {
             irlume_common::dlog!(
                 "{ir_device}: metadata node {node} would not open; using brightness"
             );
-            return None;
+            return Err(format!("metadata node {node} would not open"));
         }
         let mut log = Self {
             fd,
-            device: node.clone(),
+            device: node.to_string(),
             buffers: Vec::new(),
             by_timestamp: std::collections::HashMap::new(),
             restore_format: UVCH,
             streaming: false,
+            timing: crate::capture_timing::Recorder::default(),
             #[cfg(test)]
             sentinel_events: None,
         };
         match log.start() {
-            Ok(()) => Some(log),
+            Ok(()) => Ok(log),
             Err(why) => {
                 irlume_common::dlog!(
                     "{ir_device}: no illumination metadata from {node} ({why}); using brightness"
                 );
-                None
+                Err(why)
             }
         }
     }
@@ -715,6 +765,7 @@ impl IlluminationLog {
             by_timestamp: std::collections::HashMap::new(),
             restore_format: 0,
             streaming: false,
+            timing: crate::capture_timing::Recorder::default(),
             sentinel_events: Some(events),
         }
     }
@@ -731,6 +782,9 @@ impl Drop for IlluminationLog {
             return;
         }
         if self.streaming {
+            let _timing = self
+                .timing
+                .stage(crate::capture_timing::Stage::MetadataStreamoff);
             let mut kind = META_CAPTURE as c_int;
             let _ = self.ioctl(
                 vidioc_streamoff(),
@@ -744,25 +798,36 @@ impl Drop for IlluminationLog {
         // skipping this silently left the node on UVCM for the next process
         // (measured: the format survived every capture until REQBUFS(0) was
         // added here).
-        self.buffers.clear();
-        let mut release = V4l2RequestBuffers {
-            count: 0,
-            kind: META_CAPTURE,
-            memory: MEMORY_MMAP,
-            capabilities: 0,
-            flags: 0,
-            _reserved: [0; 3],
-        };
-        let _ = self.ioctl(
-            vidioc_reqbufs(),
-            &mut release as *mut _ as *mut libc::c_void,
-            "REQBUFS(0)",
-        );
+        {
+            let _timing = self
+                .timing
+                .stage(crate::capture_timing::Stage::MetadataBuffers);
+            self.buffers.clear();
+            let mut release = V4l2RequestBuffers {
+                count: 0,
+                kind: META_CAPTURE,
+                memory: MEMORY_MMAP,
+                capabilities: 0,
+                flags: 0,
+                _reserved: [0; 3],
+            };
+            let _ = self.ioctl(
+                vidioc_reqbufs(),
+                &mut release as *mut _ as *mut libc::c_void,
+                "REQBUFS(0)",
+            );
+        }
         // The format outlives this process, so hand the node back as found.
         if self.restore_format != 0 && self.restore_format != UVCM {
+            let _timing = self
+                .timing
+                .stage(crate::capture_timing::Stage::MetadataFormat);
             let _ = self.set_format(self.restore_format);
         }
         if self.fd >= 0 {
+            let _timing = self
+                .timing
+                .stage(crate::capture_timing::Stage::MetadataClose);
             // SAFETY: fd was opened by this type and is closed exactly once.
             unsafe { libc::close(self.fd) };
         }
@@ -984,8 +1049,79 @@ fn offers_uvcm(node: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "capture-timing")]
+    #[test]
+    fn teardown_timing_keeps_close_after_metadata_ioctl_failures() {
+        use std::{
+            io::Read,
+            os::{fd::IntoRawFd, unix::net::UnixStream},
+        };
+        let (mut peer, owned) = UnixStream::pair().unwrap();
+        peer.set_read_timeout(Some(std::time::Duration::from_secs(1)))
+            .unwrap();
+        let timings = crate::CaptureTimings::default();
+        let control = crate::CaptureControl::with_progress(crate::no_progress())
+            .with_capture_timings(Some(timings.clone()));
+        // A socket rejects V4L2 ioctls. Exercise the real error cleanup and fd
+        // ownership without opening a camera or depending on fd-number reuse.
+        let mut log = super::IlluminationLog::test_sentinel(Default::default());
+        log.sentinel_events = None;
+        log.fd = owned.into_raw_fd();
+        log.streaming = true;
+        log.restore_format = super::UVCH;
+        drop(log.with_timing(crate::capture_timing::Recorder::from_control(&control)));
+        assert_eq!(peer.read(&mut [0u8; 1]).unwrap(), 0);
+        let snapshot = timings.snapshot();
+        for label in [
+            "metadata_streamoff",
+            "metadata_buffers",
+            "metadata_format",
+            "metadata_close",
+        ] {
+            assert!(snapshot[label].is_some(), "unrecorded {label}");
+        }
+        assert!(snapshot["image_stop"].is_none());
+        assert!(snapshot["emitter_restore"].is_none());
+    }
     use super::*;
     use crate::capture_qualification::IlluminationMetadataPresence;
+
+    #[test]
+    fn explicit_absence_and_exact_failure_never_fall_back_to_discovery() {
+        assert!(IlluminationLog::open_selected(
+            "/dev/a-configured-ir-node",
+            MetadataSelection::Absent
+        )
+        .unwrap()
+        .is_none());
+        let error = IlluminationLog::open_selected(
+            "/dev/a-configured-ir-node",
+            MetadataSelection::Exact("/definitely/missing/metadata"),
+        )
+        .err()
+        .expect("required exact metadata must fail");
+        assert!(error.contains("would not open"), "{error}");
+    }
+
+    #[test]
+    fn exact_metadata_selection_calls_only_the_permitted_open() {
+        let events = std::cell::RefCell::new(Vec::new());
+        let selected = IlluminationLog::open_selected_with(
+            "/dev/video2",
+            MetadataSelection::Exact("/dev/video3"),
+            |_| {
+                events.borrow_mut().push("discover".to_string());
+                Some("/dev/video1".into())
+            },
+            |image, metadata| {
+                events.borrow_mut().push(format!("open:{image}:{metadata}"));
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert_eq!(selected, Some(()));
+        assert_eq!(events.into_inner(), ["open:/dev/video2:/dev/video3"]);
+    }
 
     #[test]
     fn a_discovered_node_maps_to_present_and_no_node_to_absent() {

--- a/crates/irlume-camera/src/ir_target.rs
+++ b/crates/irlume-camera/src/ir_target.rs
@@ -1,0 +1,828 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! Configured, sysfs-validated target for experimental IR-only capture.
+//!
+//! Resolution reads configuration and sysfs only. It never opens a video node,
+//! probes formats, or discovers a replacement endpoint.
+
+use std::os::unix::fs::{FileTypeExt, MetadataExt};
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct DeviceNumber(u32, u32);
+
+#[derive(Debug)]
+struct ResolvedEndpoint {
+    path: PathBuf,
+    device: DeviceNumber,
+}
+
+trait DeviceAccess {
+    fn resolve_endpoint(&self, path: &str) -> Result<ResolvedEndpoint, IrTargetError>;
+    fn endpoint_for_node(&self, node: &str) -> String;
+}
+
+struct HostDevices;
+
+impl DeviceAccess for HostDevices {
+    fn resolve_endpoint(&self, path: &str) -> Result<ResolvedEndpoint, IrTargetError> {
+        let resolved = std::fs::canonicalize(path).map_err(|_| {
+            IrTargetError::InvalidEndpoint(format!("configured endpoint {path} is missing"))
+        })?;
+        let metadata = std::fs::metadata(&resolved).map_err(|_| {
+            IrTargetError::InvalidEndpoint(format!("configured endpoint {path} is unreadable"))
+        })?;
+        if !metadata.file_type().is_char_device() {
+            return Err(IrTargetError::InvalidEndpoint(format!(
+                "configured endpoint {path} is not a character device"
+            )));
+        }
+        let rdev = metadata.rdev();
+        Ok(ResolvedEndpoint {
+            path: resolved,
+            device: DeviceNumber(libc::major(rdev), libc::minor(rdev)),
+        })
+    }
+
+    fn endpoint_for_node(&self, node: &str) -> String {
+        format!("/dev/{node}")
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct IrCaptureTarget {
+    rgb_endpoint: String,
+    endpoint: String,
+    metadata_endpoint: Option<String>,
+    identity: String,
+    interface: PathBuf,
+    image_name: String,
+    image_device: DeviceNumber,
+    metadata_device: Option<DeviceNumber>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum IrTargetError {
+    Unconfigured,
+    InvalidEndpoint(String),
+    BindingUnavailable(String),
+    UnsupportedTopology(String),
+    Changed,
+}
+
+impl std::fmt::Display for IrTargetError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unconfigured => f.write_str("an explicit RGB and IR camera pair is required"),
+            Self::InvalidEndpoint(reason) => write!(f, "invalid configured IR target: {reason}"),
+            Self::BindingUnavailable(reason) => {
+                write!(f, "IR target identity unavailable: {reason}")
+            }
+            Self::UnsupportedTopology(reason) => {
+                write!(f, "unsupported IR target topology: {reason}")
+            }
+            Self::Changed => f.write_str("configured IR target changed after validation"),
+        }
+    }
+}
+
+impl std::error::Error for IrTargetError {}
+
+impl IrCaptureTarget {
+    #[must_use]
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    #[must_use]
+    pub fn metadata_endpoint(&self) -> Option<&str> {
+        self.metadata_endpoint.as_deref()
+    }
+
+    #[must_use]
+    pub fn identity(&self) -> &str {
+        &self.identity
+    }
+
+    #[must_use]
+    pub fn lease_endpoints(&self) -> Vec<&str> {
+        let mut endpoints = vec![self.endpoint.as_str()];
+        if let Some(metadata) = self.metadata_endpoint.as_deref() {
+            endpoints.push(metadata);
+        }
+        endpoints
+    }
+
+    /// Re-read the exact configured endpoints and sysfs evidence. A changed
+    /// node, interface, identity, index, name, or sibling set is refused.
+    ///
+    /// # Errors
+    /// Returns the concrete configuration, identity, topology, or change refusal.
+    pub fn validate(&self) -> Result<(), IrTargetError> {
+        self.validate_in(Path::new("/sys/class/video4linux"))
+    }
+
+    /// Revalidate the target before routing its image open through an existing
+    /// operation lease. The operation must cover [`Self::lease_endpoints`].
+    ///
+    /// # Errors
+    /// Returns a target-validation, lease-continuity, or camera-open error.
+    pub fn open(
+        &self,
+        operation: &crate::lease::CameraOperationSession,
+    ) -> irlume_common::Result<crate::IrCamera> {
+        self.open_with(|| self.validate(), |endpoint| operation.open_ir(endpoint))
+    }
+
+    /// Capture once through this exact configured target and operation lease.
+    ///
+    /// The target is revalidated before open and again before its fixed-startup
+    /// session. Explicit metadata absence never falls back to discovery.
+    ///
+    /// # Errors
+    /// Returns cancellation, deadline, target, lease, camera, metadata, emitter,
+    /// privacy, delivered-rate, or capture errors.
+    pub fn capture_with_stats_and_control(
+        &self,
+        operation: &crate::lease::CameraOperationSession,
+        control: &crate::CaptureControl,
+    ) -> irlume_common::Result<(crate::Frame, crate::IrCaptureStats)> {
+        // Nested capture diagnostics must reuse this lease rather than wait
+        // for the camera already owned here. Keep teardown in the same scope.
+        operation
+            .run(|| {
+                control.check()?;
+                let camera = {
+                    let _timing = control.stage(crate::capture_timing::Stage::Open);
+                    self.open(operation)?
+                };
+                let mut session = camera.session_for_target_with_control(self, control)?;
+                let result = {
+                    let _timing = control.stage(crate::capture_timing::Stage::Frames);
+                    session.capture_with_stats()
+                };
+                finish_capture(control, session, result)
+            })
+            .map_err(|error| irlume_common::Error::Hardware(error.to_string()))?
+    }
+
+    fn open_with<T>(
+        &self,
+        validate: impl FnOnce() -> Result<(), IrTargetError>,
+        open_ir: impl FnOnce(&str) -> irlume_common::Result<T>,
+    ) -> irlume_common::Result<T> {
+        validate().map_err(|error| irlume_common::Error::Hardware(error.to_string()))?;
+        open_ir(&self.endpoint)
+    }
+
+    pub(crate) fn validate_in(&self, sysfs: &Path) -> Result<(), IrTargetError> {
+        let observed = resolve_configured_pair_with(
+            Some((self.rgb_endpoint.clone(), self.endpoint.clone())),
+            sysfs,
+            &HostDevices,
+        )?;
+        if observed == *self {
+            Ok(())
+        } else {
+            Err(IrTargetError::Changed)
+        }
+    }
+
+    pub(crate) fn metadata_selection(&self) -> crate::ir_metadata::MetadataSelection<'_> {
+        self.metadata_endpoint.as_deref().map_or(
+            crate::ir_metadata::MetadataSelection::Absent,
+            crate::ir_metadata::MetadataSelection::Exact,
+        )
+    }
+}
+
+fn finish_capture<R, S>(
+    control: &crate::CaptureControl,
+    session: S,
+    result: irlume_common::Result<R>,
+) -> irlume_common::Result<R> {
+    {
+        let _timing = control.stage(crate::capture_timing::Stage::SessionRelease);
+        drop(session);
+    }
+    control.check()?;
+    result
+}
+
+/// Resolve the configured pair without device I/O or fallback discovery.
+///
+/// # Errors
+/// Returns a configuration, identity, or supported-topology refusal.
+pub fn configured_ir_target() -> Result<IrCaptureTarget, IrTargetError> {
+    resolve_configured_pair_with(
+        crate::configured_pair_no_probe(),
+        Path::new("/sys/class/video4linux"),
+        &HostDevices,
+    )
+}
+
+#[derive(Debug)]
+struct NodeEvidence {
+    endpoint: String,
+    interface: PathBuf,
+    index: u32,
+    name: String,
+    device: DeviceNumber,
+}
+
+fn node_name(endpoint: &str) -> Result<&str, IrTargetError> {
+    Path::new(endpoint)
+        .file_name()
+        .and_then(|v| v.to_str())
+        .filter(|v| {
+            v.starts_with("video") && v[5..].chars().all(|c| c.is_ascii_digit()) && v.len() > 5
+        })
+        .ok_or_else(|| {
+            IrTargetError::InvalidEndpoint(format!("{endpoint} is not a video node path"))
+        })
+}
+
+fn sysfs_device(class: &Path, endpoint: &str) -> Result<DeviceNumber, IrTargetError> {
+    let raw = std::fs::read_to_string(class.join("dev")).map_err(|_| {
+        IrTargetError::UnsupportedTopology(format!("{endpoint} has no readable sysfs dev number"))
+    })?;
+    let (major, minor) = raw.trim().split_once(':').ok_or_else(|| {
+        IrTargetError::UnsupportedTopology(format!("{endpoint} has an invalid sysfs dev number"))
+    })?;
+    let parse = |value: &str| value.parse::<u32>().ok();
+    match (parse(major), parse(minor)) {
+        (Some(major), Some(minor)) => Ok(DeviceNumber(major, minor)),
+        _ => Err(IrTargetError::UnsupportedTopology(format!(
+            "{endpoint} has an invalid sysfs dev number"
+        ))),
+    }
+}
+
+fn evidence(resolved: ResolvedEndpoint, sysfs: &Path) -> Result<NodeEvidence, IrTargetError> {
+    let endpoint = resolved.path.to_string_lossy().into_owned();
+    let node = node_name(&endpoint)?;
+    let class = sysfs.join(node);
+    let interface = std::fs::canonicalize(class.join("device")).map_err(|_| {
+        IrTargetError::InvalidEndpoint(format!("{endpoint} has no readable sysfs interface"))
+    })?;
+    let index = std::fs::read_to_string(class.join("index"))
+        .ok()
+        .and_then(|v| v.trim().parse().ok())
+        .ok_or_else(|| {
+            IrTargetError::UnsupportedTopology(format!("{endpoint} has no unambiguous sysfs index"))
+        })?;
+    let name = std::fs::read_to_string(class.join("name"))
+        .ok()
+        .map(|v| v.trim().to_owned())
+        .filter(|v| !v.is_empty())
+        .ok_or_else(|| {
+            IrTargetError::UnsupportedTopology(format!("{endpoint} has no readable sysfs name"))
+        })?;
+    let advertised = sysfs_device(&class, &endpoint)?;
+    if advertised != resolved.device {
+        return Err(IrTargetError::InvalidEndpoint(format!(
+            "{endpoint} device number does not match its sysfs entry"
+        )));
+    }
+    Ok(NodeEvidence {
+        endpoint,
+        interface,
+        index,
+        name,
+        device: resolved.device,
+    })
+}
+
+fn identity(interface: &Path) -> Result<String, IrTargetError> {
+    let mut cursor = Some(interface);
+    while let Some(path) = cursor {
+        if path.join("idVendor").is_file() {
+            let read = |name: &str| {
+                std::fs::read_to_string(path.join(name))
+                    .ok()
+                    .map(|v| v.trim().to_owned())
+                    .filter(|v| !v.is_empty())
+            };
+            let vendor = read("idVendor").ok_or_else(|| {
+                IrTargetError::BindingUnavailable("USB vendor is unreadable".into())
+            })?;
+            let product = read("idProduct").ok_or_else(|| {
+                IrTargetError::BindingUnavailable("USB product is unreadable".into())
+            })?;
+            let mut value = format!("{vendor}:{product}");
+            if let Some(serial) = read("serial") {
+                value.push(':');
+                value.push_str(&serial);
+            }
+            return Ok(value.to_lowercase());
+        }
+        cursor = path.parent();
+    }
+    Err(IrTargetError::BindingUnavailable(
+        "no USB identity in the IR interface ancestry".into(),
+    ))
+}
+
+fn siblings(
+    interface: &Path,
+    sysfs: &Path,
+    devices: &impl DeviceAccess,
+) -> Result<Vec<NodeEvidence>, IrTargetError> {
+    let entries = std::fs::read_dir(sysfs).map_err(|_| {
+        IrTargetError::UnsupportedTopology("video4linux sysfs is unreadable".into())
+    })?;
+    let mut found = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|_| {
+            IrTargetError::UnsupportedTopology("video4linux membership is unreadable".into())
+        })?;
+        let candidate_interface = match std::fs::canonicalize(entry.path().join("device")) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        if candidate_interface != interface {
+            continue;
+        }
+        let node = entry
+            .file_name()
+            .into_string()
+            .map_err(|_| IrTargetError::UnsupportedTopology("non-Unicode video node".into()))?;
+        let endpoint = devices.endpoint_for_node(&node);
+        found.push(evidence(devices.resolve_endpoint(&endpoint)?, sysfs)?);
+    }
+    found.sort_by(|a, b| {
+        a.index
+            .cmp(&b.index)
+            .then_with(|| a.endpoint.cmp(&b.endpoint))
+    });
+    Ok(found)
+}
+
+fn resolve_configured_pair_with(
+    pair: Option<(String, String)>,
+    sysfs: &Path,
+    devices: &impl DeviceAccess,
+) -> Result<IrCaptureTarget, IrTargetError> {
+    let (rgb_endpoint, endpoint) = pair.ok_or(IrTargetError::Unconfigured)?;
+    let rgb_resolved = devices.resolve_endpoint(&rgb_endpoint)?;
+    let ir_resolved = devices.resolve_endpoint(&endpoint)?;
+    if rgb_resolved.path == ir_resolved.path || rgb_resolved.device == ir_resolved.device {
+        return Err(IrTargetError::InvalidEndpoint(
+            "RGB and IR resolve to the same endpoint".into(),
+        ));
+    }
+    let rgb = evidence(rgb_resolved, sysfs)?;
+    let ir = evidence(ir_resolved, sysfs)?;
+    if rgb.interface == ir.interface {
+        return Err(IrTargetError::UnsupportedTopology(
+            "configured RGB shares the IR interface".into(),
+        ));
+    }
+    if ir.index != 0 {
+        return Err(IrTargetError::UnsupportedTopology(
+            "selected IR image node is not sysfs index 0".into(),
+        ));
+    }
+    let members = siblings(&ir.interface, sysfs, devices)?;
+    if members.first().is_none_or(|node| {
+        node.endpoint != ir.endpoint || node.device != ir.device || node.index != 0
+    }) {
+        return Err(IrTargetError::UnsupportedTopology(
+            "selected IR image is not the sole index-0 interface member".into(),
+        ));
+    }
+    let metadata_endpoint = match members.as_slice() {
+        [_image] => None,
+        [image, metadata] if metadata.index == 1 && metadata.name == image.name => {
+            Some(metadata.endpoint.clone())
+        }
+        _ => return Err(IrTargetError::UnsupportedTopology("IR interface must contain one image node and at most its same-name index-1 metadata companion".into())),
+    };
+    Ok(IrCaptureTarget {
+        rgb_endpoint: rgb.endpoint,
+        endpoint: ir.endpoint,
+        metadata_endpoint,
+        identity: identity(&ir.interface)?,
+        interface: ir.interface,
+        image_name: ir.name,
+        image_device: ir.device,
+        metadata_device: members.get(1).map(|node| node.device),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::symlink;
+    struct Fixture {
+        root: PathBuf,
+        sysfs: PathBuf,
+        dev: PathBuf,
+    }
+    impl Fixture {
+        fn new(tag: &str) -> Self {
+            let root =
+                std::env::temp_dir().join(format!("irlume-ir-target-{tag}-{}", std::process::id()));
+            let _ = std::fs::remove_dir_all(&root);
+            let sysfs = root.join("sys/class/video4linux");
+            let dev = root.join("dev");
+            std::fs::create_dir_all(&sysfs).unwrap();
+            std::fs::create_dir_all(&dev).unwrap();
+            Self { root, sysfs, dev }
+        }
+        fn interface(&self, name: &str, vendor: Option<&str>) -> PathBuf {
+            let usb = self.root.join("sys/devices/pci0000:00/usb1/1-1");
+            std::fs::create_dir_all(&usb).unwrap();
+            if let Some(v) = vendor {
+                std::fs::write(usb.join("idVendor"), v).unwrap();
+                std::fs::write(usb.join("idProduct"), "1234\n").unwrap();
+                std::fs::write(usb.join("serial"), "fixture\n").unwrap();
+            }
+            let i = usb.join(name);
+            std::fs::create_dir_all(&i).unwrap();
+            i
+        }
+        fn node(&self, node: &str, interface: &Path, index: &str, name: &str) -> String {
+            let class = self.sysfs.join(node);
+            std::fs::create_dir_all(&class).unwrap();
+            symlink(interface, class.join("device")).unwrap();
+            std::fs::write(class.join("index"), index).unwrap();
+            std::fs::write(class.join("name"), name).unwrap();
+            std::fs::write(
+                class.join("dev"),
+                format!("81:{}\n", node.trim_start_matches("video")),
+            )
+            .unwrap();
+            let backing = self.root.join("nodes").join(node);
+            std::fs::create_dir_all(backing.parent().unwrap()).unwrap();
+            std::fs::write(&backing, b"").unwrap();
+            let dev = self.dev.join(node);
+            symlink(backing, &dev).unwrap();
+            dev.to_string_lossy().into_owned()
+        }
+
+        fn resolve(
+            &self,
+            pair: Option<(String, String)>,
+        ) -> Result<IrCaptureTarget, IrTargetError> {
+            resolve_configured_pair_with(pair, &self.sysfs, self)
+        }
+    }
+    impl DeviceAccess for Fixture {
+        fn resolve_endpoint(&self, path: &str) -> Result<ResolvedEndpoint, IrTargetError> {
+            let resolved = std::fs::canonicalize(path).map_err(|_| {
+                IrTargetError::InvalidEndpoint(format!("fixture endpoint {path} is missing"))
+            })?;
+            let node = node_name(resolved.to_str().unwrap())?;
+            let minor = node.trim_start_matches("video").parse().unwrap();
+            Ok(ResolvedEndpoint {
+                path: resolved,
+                device: DeviceNumber(81, minor),
+            })
+        }
+
+        fn endpoint_for_node(&self, node: &str) -> String {
+            self.dev.join(node).to_string_lossy().into_owned()
+        }
+    }
+    impl Drop for Fixture {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
+    }
+    #[test]
+    fn isolated_ir_interface_resolves_exact_optional_metadata() {
+        let f = Fixture::new("ok");
+        let rgb_if = f.interface("1-1:1.0", None);
+        let ir_if = f.interface("1-1:1.2", Some("046d\n"));
+        let rgb = f.node("video0", &rgb_if, "0\n", "RGB Camera\n");
+        let ir = f.node("video2", &ir_if, "0\n", "IR Camera\n");
+        let meta = f.node("video3", &ir_if, "1\n", "IR Camera\n");
+        let t = f.resolve(Some((rgb, ir.clone()))).unwrap();
+        let canonical_ir = std::fs::canonicalize(&ir).unwrap();
+        let canonical_meta = std::fs::canonicalize(&meta).unwrap();
+        assert_eq!(t.endpoint(), canonical_ir.to_str().unwrap());
+        assert_eq!(t.metadata_endpoint(), canonical_meta.to_str());
+        assert_eq!(t.identity(), "046d:1234:fixture");
+        assert_eq!(
+            t.lease_endpoints(),
+            vec![
+                canonical_ir.to_str().unwrap(),
+                canonical_meta.to_str().unwrap()
+            ]
+        );
+        assert_eq!(
+            resolve_configured_pair_with(
+                Some((t.rgb_endpoint.clone(), t.endpoint.clone())),
+                &f.sysfs,
+                &f
+            )
+            .unwrap(),
+            t
+        );
+    }
+    #[test]
+    fn metadata_absence_is_explicit_and_does_not_discover() {
+        let f = Fixture::new("absent");
+        let rgb_if = f.interface("1-1:1.0", None);
+        let ir_if = f.interface("1-1:1.2", Some("046d\n"));
+        let rgb = f.node("video0", &rgb_if, "0\n", "RGB Camera\n");
+        let ir = f.node("video2", &ir_if, "0\n", "IR Camera\n");
+        let t = f.resolve(Some((rgb, ir))).unwrap();
+        assert_eq!(t.metadata_endpoint(), None);
+        assert_eq!(t.lease_endpoints().len(), 1);
+    }
+    #[test]
+    fn unsafe_or_ambiguous_topologies_fail_closed() {
+        assert_eq!(
+            resolve_configured_pair_with(None, Path::new("/missing"), &Fixture::new("unused")),
+            Err(IrTargetError::Unconfigured)
+        );
+        let f = Fixture::new("bad");
+        let rgb_if = f.interface("1-1:1.0", None);
+        let ir_if = f.interface("1-1:1.2", Some("046d\n"));
+        let rgb = f.node("video0", &rgb_if, "0\n", "RGB Camera\n");
+        let ir = f.node("video2", &ir_if, "0\n", "IR Camera\n");
+        assert!(matches!(
+            f.resolve(Some((ir.clone(), ir.clone()))),
+            Err(IrTargetError::InvalidEndpoint(_))
+        ));
+        let _ = f.node("video4", &ir_if, "2\n", "IR Camera\n");
+        assert!(matches!(
+            f.resolve(Some((rgb, ir))),
+            Err(IrTargetError::UnsupportedTopology(_))
+        ));
+    }
+    #[test]
+    fn revalidation_detects_renumbering_and_replacement() {
+        let f = Fixture::new("changed");
+        let rgb_if = f.interface("1-1:1.0", None);
+        let ir_if = f.interface("1-1:1.2", Some("046d\n"));
+        let rgb = f.node("video0", &rgb_if, "0\n", "RGB Camera\n");
+        let ir = f.node("video2", &ir_if, "0\n", "IR Camera\n");
+        let t = f.resolve(Some((rgb, ir))).unwrap();
+        std::fs::write(f.sysfs.join("video2/index"), "1\n").unwrap();
+        assert!(matches!(
+            resolve_configured_pair_with(
+                Some((t.rgb_endpoint.clone(), t.endpoint.clone())),
+                &f.sysfs,
+                &f
+            ),
+            Err(IrTargetError::Changed) | Err(IrTargetError::UnsupportedTopology(_))
+        ));
+    }
+
+    #[test]
+    fn binding_and_interface_ambiguity_are_never_guessed() {
+        let f = Fixture::new("binding");
+        let no_id = f.root.join("sys/devices/pci0000:00/usb2/2-1/2-1:1.2");
+        std::fs::create_dir_all(&no_id).unwrap();
+        let rgb_if = f.interface("1-1:1.0", None);
+        let rgb = f.node("video0", &rgb_if, "0\n", "RGB Camera\n");
+        let ir = f.node("video2", &no_id, "0\n", "IR Camera\n");
+        assert!(matches!(
+            f.resolve(Some((rgb, ir))),
+            Err(IrTargetError::BindingUnavailable(_))
+        ));
+
+        let f = Fixture::new("shared");
+        let interface = f.interface("1-1:1.0", Some("046d\n"));
+        let rgb = f.node("video0", &interface, "0\n", "RGB Camera\n");
+        let ir = f.node("video2", &interface, "0\n", "IR Camera\n");
+        assert!(matches!(
+            f.resolve(Some((rgb, ir))),
+            Err(IrTargetError::UnsupportedTopology(_))
+        ));
+    }
+
+    #[test]
+    fn metadata_must_be_the_same_name_index_one_companion() {
+        for (tag, index, name) in [
+            ("wrong-index", "2\n", "IR Camera\n"),
+            ("wrong-name", "1\n", "Other Camera\n"),
+        ] {
+            let f = Fixture::new(tag);
+            let rgb_if = f.interface("1-1:1.0", None);
+            let ir_if = f.interface("1-1:1.2", Some("046d\n"));
+            let rgb = f.node("video0", &rgb_if, "0\n", "RGB Camera\n");
+            let ir = f.node("video2", &ir_if, "0\n", "IR Camera\n");
+            let _metadata = f.node("video3", &ir_if, index, name);
+            assert!(matches!(
+                f.resolve(Some((rgb, ir))),
+                Err(IrTargetError::UnsupportedTopology(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn canonical_aliases_bind_to_the_sysfs_device_number() {
+        let f = Fixture::new("alias");
+        let rgb_if = f.interface("1-1:1.0", None);
+        let ir_if = f.interface("1-1:1.2", Some("046d\n"));
+        let rgb = f.node("video0", &rgb_if, "0\n", "RGB Camera\n");
+        let ir = f.node("video2", &ir_if, "0\n", "IR Camera\n");
+        let aliases = f.dev.join("by-id");
+        std::fs::create_dir_all(&aliases).unwrap();
+        let alias = aliases.join("configured-ir");
+        symlink(&ir, &alias).unwrap();
+        let target = f
+            .resolve(Some((rgb, alias.to_string_lossy().into_owned())))
+            .unwrap();
+        assert_eq!(
+            target.endpoint(),
+            std::fs::canonicalize(ir).unwrap().to_str().unwrap()
+        );
+    }
+
+    #[test]
+    fn path_and_sysfs_device_number_must_correspond() {
+        let f = Fixture::new("rdev");
+        let rgb_if = f.interface("1-1:1.0", None);
+        let ir_if = f.interface("1-1:1.2", Some("046d\n"));
+        let rgb = f.node("video0", &rgb_if, "0\n", "RGB Camera\n");
+        let ir = f.node("video2", &ir_if, "0\n", "IR Camera\n");
+        std::fs::write(f.sysfs.join("video2/dev"), "81:99\n").unwrap();
+        assert!(matches!(
+            f.resolve(Some((rgb, ir))),
+            Err(IrTargetError::InvalidEndpoint(_))
+        ));
+    }
+
+    #[test]
+    fn validated_open_routes_only_the_canonical_ir_endpoint() {
+        let f = Fixture::new("open-recorder");
+        let rgb_if = f.interface("1-1:1.0", None);
+        let ir_if = f.interface("1-1:1.2", Some("046d\n"));
+        let rgb = f.node("video0", &rgb_if, "0\n", "RGB Camera\n");
+        let ir = f.node("video2", &ir_if, "0\n", "IR Camera\n");
+        let target = f.resolve(Some((rgb, ir))).unwrap();
+        let opens = std::cell::RefCell::new(Vec::new());
+        target
+            .open_with(
+                || {
+                    resolve_configured_pair_with(
+                        Some((target.rgb_endpoint.clone(), target.endpoint.clone())),
+                        &f.sysfs,
+                        &f,
+                    )
+                    .map(|_| ())
+                },
+                |endpoint| {
+                    opens.borrow_mut().push(endpoint.to_owned());
+                    Ok(())
+                },
+            )
+            .unwrap();
+        assert_eq!(opens.into_inner(), [target.endpoint()]);
+    }
+
+    #[test]
+    fn target_capture_releases_before_the_final_control_check() {
+        use std::sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        };
+
+        struct CancelOnDrop(Arc<AtomicBool>);
+        impl Drop for CancelOnDrop {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let observed = cancelled.clone();
+        let control = crate::CaptureControl::new(
+            crate::no_progress(),
+            Arc::new(move || observed.load(Ordering::SeqCst)),
+        );
+        let result = finish_capture::<(), _>(
+            &control,
+            CancelOnDrop(cancelled.clone()),
+            Err(irlume_common::Error::Hardware("capture failed".into())),
+        );
+        assert!(cancelled.load(Ordering::SeqCst));
+        assert!(matches!(result, Err(irlume_common::Error::Preempted(_))));
+    }
+
+    const MISSING_IR: &str = "/definitely-missing-irlume-context-fixture/ir";
+
+    fn unopened_target() -> IrCaptureTarget {
+        IrCaptureTarget {
+            rgb_endpoint: "/definitely-missing-irlume-context-fixture/rgb".into(),
+            endpoint: MISSING_IR.into(),
+            metadata_endpoint: None,
+            identity: "fixture".into(),
+            interface: PathBuf::from("/definitely-missing-irlume-context-fixture/sysfs"),
+            image_name: "fixture IR".into(),
+            image_device: DeviceNumber(81, 2),
+            metadata_device: None,
+        }
+    }
+
+    #[test]
+    fn privacy_lookup_without_active_scope_waits_for_its_own_lease() {
+        crate::backend::tests::with_test_camera_operation(MISSING_IR, |_| {
+            assert!(crate::lease::active_permit(MISSING_IR).unwrap().is_none());
+            let started = std::time::Instant::now();
+            assert!(!crate::privacy_engaged(MISSING_IR));
+            let elapsed = started.elapsed();
+            eprintln!("unscoped privacy lookup elapsed: {elapsed:?}");
+            assert!(elapsed >= std::time::Duration::from_secs(2));
+        });
+    }
+
+    #[test]
+    fn target_capture_keeps_its_lease_active_for_nested_privacy_lookup() {
+        use std::sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        };
+        crate::backend::tests::with_test_camera_operation(MISSING_IR, |operation| {
+            let reused = Arc::new(AtomicBool::new(false));
+            let observed = reused.clone();
+            // Exercise the real helper before any V4L2 open. The existing
+            // cancellation callback observes the same scope used by capture.
+            let control = crate::CaptureControl::new(
+                crate::no_progress(),
+                Arc::new(move || {
+                    let started = std::time::Instant::now();
+                    assert!(!crate::privacy_engaged(MISSING_IR));
+                    eprintln!(
+                        "target-scoped privacy lookup elapsed: {:?}",
+                        started.elapsed()
+                    );
+                    observed.store(
+                        crate::lease::permit_for_endpoint(
+                            MISSING_IR,
+                            crate::lease::CameraOperationKind::Diagnostics,
+                            std::time::Duration::ZERO,
+                        )
+                        .is_ok_and(|lease| {
+                            lease.operation() == crate::lease::CameraOperationKind::Authentication
+                        }),
+                        Ordering::SeqCst,
+                    );
+                    true
+                }),
+            );
+            let result = unopened_target().capture_with_stats_and_control(operation, &control);
+            assert!(matches!(result, Err(irlume_common::Error::Preempted(_))));
+            assert!(
+                reused.load(Ordering::SeqCst),
+                "nested lookup lost the held operation"
+            );
+            assert!(crate::lease::active_permit(MISSING_IR).unwrap().is_none());
+            operation.lease().validate().unwrap();
+        });
+    }
+
+    #[test]
+    fn target_capture_retains_context_during_unwind_and_clears_it_afterward() {
+        use std::sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        };
+        struct ObserveDrop(Arc<AtomicBool>);
+        impl Drop for ObserveDrop {
+            fn drop(&mut self) {
+                self.0.store(
+                    crate::lease::active_permit(MISSING_IR).unwrap().is_some(),
+                    Ordering::SeqCst,
+                );
+            }
+        }
+        crate::backend::tests::with_test_camera_operation(MISSING_IR, |operation| {
+            let active_during_drop = Arc::new(AtomicBool::new(false));
+            let observed = active_during_drop.clone();
+            let control = crate::CaptureControl::new(
+                crate::no_progress(),
+                Arc::new(move || {
+                    let _drop = ObserveDrop(observed.clone());
+                    panic!("synthetic capture callback unwind");
+                }),
+            );
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                unopened_target().capture_with_stats_and_control(operation, &control)
+            }));
+            assert!(result.is_err());
+            assert!(active_during_drop.load(Ordering::SeqCst));
+            assert!(crate::lease::active_permit(MISSING_IR).unwrap().is_none());
+            operation.lease().validate().unwrap();
+        });
+    }
+
+    #[cfg(feature = "capture-timing")]
+    #[test]
+    fn target_capture_cleanup_uses_the_existing_release_timing_scope() {
+        let timings = crate::CaptureTimings::default();
+        let control = crate::CaptureControl::with_progress(crate::no_progress())
+            .with_capture_timings(Some(timings.clone()));
+        finish_capture(&control, (), Ok(())).unwrap();
+        let snapshot = timings.snapshot();
+        assert!(snapshot["session_release"].is_some());
+        assert!(snapshot["open"].is_none());
+        assert!(snapshot["frames"].is_none());
+    }
+}

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -31,6 +31,12 @@
 //! panic on some drivers. Probe, don't assume.
 
 mod backend;
+mod capture_control;
+mod capture_timing;
+pub use capture_control::CaptureControl;
+use capture_timing::Stage;
+#[cfg(feature = "capture-timing")]
+pub use capture_timing::{CaptureTimings, RateFillFailure};
 pub mod capture_qualification;
 pub mod census;
 /// Versioned, backend-neutral camera data contracts.
@@ -46,12 +52,17 @@ pub mod ir_emitter;
 /// (`fuzz/fuzz_targets/uvc_illumination.rs`, #568); the ioctls and the
 /// stream below it stay crate-internal.
 pub mod ir_metadata;
+mod ir_target;
+pub use ir_target::{configured_ir_target, IrCaptureTarget, IrTargetError};
 pub mod lease;
 mod lifecycle;
 mod media_graph;
 mod rate_gate;
 mod sequential_batch;
-pub use sequential_batch::{capture_sequential_batch_with_progress, SequentialBatchRequest};
+pub use sequential_batch::{
+    capture_sequential_batch_with_control, capture_sequential_batch_with_progress,
+    SequentialBatchRequest,
+};
 // Public for exactly one item, `pending_summary`, doctor's read-only view of
 // the store (#429); every record type stays crate-private so no other code
 // path grows a reader of these files.
@@ -660,18 +671,58 @@ enum PrivacyBoundary {
 }
 
 #[derive(Debug)]
-struct PrivacyBoundaryRefusal(String);
+struct PrivacyBoundaryRefusal {
+    why: String,
+    #[cfg(feature = "capture-timing")]
+    cause: Option<PrivacyBoundaryCause>,
+}
+
+#[cfg(feature = "capture-timing")]
+#[derive(Clone, Copy, Debug)]
+enum PrivacyBoundaryCause {
+    Engaged,
+    ReadFailure {
+        raw_errno: Option<i32>,
+        kind: std::io::ErrorKind,
+    },
+}
 
 impl std::fmt::Display for PrivacyBoundaryRefusal {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.0)
+        f.write_str(&self.why)
     }
 }
 
 impl std::error::Error for PrivacyBoundaryRefusal {}
 
+#[cfg(test)]
 fn privacy_boundary_error(why: String) -> std::io::Error {
-    std::io::Error::other(PrivacyBoundaryRefusal(why))
+    std::io::Error::other(PrivacyBoundaryRefusal {
+        why,
+        #[cfg(feature = "capture-timing")]
+        cause: None,
+    })
+}
+
+// Preserve the existing privacy decision and error text. Optional diagnostics
+// retain only the observation class before that decision formats its message.
+fn privacy_capture_boundary(observed: std::io::Result<Option<bool>>) -> std::io::Result<()> {
+    #[cfg(feature = "capture-timing")]
+    let cause = match &observed {
+        Ok(Some(true)) => Some(PrivacyBoundaryCause::Engaged),
+        Err(error) => Some(PrivacyBoundaryCause::ReadFailure {
+            raw_errno: error.raw_os_error(),
+            kind: error.kind(),
+        }),
+        _ => None,
+    };
+    privacy_permits_ir_capture(observed).map_err(|why| {
+        std::io::Error::other(PrivacyBoundaryRefusal {
+            why,
+            #[cfg(feature = "capture-timing")]
+            cause,
+        })
+    })
 }
 
 fn is_privacy_boundary_error(error: &std::io::Error) -> bool {
@@ -832,7 +883,7 @@ impl CameraState for V4l2CameraState {
                     ));
                 }
             }
-            privacy_permits_ir_capture(privacy_state(dev)).map_err(privacy_boundary_error)?;
+            privacy_capture_boundary(privacy_state(dev))?;
         }
         Ok(())
     }
@@ -1206,6 +1257,7 @@ struct CameraStateStream<'a, S: CameraState> {
     state_started: bool,
     stream_started_validated: bool,
     privacy_refused: bool,
+    timing: capture_timing::Recorder,
 }
 
 type SafeStream<'a> = CameraStateStream<'a, V4l2CameraState>;
@@ -1425,6 +1477,7 @@ impl<'a, S: CameraState> CameraStateStream<'a, S> {
             state_started: false,
             stream_started_validated: false,
             privacy_refused: false,
+            timing: capture_timing::Recorder::default(),
         };
         verify_stream_state(
             &stream.state,
@@ -1459,9 +1512,7 @@ impl<'a, S: CameraState> CameraStateStream<'a, S> {
             ..
         } = self;
         let inner = inner.as_mut().ok_or_else(|| {
-            ValidatedDequeueError::Io(std::io::Error::other(
-                "capture stream stopped after privacy refusal",
-            ))
+            ValidatedDequeueError::Io(std::io::Error::other(CaptureEvidenceError::StoppedStream))
         })?;
         let dequeued = match dequeue_validated_typed(inner, *layout, || {
             state.require_dequeue_boundary(dev)
@@ -1502,6 +1553,7 @@ impl<'a, S: CameraState> CameraStateStream<'a, S> {
         let Some(inner) = self.inner.take() else {
             return;
         };
+        let _timing = self.timing.stage(Stage::ImageStop);
         let device = self.device.clone();
         if std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || drop(inner))).is_err() {
             irlume_common::dlog!("{device}: stream teardown failed (STREAMOFF); frames unaffected");
@@ -1609,6 +1661,7 @@ const MAX_RATE_FILL_ATTEMPTS: usize = 64;
 
 struct TrackedStream<S> {
     stream: Option<S>,
+    control: CaptureControl,
     sequence: frame_provenance::SequenceTracker,
     timestamp: frame_provenance::TimestampTracker,
     rate_window: rate_gate::RateWindow,
@@ -1623,6 +1676,7 @@ impl<S> TrackedStream<S> {
     fn new(stream: S, rate_config: rate_gate::StreamRateConfig) -> Self {
         Self {
             stream: Some(stream),
+            control: CaptureControl::with_progress(no_progress()),
             sequence: frame_provenance::SequenceTracker::new(),
             timestamp: frame_provenance::TimestampTracker::new(),
             rate_window: rate_gate::RateWindow::with_capacity(rate_config.policy().window()),
@@ -1632,6 +1686,11 @@ impl<S> TrackedStream<S> {
             sequence_span_sum: 0,
             recovery_epoch_pending: false,
         }
+    }
+
+    fn with_control(mut self, control: &CaptureControl) -> Self {
+        self.control = control.clone();
+        self
     }
 
     #[cfg(test)]
@@ -1711,6 +1770,37 @@ impl TrackedStream<SafeStream<'_>> {
     }
 }
 
+// Keep internal capture failures typed until the public error boundary. The
+// existing I/O kind and Display text remain unchanged for ordinary callers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CaptureEvidenceError {
+    ContinuityAlignment,
+    ContinuityAccounting,
+    IncompleteWindow,
+    MissingStream,
+    StoppedStream,
+}
+
+impl std::fmt::Display for CaptureEvidenceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::ContinuityAlignment => {
+                "sequence/timestamp continuity diverged; explicit stream recovery required"
+            }
+            Self::ContinuityAccounting => {
+                "continuity observation accounting overflowed; explicit recovery required"
+            }
+            Self::IncompleteWindow => {
+                "could not establish delivered-rate evidence within the bounded fill"
+            }
+            Self::MissingStream => "capture stream missing after recovery",
+            Self::StoppedStream => "capture stream stopped after privacy refusal",
+        })
+    }
+}
+
+impl std::error::Error for CaptureEvidenceError {}
+
 fn account_continuity_observation(
     observations: &mut u64,
     discarded_observations: &mut u64,
@@ -1731,7 +1821,7 @@ fn account_continuity_observation(
     else {
         timestamp_tracker.fail_current_epoch();
         return Err(std::io::Error::other(
-            "continuity observation accounting overflowed; explicit recovery required",
+            CaptureEvidenceError::ContinuityAccounting,
         ));
     };
     *observations = next_observations;
@@ -1750,7 +1840,7 @@ fn ensure_continuity_alignment(
     {
         timestamp_tracker.fail_current_epoch();
         return Err(std::io::Error::other(
-            "sequence/timestamp continuity diverged; explicit stream recovery required",
+            CaptureEvidenceError::ContinuityAlignment,
         ));
     }
     Ok(())
@@ -1842,7 +1932,9 @@ fn begin_recovered_continuity_epoch(
 
 impl<S: ValidatedStream> TrackedStream<S> {
     fn next_discarded(&mut self) -> std::io::Result<()> {
+        self.control.check_io()?;
         let Self {
+            control,
             stream,
             sequence,
             timestamp,
@@ -1855,8 +1947,9 @@ impl<S: ValidatedStream> TrackedStream<S> {
         } = self;
         let dequeued = stream
             .as_mut()
-            .ok_or_else(|| std::io::Error::other("capture stream missing after recovery"))?
+            .ok_or_else(|| std::io::Error::other(CaptureEvidenceError::MissingStream))?
             .next_validated();
+        control.check_io()?;
         let (facts, delivered) = match dequeued {
             Ok((_, facts)) => {
                 begin_recovered_continuity_epoch(
@@ -1898,6 +1991,7 @@ impl<S: ValidatedStream> TrackedStream<S> {
     }
 
     fn fill_rate_evidence_with_startup(&mut self, adaptive_ir: bool) -> std::io::Result<()> {
+        self.control.check_io()?;
         if self.rate_window.ready() {
             return Ok(());
         }
@@ -1922,7 +2016,7 @@ impl<S: ValidatedStream> TrackedStream<S> {
         }
         if !self.rate_window.ready() {
             return Err(std::io::Error::other(
-                "could not establish delivered-rate evidence within the bounded fill",
+                CaptureEvidenceError::IncompleteWindow,
             ));
         }
         if adaptive_ir {
@@ -1960,6 +2054,7 @@ impl<S: ValidatedStream> TrackedStream<S> {
         self.fill_rate_evidence().map_err(DeliveryError::Io)?;
 
         let Self {
+            control,
             stream,
             sequence,
             timestamp,
@@ -1969,12 +2064,14 @@ impl<S: ValidatedStream> TrackedStream<S> {
             discarded_observations,
             sequence_span_sum,
             recovery_epoch_pending,
+            ..
         } = self;
         let dequeued = stream
             .as_mut()
-            .ok_or_else(|| std::io::Error::other("capture stream missing after recovery"))
+            .ok_or_else(|| std::io::Error::other(CaptureEvidenceError::MissingStream))
             .map_err(DeliveryError::Io)?
             .next_validated();
+        control.check_io().map_err(DeliveryError::Io)?;
         let (payload, facts) = match dequeued {
             Ok(frame) => frame,
             Err(ValidatedDequeueError::Corrupt(facts)) => {
@@ -2076,13 +2173,19 @@ impl IrSessionStartup {
     }
 
     fn fill<S: ValidatedStream>(self, stream: &mut TrackedStream<S>) -> std::io::Result<()> {
-        match self {
+        let result = match self {
             // The joint fill resets both windows and measures simultaneous
             // delivery. A solo IR window would only be thrown away there.
             Self::Paired => Ok(()),
             Self::Fixed => stream.fill_rate_evidence(),
             Self::Adaptive => stream.fill_rate_evidence_with_startup(true),
+        };
+        // Preserve the typed cause before map_io converts it to production prose.
+        #[cfg(feature = "capture-timing")]
+        if let Err(error) = &result {
+            stream.control.record_rate_fill_failure(error);
         }
+        result
     }
 }
 
@@ -2436,6 +2539,12 @@ fn camera_busy_error(device: &str, holders: Holders) -> Error {
 /// Map common io errors to actionable messages (linhello lesson: EBUSY/privacy
 /// are routine and need a clear cause, not a raw errno).
 fn map_io(device: &str, e: std::io::Error) -> Error {
+    if capture_control::is_expired(&e) {
+        return Error::DeadlineExpired;
+    }
+    if capture_control::is_cancelled(&e) {
+        return Error::Preempted("camera capture cancelled".into());
+    }
     use std::io::ErrorKind;
     match e.raw_os_error() {
         Some(libc::EBUSY) => camera_busy_error(device, camera_holders(device)),
@@ -3986,6 +4095,18 @@ impl RgbCamera {
         &self,
         progress: &Progress,
     ) -> irlume_common::Result<RgbSession<'_>> {
+        self.session_with_control(&CaptureControl::with_progress(progress.clone()))
+    }
+
+    /// Start an RGB session with cooperative request cancellation.
+    ///
+    /// # Errors
+    /// Returns cancellation before setup or the camera/lease errors of [`Self::session`].
+    pub fn session_with_control(
+        &self,
+        control: &CaptureControl,
+    ) -> irlume_common::Result<RgbSession<'_>> {
+        control.check()?;
         self.lease
             .require_endpoint(&self.device)
             .map_err(|error| Error::Hardware(error.to_string()))?;
@@ -4029,9 +4150,10 @@ impl RgbCamera {
                     self.requested_interval,
                     self.accepted_interval,
                 ),
-            ),
+            )
+            .with_control(control),
             warmed: false,
-            progress: progress.clone(),
+            progress: control.progress.clone(),
             _blc_restore: blc_restore,
             _session_slot: session_slot,
         })
@@ -4301,6 +4423,7 @@ impl<'a> RgbSession<'a> {
     /// Same drop-then-reopen shape as explicit IR session recovery.
     #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn recover(&mut self) -> irlume_common::Result<()> {
+        self.stream.control.check()?;
         self.cam
             .lease
             .require_endpoint(&self.cam.device)
@@ -4497,11 +4620,24 @@ pub fn capture_rgb_burst_with_progress(
     n: usize,
     progress: &Progress,
 ) -> irlume_common::Result<Vec<Frame>> {
+    capture_rgb_burst_with_control(device, n, &CaptureControl::with_progress(progress.clone()))
+}
+
+/// Capture an RGB burst with cooperative request cancellation.
+///
+/// # Errors
+/// Returns cancellation or the errors of [`capture_rgb_burst_with_progress`].
+pub fn capture_rgb_burst_with_control(
+    device: &str,
+    n: usize,
+    control: &CaptureControl,
+) -> irlume_common::Result<Vec<Frame>> {
+    control.check()?;
     let opened = std::time::Instant::now();
     let cam = RgbCamera::open(device)?;
     let open_ms = opened.elapsed().as_millis();
     let armed = std::time::Instant::now();
-    let mut session = cam.session_with_progress(progress)?;
+    let mut session = cam.session_with_control(control)?;
     let arm_ms = armed.elapsed().as_millis();
     let captured = std::time::Instant::now();
     let frames = session.burst(n);
@@ -4512,6 +4648,7 @@ pub fn capture_rgb_burst_with_progress(
         "{}",
         capture_stage_summary("rgb", device, open_ms, arm_ms, capture_ms)
     );
+    control.check()?;
     frames
 }
 
@@ -5051,6 +5188,19 @@ pub fn capture_rgb_denoised_with_progress(
     )?)
 }
 
+/// Capture a denoised RGB frame with cooperative request cancellation.
+///
+/// # Errors
+/// Returns cancellation or the errors of [`capture_rgb_denoised_with_progress`].
+pub fn capture_rgb_denoised_with_control(
+    device: &str,
+    control: &CaptureControl,
+) -> irlume_common::Result<Frame> {
+    let frame = median_frame(capture_rgb_burst_with_control(device, RGB_BURST, control)?)?;
+    control.check()?;
+    Ok(frame)
+}
+
 /// Per-pixel temporal median across same-sized frames (sorts each byte position
 /// across the burst, keeps the middle value). Returns the lone frame unchanged
 /// for a degenerate burst. Private on purpose: callers must pass at least one
@@ -5163,26 +5313,71 @@ pub fn capture_ir_sequential_with_stats_and_progress(
     capture_ir_with_startup(device, progress, IrSessionStartup::Adaptive)
 }
 
+/// Capture IR with cooperative request cancellation.
+///
+/// # Errors
+/// Returns cancellation or the errors of [`capture_ir_with_stats_and_progress`].
+pub fn capture_ir_with_stats_and_control(
+    device: &str,
+    control: &CaptureControl,
+) -> irlume_common::Result<(Frame, IrCaptureStats)> {
+    capture_ir_with_control_and_startup(device, control, IrSessionStartup::Fixed)
+}
+
+/// Capture sequential IR with cooperative request cancellation.
+///
+/// # Errors
+/// Returns cancellation or the errors of [`capture_ir_sequential_with_stats_and_progress`].
+pub fn capture_ir_sequential_with_stats_and_control(
+    device: &str,
+    control: &CaptureControl,
+) -> irlume_common::Result<(Frame, IrCaptureStats)> {
+    capture_ir_with_control_and_startup(device, control, IrSessionStartup::Adaptive)
+}
+
 fn capture_ir_with_startup(
     device: &str,
     progress: &Progress,
     startup: IrSessionStartup,
 ) -> irlume_common::Result<(Frame, IrCaptureStats)> {
+    capture_ir_with_control_and_startup(
+        device,
+        &CaptureControl::with_progress(progress.clone()),
+        startup,
+    )
+}
+
+fn capture_ir_with_control_and_startup(
+    device: &str,
+    control: &CaptureControl,
+    startup: IrSessionStartup,
+) -> irlume_common::Result<(Frame, IrCaptureStats)> {
+    control.check()?;
     let opened = std::time::Instant::now();
-    let cam = IrCamera::open(device)?;
+    let cam = {
+        let _timing = control.stage(Stage::Open);
+        IrCamera::open(device)?
+    };
     let open_ms = opened.elapsed().as_millis();
     let armed = std::time::Instant::now();
-    let mut session = cam.session_with_startup(progress, startup)?;
+    let mut session = cam.session_with_control_and_startup(control, startup)?;
     let arm_ms = armed.elapsed().as_millis();
     let captured = std::time::Instant::now();
-    let shot = session.capture_with_stats();
+    let shot = {
+        let _timing = control.stage(Stage::Frames);
+        session.capture_with_stats()
+    };
     let capture_ms = captured.elapsed().as_millis();
     // Drop the stream before `cam`: the session borrows the device.
-    drop(session);
+    {
+        let _timing = control.stage(Stage::SessionRelease);
+        drop(session);
+    }
     irlume_common::dlog!(
         "{}",
         capture_stage_summary("ir", device, open_ms, arm_ms, capture_ms)
     );
+    control.check()?;
     shot
 }
 
@@ -5353,14 +5548,82 @@ impl IrCamera {
         self.session_with_startup(progress, IrSessionStartup::Paired)
     }
 
+    /// Arm a paired IR session with cooperative request cancellation.
+    ///
+    /// # Errors
+    /// Returns cancellation or the errors of [`Self::session_for_pair_with_progress`].
+    pub fn session_for_pair_with_control(
+        &self,
+        control: &CaptureControl,
+    ) -> irlume_common::Result<IrSession<'_>> {
+        self.session_with_control_and_startup(control, IrSessionStartup::Paired)
+    }
+
     fn session_with_startup(
         &self,
         progress: &Progress,
         startup: IrSessionStartup,
     ) -> irlume_common::Result<IrSession<'_>> {
+        self.session_with_control_and_startup(
+            &CaptureControl::with_progress(progress.clone()),
+            startup,
+        )
+    }
+
+    fn session_with_control_and_startup(
+        &self,
+        control: &CaptureControl,
+        startup: IrSessionStartup,
+    ) -> irlume_common::Result<IrSession<'_>> {
+        self.session_with_control_startup_metadata(
+            control,
+            startup,
+            ir_metadata::MetadataSelection::Discover,
+        )
+    }
+
+    /// Start a fixed-startup IR-only session bound to a previously validated
+    /// configured target. The target is revalidated before any stream or
+    /// metadata endpoint is opened; explicit metadata absence never discovers.
+    ///
+    /// # Errors
+    /// Returns target-change, camera, metadata, privacy, emitter, or capture errors.
+    pub fn session_for_target_with_control<'a>(
+        &'a self,
+        target: &IrCaptureTarget,
+        control: &CaptureControl,
+    ) -> irlume_common::Result<IrSession<'a>> {
+        if self.device != target.endpoint() {
+            return Err(Error::Hardware(
+                "opened IR camera does not match validated target".into(),
+            ));
+        }
+        target
+            .validate()
+            .map_err(|error| Error::Hardware(error.to_string()))?;
+        self.session_with_control_startup_metadata(
+            control,
+            IrSessionStartup::Fixed,
+            target.metadata_selection(),
+        )
+    }
+
+    fn session_with_control_startup_metadata<'a>(
+        &'a self,
+        control: &CaptureControl,
+        startup: IrSessionStartup,
+        metadata: ir_metadata::MetadataSelection<'_>,
+    ) -> irlume_common::Result<IrSession<'a>> {
+        let _setup_timing = control.stage(Stage::SessionSetup);
+        control.check()?;
         self.lease
             .require_endpoint(&self.device)
             .map_err(|error| Error::Hardware(error.to_string()))?;
+        if let ir_metadata::MetadataSelection::Exact(endpoint) = metadata {
+            self.lease
+                .require_endpoint(endpoint)
+                .map_err(|error| Error::Hardware(error.to_string()))?;
+        }
         let session_slot = SessionSlot::acquire(&self.session_active, &self.device)?;
         // DECLARED before the stream so it drops AFTER it. Locals drop in
         // reverse declaration order, and `warm_up_stream` below can fail: with
@@ -5369,23 +5632,30 @@ impl IrCamera {
         // this change removes. Assigned further down, once the stream exists.
         let mode;
         let arm_alloc_started = std::time::Instant::now();
-        let mut stream = TrackedStream::new(
-            SafeStream::open(
-                V4l2CameraState::with_ir_interval(
+        let mut stream = {
+            let _timing = control.stage(Stage::Buffers);
+            TrackedStream::new(
+                SafeStream::open(
+                    V4l2CameraState::with_ir_interval(
+                        &self.device,
+                        self.lease.clone(),
+                        self.accepted_interval,
+                    ),
                     &self.device,
-                    self.lease.clone(),
+                    &self.dev,
+                    &self.negotiated,
+                )?,
+                rate_gate::StreamRateConfig::new(
+                    contracts::StreamRole::Ir,
+                    self.requested_interval,
                     self.accepted_interval,
                 ),
-                &self.device,
-                &self.dev,
-                &self.negotiated,
-            )?,
-            rate_gate::StreamRateConfig::new(
-                contracts::StreamRole::Ir,
-                self.requested_interval,
-                self.accepted_interval,
-            ),
-        );
+            )
+        };
+        stream.control = control.clone();
+        if let Some(inner) = stream.stream.as_mut() {
+            inner.timing = capture_timing::Recorder::from_control(control);
+        }
         let alloc_ms = arm_alloc_started.elapsed().as_millis();
         // The metadata queue has to be streaming before the image queue starts,
         // or uvcvideo produces no metadata at all (measured: zero bytes over
@@ -5393,7 +5663,12 @@ impl IrCamera {
         // buffers; STREAMON happens on the first dequeue, inside ordinary
         // warm-up below or the paired joint fill. Metadata must start here.
         let meta_started = std::time::Instant::now();
-        let mut meta = ir_metadata::IlluminationLog::open(&self.device);
+        let mut meta = {
+            let _timing = control.stage(Stage::Metadata);
+            ir_metadata::IlluminationLog::open_selected(&self.device, metadata)
+                .map_err(|reason| Error::Hardware(format!("{}: {reason}", self.device)))?
+                .map(|log| log.with_timing(capture_timing::Recorder::from_control(control)))
+        };
         let metadata_ms = meta_started.elapsed().as_millis();
         // BEFORE any image dequeue, because the first dequeue is STREAMON.
         // Microsoft's sequence sets the property and THEN starts streaming, and
@@ -5420,31 +5695,42 @@ impl IrCamera {
             .require_endpoint(&self.device)
             .map_err(|error| Error::Hardware(error.to_string()))?;
         let emitter_started = std::time::Instant::now();
-        mode = enable_ir_emitter_privacy_bounded(
-            &self.device,
-            &self.dev,
-            &self.card,
-            self.lease.clone(),
-            "before Face Authentication D1",
-        )?;
+        control.check()?;
+        mode = {
+            let _timing = control.stage(Stage::Emitter);
+            enable_ir_emitter_privacy_bounded(
+                &self.device,
+                &self.dev,
+                &self.card,
+                self.lease.clone(),
+                "before Face Authentication D1",
+            )?
+            .with_timing(capture_timing::Recorder::from_control(control))
+        };
         let emitter_ms = emitter_started.elapsed().as_millis();
         // Survive the first-capture-after-resume race (uvcvideo still
         // re-initializing).
         let warmup_started = std::time::Instant::now();
-        startup.warm_up(&self.device, &mut stream, progress)?;
+        {
+            let _timing = control.stage(Stage::Warmup);
+            startup.warm_up(&self.device, &mut stream, &control.progress)?;
+        }
         let warmup_ms = warmup_started.elapsed().as_millis();
         // Rate establishment internally discards more frames than the metadata
         // ring can hold. Drain those records now, after the fill, so buffers are
         // requeued before the first frame a caller can observe.
         let fill_started = std::time::Instant::now();
-        let fill_result = fill_rate_then_drain_metadata(
-            || startup.fill(&mut stream),
-            || {
-                if let Some(log) = meta.as_mut() {
-                    log.drain();
-                }
-            },
-        );
+        let fill_result = {
+            let _timing = control.stage(Stage::RateFill);
+            fill_rate_then_drain_metadata(
+                || startup.fill(&mut stream),
+                || {
+                    if let Some(log) = meta.as_mut() {
+                        log.drain();
+                    }
+                },
+            )
+        };
         let fill_ms = fill_started.elapsed().as_millis();
         irlume_common::dlog!(
             "[capture-stage] ir-arm {}: alloc={alloc_ms}ms metadata={metadata_ms}ms \
@@ -5920,6 +6206,7 @@ impl IrSession<'_> {
     /// grace window returned dark IR frames.
     #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn recover(&mut self) -> irlume_common::Result<()> {
+        self.stream.control.check()?;
         self.cam
             .lease
             .require_endpoint(&self.cam.device)
@@ -9366,6 +9653,9 @@ where
         match next() {
             Ok(()) => return Ok(()),
             Err(e) => {
+                if capture_control::is_expired(&e) {
+                    return Err(Error::DeadlineExpired);
+                }
                 // The window COMPLETED: the driver call came back, the thread
                 // was never stuck, and the watchdog clock resets before the
                 // caller spends unbounded time (inference, a retry's reopen)
@@ -9395,6 +9685,9 @@ where
 
 #[cfg(test)]
 mod tests {
+    mod capture_cancellation_tests {
+        include!("capture_cancellation_tests.rs");
+    }
     mod sequential_batch_tests {
         include!("sequential_batch_tests.rs");
     }
@@ -10311,6 +10604,26 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "capture-timing")]
+    #[test]
+    fn teardown_timing_image_stop_preserves_cleanup_and_is_idempotent() {
+        let format = fake_format(b"GREY");
+        let (state, calls) = FakeCameraState::new(format);
+        let timings = CaptureTimings::default();
+        let control = CaptureControl::with_progress(no_progress())
+            .with_capture_timings(Some(timings.clone()));
+        let mut stream = CameraStateStream::open(state, "/dev/fake", &(), &format).unwrap();
+        stream.timing = capture_timing::Recorder::from_control(&control);
+        stream.stop();
+        let stopped = timings.snapshot();
+        assert!(stopped["image_stop"].is_some());
+        assert!(calls.borrow().ends_with(&["cleanup", "stop"]));
+        let count = calls.borrow().len();
+        drop(stream);
+        assert_eq!(calls.borrow().len(), count);
+        assert_eq!(timings.snapshot(), stopped);
+    }
+
     #[test]
     fn every_stream_endpoint_boundary_fails_closed_and_tears_down() {
         let format = fake_format(b"GREY");
@@ -10877,6 +11190,205 @@ mod tests {
             },
             rate_gate::StreamRateConfig::new(role, interval, interval),
         )
+    }
+
+    #[test]
+    fn capture_evidence_errors_keep_existing_io_contract() {
+        let cases = [
+            (
+                CaptureEvidenceError::ContinuityAlignment,
+                "sequence/timestamp continuity diverged; explicit stream recovery required",
+            ),
+            (
+                CaptureEvidenceError::ContinuityAccounting,
+                "continuity observation accounting overflowed; explicit recovery required",
+            ),
+            (
+                CaptureEvidenceError::IncompleteWindow,
+                "could not establish delivered-rate evidence within the bounded fill",
+            ),
+            (
+                CaptureEvidenceError::MissingStream,
+                "capture stream missing after recovery",
+            ),
+            (
+                CaptureEvidenceError::StoppedStream,
+                "capture stream stopped after privacy refusal",
+            ),
+        ];
+        for (site, expected) in cases {
+            let error = std::io::Error::other(site);
+            assert_eq!(error.kind(), std::io::ErrorKind::Other);
+            assert_eq!(error.to_string(), expected);
+            assert!(
+                matches!(map_io("synthetic", error), irlume_common::Error::Hardware(message) if message == format!("synthetic: {expected}"))
+            );
+        }
+    }
+
+    #[cfg(feature = "capture-timing")]
+    #[test]
+    fn rate_fill_detail_preserves_accounting_and_missing_stream_guards() {
+        for missing in [false, true] {
+            let timings = CaptureTimings::default();
+            let control = CaptureControl::with_progress(no_progress())
+                .with_capture_timings(Some(timings.clone()));
+            let mut stream =
+                rate_fill_fixture(contracts::StreamRole::Ir, 120, 66_667).with_control(&control);
+            if missing {
+                stream.take();
+            } else {
+                stream.observations = u64::MAX;
+            }
+            let error = IrSessionStartup::Fixed.fill(&mut stream).unwrap_err();
+            assert_eq!(error.kind(), std::io::ErrorKind::Other);
+            let expected = if missing {
+                "camera_rate_fill_missing_stream"
+            } else {
+                "camera_rate_fill_continuity_accounting"
+            };
+            assert_eq!(timings.rate_fill_failure().unwrap().as_str(), expected);
+            if !missing {
+                assert_eq!(stream.observations, u64::MAX);
+                assert!(stream.timestamp.epoch_failed_for_test());
+            }
+            assert!(stream.next().is_err());
+        }
+    }
+
+    #[cfg(feature = "capture-timing")]
+    #[test]
+    fn rate_fill_detail_preserves_failed_continuity_after_warmup() {
+        let timings = CaptureTimings::default();
+        let control = CaptureControl::with_progress(no_progress())
+            .with_capture_timings(Some(timings.clone()));
+        let mut stream =
+            rate_fill_fixture(contracts::StreamRole::Ir, 120, 66_667).with_control(&control);
+        IrSessionStartup::Fixed
+            .warm_up("synthetic", &mut stream, &no_progress())
+            .unwrap();
+        assert!(stream.observations > 0);
+        let frames = &mut stream.stream_mut().unwrap().metadata;
+        frames[2].sequence = frames[1].sequence;
+        let error = IrSessionStartup::Fixed.fill(&mut stream).unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::Other);
+        assert_eq!(
+            error.to_string(),
+            "sequence/timestamp continuity diverged; explicit stream recovery required"
+        );
+        assert_eq!(
+            timings.rate_fill_failure().unwrap().as_str(),
+            "camera_rate_fill_continuity_alignment"
+        );
+        assert!(stream.timestamp.epoch_failed_for_test());
+        assert!(
+            stream.next().is_err(),
+            "failed continuity must never heal implicitly"
+        );
+    }
+
+    #[cfg(feature = "capture-timing")]
+    #[test]
+    fn rate_fill_detail_preserves_bounded_corrupt_window_failure() {
+        let timings = CaptureTimings::default();
+        let control = CaptureControl::with_progress(no_progress())
+            .with_capture_timings(Some(timings.clone()));
+        let mut stream =
+            rate_fill_fixture(contracts::StreamRole::Ir, 120, 66_667).with_control(&control);
+        for metadata in &mut stream.stream_mut().unwrap().metadata {
+            metadata.flags |= v4l::buffer::Flags::ERROR;
+        }
+        let error = IrSessionStartup::Fixed.fill(&mut stream).unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::Other);
+        assert_eq!(
+            error.to_string(),
+            "could not establish delivered-rate evidence within the bounded fill"
+        );
+        assert_eq!(
+            timings.rate_fill_failure().unwrap().as_str(),
+            "camera_rate_fill_incomplete_window"
+        );
+        assert_eq!(
+            stream.observations,
+            u64::try_from(
+                rate_gate::startup_flush(contracts::StreamRole::Ir) + MAX_RATE_FILL_ATTEMPTS
+            )
+            .unwrap()
+        );
+        assert!(!stream.rate_window.ready());
+    }
+
+    #[cfg(feature = "capture-timing")]
+    #[test]
+    fn rate_fill_diagnostic_records_typed_failure_without_changing_failed_stream() {
+        let timings = CaptureTimings::default();
+        let untouched = CaptureTimings::default();
+        let control = CaptureControl::with_progress(no_progress())
+            .with_capture_timings(Some(timings.clone()));
+        let mut stream =
+            rate_fill_fixture(contracts::StreamRole::Ir, 100, 66_667).with_control(&control);
+        // The fifth dequeue repeats the previous timestamp during Fixed startup.
+        stream.stream_mut().unwrap().metadata[4].timestamp =
+            stream.stream_mut().unwrap().metadata[3].timestamp;
+        let mut drained = false;
+        let error = fill_rate_then_drain_metadata(
+            || IrSessionStartup::Fixed.fill(&mut stream),
+            || drained = true,
+        )
+        .unwrap_err();
+        assert!(!drained, "failed fill must not drain metadata");
+        assert!(matches!(
+            error
+                .get_ref()
+                .unwrap()
+                .downcast_ref::<frame_provenance::TimestampTrackerError>(),
+            Some(frame_provenance::TimestampTrackerError::NonIncreasing { .. })
+        ));
+        assert_eq!(
+            timings.rate_fill_failure(),
+            Some(RateFillFailure::TimestampNonIncreasing)
+        );
+        assert_eq!(untouched.rate_fill_failure(), None);
+        assert!(
+            stream.next().is_err(),
+            "instrumentation must not heal the failed epoch"
+        );
+    }
+
+    #[cfg(feature = "capture-timing")]
+    #[test]
+    fn rate_fill_diagnostic_preserves_success_and_control_refusals() {
+        for cancel in [false, true] {
+            let timings = CaptureTimings::default();
+            let control = CaptureControl::new(no_progress(), std::sync::Arc::new(move || cancel))
+                .with_capture_timings(Some(timings.clone()));
+            let mut stream =
+                rate_fill_fixture(contracts::StreamRole::Ir, 100, 66_667).with_control(&control);
+            let result = IrSessionStartup::Fixed.fill(&mut stream);
+            if cancel {
+                assert!(matches!(
+                    result.map_err(|error| map_io("synthetic", error)),
+                    Err(irlume_common::Error::Preempted(_))
+                ));
+                assert_eq!(stream.observations, 0);
+            } else {
+                result.unwrap();
+                assert!(stream.next().is_ok());
+                assert_eq!(timings.rate_fill_failure(), None);
+            }
+        }
+        let control = CaptureControl::with_progress(no_progress())
+            .with_deadline(Some(std::time::Instant::now()))
+            .with_capture_timings(Some(CaptureTimings::default()));
+        let mut stream =
+            rate_fill_fixture(contracts::StreamRole::Ir, 100, 66_667).with_control(&control);
+        assert!(matches!(
+            IrSessionStartup::Fixed
+                .fill(&mut stream)
+                .map_err(|error| map_io("synthetic", error)),
+            Err(irlume_common::Error::DeadlineExpired)
+        ));
+        assert_eq!(stream.observations, 0);
     }
 
     #[test]
@@ -15099,6 +15611,22 @@ mod tests {
 
         assert!(privacy_permits_ir_capture(Ok(Some(false))).is_ok());
         assert!(privacy_permits_ir_capture(Ok(None)).is_ok());
+    }
+
+    #[test]
+    fn privacy_capture_boundary_preserves_legacy_messages_and_decisions() {
+        let expected = "the hardware privacy shutter is engaged (the `privacy` control reads 1); refusing IR capture and any forward emitter write";
+        let error = privacy_capture_boundary(Ok(Some(true))).unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::Other);
+        assert_eq!(error.to_string(), expected);
+        assert!(is_privacy_boundary_error(&error));
+        let error =
+            privacy_capture_boundary(Err(std::io::Error::other("private fixture"))).unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::Other);
+        assert_eq!(error.to_string(), "could not read the hardware privacy control (private fixture); refusing IR capture and any forward emitter write while the shutter state is unknown");
+        assert!(is_privacy_boundary_error(&error));
+        assert!(privacy_capture_boundary(Ok(Some(false))).is_ok());
+        assert!(privacy_capture_boundary(Ok(None)).is_ok());
     }
 
     #[test]

--- a/crates/irlume-camera/src/sequential_batch.rs
+++ b/crates/irlume-camera/src/sequential_batch.rs
@@ -1,4 +1,6 @@
-use super::{Frame, IrCamera, IrCaptureStats, Progress, RgbCamera, RuntimePairContract};
+use super::{
+    CaptureControl, Frame, IrCamera, IrCaptureStats, Progress, RgbCamera, RuntimePairContract,
+};
 use irlume_common::{Error, Result};
 use std::time::{Duration, Instant};
 
@@ -30,18 +32,41 @@ pub fn capture_sequential_batch_with_progress(
     request: SequentialBatchRequest,
     progress: &Progress,
 ) -> Result<Vec<(Frame, Frame, IrCaptureStats)>> {
-    capture_batch_with(
+    capture_sequential_batch_with_control(
+        rgb,
+        ir,
+        contract,
+        request,
+        &CaptureControl::with_progress(progress.clone()),
+    )
+}
+
+/// Collect a sequential batch with cooperative request cancellation.
+///
+/// # Errors
+/// Returns cancellation without partial evidence, or any error documented by
+/// [`capture_sequential_batch_with_progress`]. Existing stream owners clean up
+/// before another phase or downstream inference can run.
+pub fn capture_sequential_batch_with_control(
+    rgb: &RgbCamera,
+    ir: &IrCamera,
+    contract: &RuntimePairContract,
+    request: SequentialBatchRequest,
+    control: &CaptureControl,
+) -> Result<Vec<(Frame, Frame, IrCaptureStats)>> {
+    capture_batch_controlled_with(
         request,
         contract,
         (
-            || rgb.session_with_progress(progress),
+            || rgb.session_with_control(control),
             |session| session.denoised(),
         ),
         (
-            || ir.session_with_startup(progress, super::IrSessionStartup::Adaptive),
+            || ir.session_with_control_and_startup(control, super::IrSessionStartup::Adaptive),
             |session| session.capture_with_stats(),
         ),
         Instant::now,
+        control,
         || {
             rgb.lease
                 .require_endpoint(&rgb.device)
@@ -51,6 +76,7 @@ pub fn capture_sequential_batch_with_progress(
     )
 }
 
+#[cfg(test)]
 pub(super) fn capture_batch_with<R, I>(
     request: SequentialBatchRequest,
     contract: &RuntimePairContract,
@@ -65,12 +91,39 @@ pub(super) fn capture_batch_with<R, I>(
     now: impl Fn() -> Instant,
     live: impl FnOnce() -> Result<()>,
 ) -> Result<Vec<(Frame, Frame, IrCaptureStats)>> {
+    capture_batch_controlled_with(
+        request,
+        contract,
+        rgb,
+        ir,
+        now,
+        &CaptureControl::with_progress(super::no_progress()),
+        live,
+    )
+}
+
+pub(super) fn capture_batch_controlled_with<R, I>(
+    request: SequentialBatchRequest,
+    contract: &RuntimePairContract,
+    rgb: (
+        impl FnOnce() -> Result<R>,
+        impl FnMut(&mut R) -> Result<Frame>,
+    ),
+    ir: (
+        impl FnOnce() -> Result<I>,
+        impl FnMut(&mut I) -> Result<(Frame, IrCaptureStats)>,
+    ),
+    now: impl Fn() -> Instant,
+    control: &CaptureControl,
+    live: impl FnOnce() -> Result<()>,
+) -> Result<Vec<(Frame, Frame, IrCaptureStats)>> {
     if !(1..=5).contains(&request.pairs) {
         return Err(Error::Hardware(
             "sequential batch requires one through five pairs".into(),
         ));
     }
     let checkpoint = || {
+        control.check()?;
         if now() >= request.deadline {
             Err(Error::Hardware("sequential batch deadline expired".into()))
         } else {

--- a/crates/irlume-camera/src/sequential_batch_tests.rs
+++ b/crates/irlume-camera/src/sequential_batch_tests.rs
@@ -380,3 +380,34 @@ fn batch_rejects_each_real_runtime_contract_failure() {
         }
     }
 }
+
+#[test]
+fn capture_cancellation_releases_rgb_and_never_opens_ir_batch() {
+    use std::sync::{atomic::{AtomicBool, Ordering}, Arc};
+    let mut fixture = BatchFixture::new(1);
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let signal = cancelled.clone();
+    let control = CaptureControl::new(no_progress(), Arc::new(move || signal.load(Ordering::SeqCst)));
+    let events = &fixture.events;
+    let now = &fixture.now;
+    let deadline = fixture.request.deadline;
+    let contract = runtime_gate_contract();
+    let result = crate::sequential_batch::capture_batch_controlled_with(
+        fixture.request,
+        &contract,
+        (|| {
+            events.borrow_mut().push("rgb open".into());
+            Ok(Owner { role: "rgb", events, now, expire_on_drop: false, deadline })
+        }, |_owner| {
+            cancelled.store(true, Ordering::SeqCst);
+            Ok(fixture.rgb.pop_front().unwrap())
+        }),
+        (|| -> irlume_common::Result<()> { panic!("IR must not open after cancellation") },
+         |_owner| -> irlume_common::Result<(Frame, IrCaptureStats)> { panic!("IR must not capture") }),
+        || now.get(),
+        &control,
+        || panic!("cancelled partial batch must not be validated"),
+    );
+    assert!(matches!(result, Err(Error::Preempted(_))));
+    assert_eq!(*events.borrow(), ["rgb open", "rgb close"]);
+}

--- a/crates/irlume-cli/Cargo.toml
+++ b/crates/irlume-cli/Cargo.toml
@@ -24,7 +24,7 @@ libc.workspace = true   # restore default SIGPIPE so `irlume … | head` doesn't
 rand.workspace = true   # session and operation identifiers for the machine event stream
 image = { workspace = true }
 rpassword = "7"   # no-echo password prompt for `keyring arm`
-ratatui = "0.30"  # TUI (MIT), bundles crossterm; powers `irlume tui`
+ratatui = { version = "0.30", features = ["unstable-rendered-line-info"] }  # TUI (MIT), bundles crossterm; powers `irlume tui`
 
 [lints]
 workspace = true

--- a/crates/irlume-cli/src/commands.rs
+++ b/crates/irlume-cli/src/commands.rs
@@ -816,8 +816,8 @@ pub fn status(args: &[String]) -> ExitCode {
                 // Reporting this as plaintext both understates the posture and
                 // hides that the enrollment is gone.
                 (true, false) => format!(
-                    "encrypted, but the TEMPLATE KEY IS MISSING {WARN} \
-                     (unreadable; re-enroll)"
+                    "encrypted, but the TEMPLATE KEY IS MISSING {WARN} ({})",
+                    crate::recovery::missing_key_advice(recovery_set)
                 ),
                 (false, _) => format!("plaintext {WARN} (run `irlume recovery setup`)"),
             }
@@ -832,10 +832,21 @@ pub fn status(args: &[String]) -> ExitCode {
         );
     }
 
+    // The daemon can observe root-only preferences for ordinary CLI users.
+    let (preferences, preference_source) = crate::preferences::observed();
+    println!("  preferences   : {preference_source}");
+    println!(
+        "  hands-free    : {}",
+        crate::preferences::toggle_label(
+            preferences
+                .privileged_face_consent
+                .map(|required| !required)
+        )
+    );
     // Biopolicy enforcement (opt-in).
     println!(
         "  biopolicy     : {}",
-        match irlume_common::config::enforce_biopolicy_visible() {
+        match preferences.enforce_biopolicy {
             Some(true) => format!("ENFORCING {OK} (operation-class gate)"),
             Some(false) => "off (default)".into(),
             None => "unknown: root-only setting, re-run with sudo".into(),
@@ -1519,17 +1530,20 @@ pub fn deps(_args: &[String]) -> ExitCode {
 /// so enabling it can restrict which services a face may satisfy but never
 /// locks anyone out.
 pub fn biopolicy(sub: Option<&str>, _args: &[String]) -> ExitCode {
-    let visible = irlume_common::config::enforce_biopolicy_visible();
     match sub {
         None | Some("status") => {
+            let (state, source) = crate::preferences::observed();
             println!(
-                "[biopolicy] operation-class gate: {}",
-                match visible {
+                "[biopolicy] operation-class gate: {} ({source})",
+                match state.enforce_biopolicy {
                     Some(true) => "ENFORCING",
                     Some(false) => "off (default)",
-                    None => "unknown: root-only setting, re-run with sudo",
+                    None => "unknown: settings unavailable",
                 }
             );
+            if state.biopolicy_overridden {
+                println!("Observed policy includes an environment override; the saved setting may differ.");
+            }
             ExitCode::SUCCESS
         }
         Some(v @ ("on" | "off")) => {
@@ -1537,8 +1551,23 @@ pub fn biopolicy(sub: Option<&str>, _args: &[String]) -> ExitCode {
                 eprintln!("[biopolicy] needs root: sudo irlume biopolicy {v}");
                 return ExitCode::FAILURE;
             }
+            if std::env::var_os("IRLUME_ENFORCE_BIOPOLICY").is_some() {
+                eprintln!(
+                    "[biopolicy] remove the environment override before changing the saved setting"
+                );
+                return ExitCode::FAILURE;
+            }
             let val = if v == "on" { "1" } else { "0" };
-            match irlume_common::config::write_kv("settings.conf", "enforce_biopolicy", val) {
+            let update = || -> std::io::Result<()> {
+                let _lock = irlume_common::config::lock_exclusive("settings.conf")?;
+                if let irlume_common::config::KvObservation::Unknown(error) =
+                    irlume_common::config::observe_kv("settings.conf", "enforce_biopolicy")
+                {
+                    return Err(error);
+                }
+                irlume_common::config::write_kv("settings.conf", "enforce_biopolicy", val)
+            };
+            match update() {
                 Ok(()) => {
                     println!(
                         "[biopolicy] operation-class gate {} (takes effect on the next face auth; \
@@ -1914,7 +1943,7 @@ SYSTEM INTEGRATION
                         subcommands are removed (ADR-0015) and answer with a notice
   auth consent [status]         show privileged face-confirmation policy
   auth sensor status            show the saved/daemon-observed face sensor policy
-  auth sensor preflight [user]  camera-free experimental IR prerequisites
+  auth sensor preflight [--user U]  camera-free experimental IR prerequisites
   auth sensor dual              restore dual sensors (sudo; no PAM changes)
   auth sensor ir-only --yes      select EXPERIMENTAL IR-only (sudo; not qualified)
   auth consent required         require confirmation (default; sudo)

--- a/crates/irlume-cli/src/commands.rs
+++ b/crates/irlume-cli/src/commands.rs
@@ -8,6 +8,7 @@
 //! the daemon stays the only component that touches the camera / TPM / store.
 
 use crate::{daemon_request, tpm_device, user_arg};
+use irlume_common::platform::SystemCommand;
 use irlume_common::{Request, Response};
 use std::process::ExitCode;
 
@@ -688,6 +689,7 @@ fn usable_scans(profiles: &[irlume_common::ProfileSummary]) -> Option<usize> {
 pub fn status(args: &[String]) -> ExitCode {
     let user = user_arg(args);
     println!("irlume status for '{user}'");
+    println!("  face sensors  : {}", crate::sensor_policy::status_line());
 
     // Daemon + method.
     let reach = daemon_reach();
@@ -1195,16 +1197,7 @@ fn selinux_present() -> bool {
     if std::path::Path::new("/sys/fs/selinux").exists() {
         return true;
     }
-    // Honor PATH (the integration tests inject a fake `semodule` there; a
-    // real SELinux box also may not have it in the fixed /usr slots).
-    if let Ok(path) = std::env::var("PATH") {
-        for dir in std::env::split_paths(&path) {
-            if dir.join("semodule").exists() {
-                return true;
-            }
-        }
-    }
-    false
+    SystemCommand::Semodule.path().is_some()
 }
 
 /// `irlume selinux <status|load>`: manage the policy module that lets the
@@ -1234,7 +1227,12 @@ pub fn selinux(sub: Option<&str>, _args: &[String]) -> ExitCode {
             // `semodule -l` needs root; as a normal user it returns nothing, so
             // an empty list ≠ "not loaded". The live socket label is a reliable
             // positive signal either way (only our type_transition sets it).
-            let out = std::process::Command::new("semodule").args(["-l"]).output();
+            let out = SystemCommand::Semodule.path().and_then(|semodule| {
+                std::process::Command::new(semodule)
+                    .args(["-l"])
+                    .output()
+                    .ok()
+            });
             let listed = out
                 .as_ref()
                 .map(|o| o.status.success() && !o.stdout.is_empty())
@@ -1300,9 +1298,19 @@ pub fn selinux(sub: Option<&str>, _args: &[String]) -> ExitCode {
                 return ExitCode::FAILURE;
             };
             eprintln!("[selinux] semodule -i {pp} (needs root)…");
-            let st = std::process::Command::new("semodule")
-                .args(["-i", &pp])
-                .status();
+            let st = SystemCommand::Semodule
+                .path()
+                .map(|semodule| {
+                    std::process::Command::new(semodule)
+                        .args(["-i", &pp])
+                        .status()
+                })
+                .unwrap_or_else(|| {
+                    Err(std::io::Error::new(
+                        std::io::ErrorKind::NotFound,
+                        "trusted semodule executable not found",
+                    ))
+                });
             match st {
                 Ok(s) if s.success() => {
                     // Loading the module is half the job: the bound socket
@@ -1588,12 +1596,21 @@ pub fn reseal(args: &[String]) -> ExitCode {
     let Some(pw) = prompt_login_password() else {
         return ExitCode::from(2);
     };
+    let wallet_salt = match irlume_common::client::read_wallet_salt(&user) {
+        Ok(salt) => salt,
+        Err(e) => {
+            eprintln!("[reseal] failed: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
     let req = Request::SealPassword {
         kind: None, // let the daemon judge from what the user has
         user,
         // Copy the bytes out rather than moving the `String`: `Zeroizing` owns
         // the buffer and wipes it on drop, and `SecretBytes` wipes the copy.
         password: irlume_common::SecretBytes::new(pw.as_bytes().to_vec()),
+        wallet_salt,
+        wallet_salt_checked: true,
     };
     match daemon_request(&req) {
         Ok(Response::PasswordSealed) => {
@@ -1700,6 +1717,13 @@ pub fn setup(args: &[String]) -> ExitCode {
         /* default_yes: */ true,
     ) {
         if let Some(pw) = prompt_login_password() {
+            let wallet_salt = match irlume_common::client::read_wallet_salt(&user) {
+                Ok(salt) => salt,
+                Err(e) => {
+                    eprintln!("  arm failed: {e}");
+                    return ExitCode::FAILURE;
+                }
+            };
             match daemon_request(&Request::SealPassword {
                 kind: None, // let the daemon judge from what the user has
                 user: user.clone(),
@@ -1707,6 +1731,8 @@ pub fn setup(args: &[String]) -> ExitCode {
                 // so the bytes are copied rather than moved. The old `.clone()`
                 // here left a whole second password on the heap unwiped.
                 password: irlume_common::SecretBytes::new(pw.as_bytes().to_vec()),
+                wallet_salt,
+                wallet_salt_checked: true,
             }) {
                 Ok(Response::PasswordSealed) => println!("  armed {OK}"),
                 // GNOME token arm: the wizard runs in the user's session, so
@@ -1853,6 +1879,8 @@ KEYRING / TPM
   reseal                re-bind the sealed secret to current PCRs (after a
                         firmware/kernel update); safe, re-enters the password
   recovery <status|setup|restore|forget>   recovery passphrase + encryption
+  retry <status|reset> [--user U]         inspect/reset face retry state
+                        reset verifies your local password; root is an admin override
   diag                  TPM seal + PCR-drift diagnostics (run with sudo for detail)
 
 SYSTEM INTEGRATION
@@ -1884,6 +1912,14 @@ SYSTEM INTEGRATION
                         keyed on (#575; the hardware-report attachment)
   models list --json           machine model listing; all other models
                         subcommands are removed (ADR-0015) and answer with a notice
+  auth consent [status]         show privileged face-confirmation policy
+  auth sensor status            show the saved/daemon-observed face sensor policy
+  auth sensor preflight [user]  camera-free experimental IR prerequisites
+  auth sensor dual              restore dual sensors (sudo; no PAM changes)
+  auth sensor ir-only --yes      select EXPERIMENTAL IR-only (sudo; not qualified)
+  auth consent required         require confirmation (default; sudo)
+  auth consent hands-free --yes skip the keyword at privileged prompts (sudo;
+                        machine-wide opt-in). Login/lock behavior is separate.
   biopolicy <on|off|status>       opt-in operation-class gate: restrict which
                         services a face may satisfy (advanced; password unaffected)
   update [--check]                update via the channel this was installed from

--- a/crates/irlume-cli/src/consent.rs
+++ b/crates/irlume-cli/src/consent.rs
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! Machine-owner control of the existing privileged PAM intent policy.
+//! This command changes no PAM wiring and starts no authentication attempt.
+
+use irlume_common::config;
+use std::process::ExitCode;
+
+pub(crate) const OVERRIDE: &str = "IRLUME_PRIVILEGED_FACE_CONSENT";
+pub(crate) const SCOPE: &str =
+    "Applies machine-wide to configured privileged prompts, including sudo and polkit.";
+pub(crate) const WARNING: &str = "A prompt raised by an app, script or another person can authenticate while you are in view. Face matching, anti-spoofing and password fallback stay in place.";
+
+pub(crate) fn state_label(required: Option<bool>) -> &'static str {
+    match required {
+        Some(true) => "confirmation required (default)",
+        Some(false) => "hands-free (owner opt-in)",
+        None => "unknown: cannot read settings; confirmation remains required",
+    }
+}
+
+pub(crate) fn overridden() -> bool {
+    std::env::var_os(OVERRIDE).is_some()
+}
+
+pub(crate) fn run(args: &[String]) -> ExitCode {
+    let required = match args {
+        [] => None,
+        [status] if status == "status" => None,
+        [mode] if mode == "required" => Some(true),
+        [mode] if mode == "hands-free" => {
+            eprintln!("[consent] {SCOPE}\n{WARNING}\nTo accept: sudo irlume auth consent hands-free --yes");
+            return ExitCode::from(2);
+        }
+        [mode, yes] if mode == "hands-free" && yes == "--yes" => Some(false),
+        _ => {
+            eprintln!("[consent] usage: irlume auth consent <status|required|hands-free --yes>");
+            return ExitCode::from(2);
+        }
+    };
+    let Some(required) = required else {
+        println!(
+            "[consent] privileged face authentication: {}",
+            state_label(config::privileged_face_consent_visible())
+        );
+        println!("{SCOPE}");
+        if overridden() {
+            println!("Local environment override: {OVERRIDE}; the daemon may have a different environment.");
+        }
+        println!("Login and lock-screen start behavior is configured separately.");
+        return ExitCode::SUCCESS;
+    };
+    // Do not claim the new file value changed a policy hidden by an override.
+    if overridden() {
+        eprintln!("[consent] environment override {OVERRIDE} is set; remove it before changing the saved setting.");
+        return ExitCode::FAILURE;
+    }
+    if !crate::is_root() {
+        eprintln!(
+            "[consent] needs root: run sudo irlume auth consent {}",
+            if required {
+                "required"
+            } else {
+                "hands-free --yes"
+            }
+        );
+        return ExitCode::FAILURE;
+    }
+    let update = || -> std::io::Result<()> {
+        let _lock = config::lock_exclusive("settings.conf")?;
+        // write_kv preserves unrelated values, but its legacy read-error
+        // fallback is empty content. Never use that fallback for this control.
+        if let config::KvObservation::Unknown(error) =
+            config::observe_kv("settings.conf", "privileged_face_consent")
+        {
+            return Err(error);
+        }
+        config::write_kv(
+            "settings.conf",
+            "privileged_face_consent",
+            if required { "1" } else { "0" },
+        )
+    };
+    if let Err(error) = update() {
+        eprintln!("[consent] could not update settings.conf: {error}");
+        return ExitCode::FAILURE;
+    }
+    println!(
+        "[consent] saved privileged face authentication: {}",
+        state_label(Some(required))
+    );
+    println!("{SCOPE} Takes effect on subsequent attempts unless overridden in the PAM or daemon environment.");
+    if !required {
+        println!("{WARNING}");
+    }
+    ExitCode::SUCCESS
+}

--- a/crates/irlume-cli/src/consent.rs
+++ b/crates/irlume-cli/src/consent.rs
@@ -16,7 +16,7 @@ pub(crate) fn state_label(required: Option<bool>) -> &'static str {
     match required {
         Some(true) => "confirmation required (default)",
         Some(false) => "hands-free (owner opt-in)",
-        None => "unknown: cannot read settings; confirmation remains required",
+        None => "unknown: cannot read settings",
     }
 }
 
@@ -40,10 +40,16 @@ pub(crate) fn run(args: &[String]) -> ExitCode {
         }
     };
     let Some(required) = required else {
+        let (state, source) = crate::preferences::observed();
         println!(
-            "[consent] privileged face authentication: {}",
-            state_label(config::privileged_face_consent_visible())
+            "[consent] privileged face authentication: {} ({source})",
+            state_label(state.privileged_face_consent)
         );
+        if state.consent_overridden {
+            println!(
+                "Observed policy includes an environment override; the saved setting may differ."
+            );
+        }
         println!("{SCOPE}");
         if overridden() {
             println!("Local environment override: {OVERRIDE}; the daemon may have a different environment.");

--- a/crates/irlume-cli/src/fingerprint.rs
+++ b/crates/irlume-cli/src/fingerprint.rs
@@ -635,12 +635,16 @@ fn omarchy_wire_stack(content: &str) -> Option<String> {
 /// lines sit. Idempotent; returns the content to write (possibly unchanged).
 fn omarchy_unwire_stack(content: &str) -> String {
     let mut out = String::with_capacity(content.len());
-    for line in content.lines() {
-        if line.contains("pam_fprintd.so") || line.contains("omarchy-hw-laptop-closed") {
-            continue;
+    let mut continued = false;
+    for physical_line in content.split_inclusive('\n') {
+        let line = physical_line.strip_suffix('\n').unwrap_or(physical_line);
+        let line = line.strip_suffix('\r').unwrap_or(line);
+        let owned = !continued && matches!(line, OMARCHY_GATE | OMARCHY_FPRINTD);
+        let continues = crate::pamwire::has_line_continuation(physical_line);
+        if !owned {
+            out.push_str(physical_line);
         }
-        out.push_str(line);
-        out.push('\n');
+        continued = continues;
     }
     out
 }
@@ -1236,6 +1240,34 @@ auth     include  system-auth
         // Already bare stays byte-identical.
         let clean = "#%PAM-1.0\nauth     include  system-auth\n";
         assert_eq!(omarchy_unwire_stack(clean), clean);
+    }
+
+    #[test]
+    fn omarchy_unwire_preserves_foreign_token_lines_and_original_line_endings() {
+        let foreign = concat!(
+            "# administrator note: pam_fprintd.so stays here\r\n",
+            "auth optional pam_fprintd.so debug\r\n",
+            "auth optional pam_exec.so /usr/local/bin/omarchy-hw-laptop-closed\r\n",
+            "auth include system-auth",
+        );
+        assert_eq!(omarchy_unwire_stack(foreign), foreign);
+
+        let owned_without_final_newline = format!("#%PAM-1.0\n{OMARCHY_GATE}\n{OMARCHY_FPRINTD}");
+        assert_eq!(
+            omarchy_unwire_stack(&owned_without_final_newline),
+            "#%PAM-1.0\n"
+        );
+    }
+
+    #[test]
+    fn omarchy_unwire_preserves_owned_looking_text_in_a_continued_directive() {
+        let continued = format!(
+            "auth optional pam_exec.so /usr/local/bin/check \\\n{OMARCHY_GATE}\n{OMARCHY_FPRINTD}\nauth include system-auth\n"
+        );
+        let expected = format!(
+            "auth optional pam_exec.so /usr/local/bin/check \\\n{OMARCHY_GATE}\nauth include system-auth\n"
+        );
+        assert_eq!(omarchy_unwire_stack(&continued), expected);
     }
 
     #[test]

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -29,6 +29,7 @@ mod machine;
 mod models;
 mod pad;
 mod pamwire;
+mod preferences;
 mod profile_ir;
 mod recovery;
 mod retry;
@@ -1213,11 +1214,18 @@ pub(crate) fn keyring(sub: Option<&str>, args: &[String]) -> std::process::ExitC
                     // daemon, or an envelope it failed to parse. This is the
                     // dangerous reading, so refuse.
                     Ok(irlume_common::Response::KeyringInfo { kind: None, .. }) => (false, true),
-                    // No usable answer at all (daemon down, refused, older
-                    // protocol). Not "armed with something unknown": fall
-                    // through and let the erase attempt below report the real
-                    // failure, rather than blaming an envelope nobody saw.
-                    _ => (false, false),
+                    // A failed inspection is not permission to erase: a transient
+                    // failure can be followed by a successful destructive request.
+                    Ok(irlume_common::Response::Error(error)) | Err(error) => {
+                        eprintln!("[keyring] forget failed: {error} (sealed secret inspection)");
+                        (false, true)
+                    }
+                    _ => {
+                        eprintln!(
+                            "[keyring] unexpected response while inspecting the sealed secret"
+                        );
+                        (false, true)
+                    }
                 };
             if unknown && !force {
                 eprintln!(
@@ -3966,13 +3974,33 @@ fn doctor_run(
                 },
                 if recovery_set {
                     "SET ✓"
+                } else if encrypted && !key_present {
+                    "not set; no backup available"
                 } else {
                     "not set (run `irlume recovery setup`)"
                 },
             );
-            report.check(
+            if encrypted && !key_present {
+                dout!(
+                    report,
+                    "[doctor] {}",
+                    crate::recovery::missing_key_advice(recovery_set)
+                );
+            }
+            report.check_detail(
                 "templates",
-                if encrypted { State::Pass } else { State::Warn },
+                if encrypted && !key_present {
+                    State::Fail
+                } else if encrypted {
+                    State::Pass
+                } else {
+                    State::Warn
+                },
+                if encrypted && !key_present {
+                    crate::recovery::missing_key_advice(recovery_set)
+                } else {
+                    "template key observation complete"
+                },
             );
             report.check(
                 "recovery-passphrase",

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -20,6 +20,7 @@
 
 mod bitwarden;
 mod commands;
+mod consent;
 mod doctor_report;
 mod fingerprint;
 mod logintx;
@@ -30,7 +31,9 @@ mod pad;
 mod pamwire;
 mod profile_ir;
 mod recovery;
+mod retry;
 mod secrets;
+mod sensor_policy;
 mod strays;
 mod suncal;
 mod support_report;
@@ -171,6 +174,7 @@ fn main() -> std::process::ExitCode {
         (Some("enrolldev"), _) => enrolldev(&args),
         (Some("keyring"), _) => keyring(keyring_sub(&args), &args),
         (Some("recovery"), _) => recovery::run(recovery_sub(&args), &args),
+        (Some("retry"), _) => retry::run(recovery_sub(&args), &args),
         (Some("bitwarden"), sub) => bitwarden::run(sub, &args),
         (Some("fingerprint"), _) => fingerprint::run(fingerprint_sub(&args), &args),
         (Some("login"), _)
@@ -193,6 +197,8 @@ fn main() -> std::process::ExitCode {
         // whatever flags follow and answers a bad invocation with a JSON
         // usage-error rather than prose. Bare `auth` still falls through to the
         // help, which is the useful answer to a typo.
+        (Some("auth"), Some("consent")) => consent::run(&args[2..]),
+        (Some("auth"), Some("sensor")) => sensor_policy::run(&args[2..]),
         (Some("auth"), _) if args.iter().any(|a| a == "test") => machine::auth_test(&args),
         (Some("login"), sub) => pamwire::run(sub, &args),
         (Some("logs"), sub) => logs::run(sub, &args),
@@ -1056,10 +1062,19 @@ pub(crate) fn keyring(sub: Option<&str>, args: &[String]) -> std::process::ExitC
                 eprintln!("[keyring] empty password; aborted");
                 return std::process::ExitCode::from(2);
             }
+            let wallet_salt = match irlume_common::client::read_wallet_salt(&user) {
+                Ok(salt) => salt,
+                Err(e) => {
+                    eprintln!("[keyring] arm failed: {e}");
+                    return std::process::ExitCode::FAILURE;
+                }
+            };
             let req = irlume_common::Request::SealPassword {
                 kind: None, // let the daemon judge from what the user has
                 user: user.clone(),
                 password: irlume_common::SecretBytes::new(pw.as_bytes().to_vec()),
+                wallet_salt,
+                wallet_salt_checked: true,
             };
             match daemon_request(&req) {
                 Ok(irlume_common::Response::PasswordSealed) => {

--- a/crates/irlume-cli/src/pamwire.rs
+++ b/crates/irlume-cli/src/pamwire.rs
@@ -18,7 +18,7 @@
 //! `/usr/lib/pam.d`) get an `/etc` override materialized from the vendor copy and
 //! marked (revert = delete the override).
 
-use irlume_common::platform::{distro_family, DistroFamily};
+use irlume_common::platform::{distro_family, DistroFamily, SystemCommand};
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode};
 
@@ -754,7 +754,7 @@ const GDM_ONDEMAND_MIN_GNOME: u32 = 46;
 /// GNOME Shell major version via `gnome-shell --version` ("GNOME Shell 50.1" →
 /// 50). None when gnome-shell is absent/unparseable (→ conservative facefirst).
 fn gnome_shell_major() -> Option<u32> {
-    let out = std::process::Command::new("gnome-shell")
+    let out = std::process::Command::new(SystemCommand::GnomeShell.path()?)
         .arg("--version")
         .output()
         .ok()?;
@@ -1943,7 +1943,10 @@ fn wire_service(
 
 /// `Some(true/false)` when semodule could be queried (root), `None` otherwise.
 fn selinux_loaded() -> Option<bool> {
-    let out = Command::new("semodule").arg("-l").output().ok()?;
+    let out = Command::new(SystemCommand::Semodule.path()?)
+        .arg("-l")
+        .output()
+        .ok()?;
     if !out.status.success() {
         return None; // needs root to read the policy store
     }
@@ -2006,13 +2009,19 @@ pub(crate) fn relabel_daemon_socket() -> Result<(), String> {
         Ok(st) => Err(format!("{what} exited {st}")),
         Err(e) => Err(format!("could not run {what}: {e}")),
     };
+    let systemctl = SystemCommand::Systemctl
+        .path()
+        .ok_or_else(|| "could not run systemctl: trusted executable not found".to_string())?;
+    let restorecon = SystemCommand::Restorecon
+        .path()
+        .ok_or_else(|| "could not run restorecon: trusted executable not found".to_string())?;
     run(
         "systemctl try-restart irlumed.service",
-        Command::new("systemctl").args(["try-restart", "irlumed.service"]),
+        Command::new(systemctl).args(["try-restart", "irlumed.service"]),
     )?;
     run(
         "restorecon /run/irlume.sock",
-        Command::new("restorecon").arg("/run/irlume.sock"),
+        Command::new(restorecon).arg("/run/irlume.sock"),
     )
 }
 
@@ -2027,11 +2036,13 @@ fn selinux(enable: bool, apply: bool) -> Result<String, String> {
             );
         };
         if apply {
-            let ok = Command::new("semodule")
-                .args(["-i", pp.as_str()])
-                .status()
-                .map(|s| s.success())
-                .unwrap_or(false);
+            let ok = SystemCommand::Semodule.path().is_some_and(|semodule| {
+                Command::new(semodule)
+                    .args(["-i", pp.as_str()])
+                    .status()
+                    .map(|s| s.success())
+                    .unwrap_or(false)
+            });
             if !ok {
                 return Err("semodule -i irlume.pp failed".into());
             }
@@ -2053,7 +2064,13 @@ fn selinux(enable: bool, apply: bool) -> Result<String, String> {
             // selinux-policy version that refuses, no semodule at all), and the
             // next `login status` would then disagree with the line they had
             // just been shown.
-            match Command::new("semodule").args(["-r", "irlume"]).status() {
+            let Some(semodule) = SystemCommand::Semodule.path() else {
+                return Err(
+                    "could not run semodule (trusted executable not found); the module is still loaded"
+                        .into(),
+                );
+            };
+            match Command::new(semodule).args(["-r", "irlume"]).status() {
                 Ok(st) if st.success() => Ok("✓ SELinux module removed".into()),
                 Ok(st) => Err(format!(
                     "semodule -r irlume failed ({st}); the module is still loaded"

--- a/crates/irlume-cli/src/preferences.rs
+++ b/crates/irlume-cli/src/preferences.rs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! Shared preference observations for CLI status and the TUI background poll.
+use irlume_common::{PreferencesState, Request, Response};
+
+pub(crate) fn daemon_state() -> Option<PreferencesState> {
+    match irlume_common::client::request_poll(&Request::PreferencesStatus) {
+        Ok(Response::PreferencesStatus(state)) => Some(state),
+        _ => None,
+    }
+}
+
+pub(crate) fn observed() -> (PreferencesState, &'static str) {
+    match daemon_state() {
+        Some(state) => (state, "daemon observed"),
+        None => (
+            PreferencesState::observe(),
+            "local observation; daemon preferences unavailable",
+        ),
+    }
+}
+
+pub(crate) fn toggle_label(value: Option<bool>) -> &'static str {
+    match value {
+        Some(true) => "ON",
+        Some(false) => "OFF",
+        None => "UNKNOWN",
+    }
+}

--- a/crates/irlume-cli/src/recovery.rs
+++ b/crates/irlume-cli/src/recovery.rs
@@ -27,6 +27,14 @@ pub fn run(sub: Option<&str>, args: &[String]) -> ExitCode {
     }
 }
 
+pub(crate) fn missing_key_advice(recovery_set: bool) -> &'static str {
+    if recovery_set {
+        "restore the template key with the existing recovery passphrase: irlume recovery restore"
+    } else {
+        "Re-enroll to use face login again; no recovery backup is set"
+    }
+}
+
 fn status(user: &str) -> ExitCode {
     match daemon_request(&Request::RecoveryStatus { user: user.into() }) {
         Ok(Response::RecoveryStatus {
@@ -39,15 +47,12 @@ fn status(user: &str) -> ExitCode {
             println!(
                 "  templates encrypted : {}",
                 match (encrypted, key_present) {
-                    (true, true) => "yes ✓ (template key sealed in the TPM)",
-                    // The one state the old bool could not say. Naming it
-                    // matters more than any other line here: the templates are
-                    // safe from a stolen disk and unreadable by their owner, and
-                    // neither `recovery setup` nor a reseal brings them back.
-                    (true, false) =>
-                        "yes, but the TEMPLATE KEY IS GONE: this enrollment \
-                         cannot be opened. Re-enroll to use face login again.",
-                    (false, _) => "no (plaintext at rest)",
+                    (true, true) => "yes ✓ (template key sealed in the TPM)".into(),
+                    (true, false) => format!(
+                        "yes, but the TEMPLATE KEY IS GONE: {}",
+                        missing_key_advice(recovery_set)
+                    ),
+                    (false, _) => "no (plaintext at rest)".to_string(),
                 }
             );
             println!(
@@ -62,7 +67,7 @@ fn status(user: &str) -> ExitCode {
                     "no (templates stay plaintext on this host)"
                 }
             );
-            if encrypted && !recovery_set {
+            if encrypted && key_present && !recovery_set {
                 println!("  → no backstop: if the TPM seal breaks (dbx/firmware update, TPM clear, disk move),");
                 println!("    you'd have to re-enroll. Set one now:  irlume recovery setup");
             }

--- a/crates/irlume-cli/src/retry.rs
+++ b/crates/irlume-cli/src/retry.rs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! Explicit face retry recovery, separate from template-key recovery.
+use irlume_common::{Request, Response, SecretBytes};
+use std::process::ExitCode;
+
+const USAGE: &str = "usage: irlume retry <status|reset> [--user U]";
+
+pub(super) fn run(sub: Option<&str>, args: &[String]) -> ExitCode {
+    if args.len() == 2 && matches!(args[1].as_str(), "--help" | "-h") {
+        println!("{USAGE}\nReset verifies your current local login password; root performs an administrator reset.");
+        return ExitCode::SUCCESS;
+    }
+    let action = sub.unwrap_or("status");
+    if !valid_arguments(action, args) {
+        eprintln!("{USAGE} (supply at most one non-empty --user)");
+        return ExitCode::from(2);
+    }
+    let user = crate::user_arg(args);
+    match execute(action, &user) {
+        Ok(message) => {
+            println!("{message}");
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
+            eprintln!("[retry] {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+// A reset must not silently retarget an empty --user or accept contradictory
+// positional arguments. Keep both established --user U and --user=U spellings,
+// in either position, while rejecting unknown flags before daemon contact.
+fn valid_arguments(action: &str, args: &[String]) -> bool {
+    if !matches!(action, "status" | "reset") {
+        return false;
+    }
+    let mut tokens = args.iter().skip(1);
+    let (mut have_user, mut have_action) = (false, false);
+    while let Some(token) = tokens.next() {
+        let user = if token == "--user" {
+            tokens.next().map(String::as_str)
+        } else {
+            token.strip_prefix("--user=")
+        };
+        if let Some(user) = user {
+            if have_user || user.is_empty() || user.starts_with('-') {
+                return false;
+            }
+            have_user = true;
+        } else if token == action && !have_action {
+            have_action = true;
+        } else {
+            return false;
+        }
+    }
+    true
+}
+
+fn execute(action: &str, user: &str) -> Result<String, String> {
+    // Negotiate before reading a password: older daemons have no reset path.
+    let state = crate::daemon_request(&Request::RetryStatus { user: user.into() })
+        .map_err(|error| format!("could not inspect retry state: {error}; use ordinary password login and check that the daemon supports retry recovery"))?;
+    let Response::RetryStatus {
+        failures,
+        cooldown_seconds,
+        recovery_failures,
+        recovery_cooldown_seconds,
+        recovery_required,
+        password_reset_available,
+        face_budget,
+    } = state
+    else {
+        return Err("daemon does not support retry recovery or refused access to retry state; use ordinary password login and ask an administrator to check the daemon and account".into());
+    };
+    if action == "status" {
+        let cumulative = match face_budget {
+            Some(budget) => match budget.unsuccessful_requests {
+                Some(count) => format!("Cumulative face requests: {count}/{} consecutive unsuccessful; {}.", budget.limit, if budget.reset_required { "password-verified retry reset required" } else { "available after any cooldown" }),
+                None => format!("Cumulative face budget: prospective {}-request limit starts at the next admitted request; earlier history unknown.", budget.limit),
+            },
+            None => "Cumulative face budget unavailable from this daemon; enforcement unknown.".into(),
+        };
+        return Ok(format!("Face retry state for '{user}': {failures} recorded failures, {cooldown_seconds}s cooldown.\n{cumulative}\nPassword-verified retry reset: {}; {recovery_failures} failed checks, {recovery_cooldown_seconds}s cooldown.\nOrdinary password login remains available.",
+            if recovery_required { "administrator reset required" } else if password_reset_available { "available for supported local accounts" } else { "unavailable on this installation" }));
+    }
+    // SAFETY: geteuid has no preconditions.
+    let admin = unsafe { libc::geteuid() } == 0;
+    if !admin && recovery_required {
+        return Err("password-verified retry reset requires administrator repair or reset; use ordinary password login and ask an administrator".into());
+    }
+    if !admin && recovery_cooldown_seconds > 0 {
+        return Err(format!("password-verified retry reset is rate limited for {recovery_cooldown_seconds}s; wait before retrying or use ordinary password login"));
+    }
+    if !admin && !password_reset_available {
+        return Err("password-only retry reset is unavailable; use ordinary password login and ask an administrator".into());
+    }
+    let password = if admin {
+        eprintln!("[retry] Administrator reset for '{user}'.");
+        SecretBytes::new(Vec::new())
+    } else {
+        let password = crate::read_password("Current login password: ")?;
+        if password.is_empty() || password.len() > 4096 || password.as_bytes().contains(&0) {
+            return Err("password must contain 1–4096 bytes without NUL".into());
+        }
+        SecretBytes::new(password.as_bytes().to_vec())
+    };
+    match crate::daemon_request(&Request::RetryReset {
+        user: user.into(),
+        password,
+    })? {
+        Response::Ok(message) => Ok(message),
+        Response::Error(error) => Err(error),
+        _ => Err("unexpected reply; retry state reset was not confirmed".into()),
+    }
+}

--- a/crates/irlume-cli/src/sensor_policy.rs
+++ b/crates/irlume-cli/src/sensor_policy.rs
@@ -9,7 +9,7 @@ use irlume_common::config::{
 use irlume_common::{Request, Response};
 use std::process::ExitCode;
 
-const WARNING: &str = "EXPERIMENTAL: IR-only omits RGB and cross-spectrum evidence. It is not qualified for authentication assurance. Missing prerequisites use password fallback; no silent RGB fallback is permitted.";
+pub(crate) const WARNING: &str = "EXPERIMENTAL: IR-only omits RGB and cross-spectrum evidence. It is not qualified for authentication assurance. Missing prerequisites use password fallback; no silent RGB fallback is permitted.";
 
 pub(crate) fn state_label(state: State) -> &'static str {
     match state {
@@ -50,12 +50,22 @@ pub(crate) fn run(args: &[String]) -> ExitCode {
         }
         [mode, yes] if mode == "ir-only" && yes == "--yes" => Some(Policy::IrOnlyExperimental),
         [preflight] if preflight == "preflight" => return preflight_for(crate::user_arg(&[])),
-        [preflight, user] if preflight == "preflight" && !user.starts_with('-') => {
+        [preflight, flag, user]
+            if preflight == "preflight" && flag == "--user" && valid_user(user) =>
+        {
+            return preflight_for(user.clone())
+        }
+        [preflight, flag]
+            if preflight == "preflight" && flag.strip_prefix("--user=").is_some_and(valid_user) =>
+        {
+            return preflight_for(flag[7..].into())
+        }
+        [preflight, user] if preflight == "preflight" && valid_user(user) => {
             return preflight_for(user.clone())
         }
         _ => {
             eprintln!(
-                "[sensor] usage: irlume auth sensor <status|preflight [user]|dual|ir-only --yes>"
+                "[sensor] usage: irlume auth sensor <status|preflight [--user U]|dual|ir-only --yes>"
             );
             return ExitCode::from(2);
         }
@@ -96,6 +106,10 @@ pub(crate) fn run(args: &[String]) -> ExitCode {
         println!("{WARNING}");
     }
     ExitCode::SUCCESS
+}
+
+fn valid_user(user: &str) -> bool {
+    !user.is_empty() && !user.starts_with('-') && !user.chars().any(char::is_control)
 }
 
 fn preflight_for(user: String) -> ExitCode {

--- a/crates/irlume-cli/src/sensor_policy.rs
+++ b/crates/irlume-cli/src/sensor_policy.rs
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! Explicit owner selection and camera-free observation of face sensors.
+
+use irlume_common::config::{
+    self, FaceSensorPolicy as Policy, FaceSensorPolicyObservation as State,
+};
+use irlume_common::{Request, Response};
+use std::process::ExitCode;
+
+const WARNING: &str = "EXPERIMENTAL: IR-only omits RGB and cross-spectrum evidence. It is not qualified for authentication assurance. Missing prerequisites use password fallback; no silent RGB fallback is permitted.";
+
+pub(crate) fn state_label(state: State) -> &'static str {
+    match state {
+        State::DefaultDual => "dual (default)",
+        State::Explicit(Policy::Dual) => "dual (explicit)",
+        State::Explicit(Policy::IrOnlyExperimental) => {
+            "EXPERIMENTAL IR-only (owner opt-in; not qualified)"
+        }
+        State::Invalid => "invalid sensor policy; face must remain unavailable",
+        State::Unreadable => "unreadable sensor policy; state unknown",
+    }
+}
+
+pub(crate) fn local_status_line() -> String {
+    format!(
+        "local saved: {}",
+        state_label(config::observe_face_sensor_policy())
+    )
+}
+
+pub(crate) fn status_line() -> String {
+    match irlume_common::client::request_poll(&Request::FaceSensorStatus { user: None }) {
+        Ok(Response::FaceSensorStatus { policy, .. }) => {
+            format!("daemon observed: {}", state_label(policy))
+        }
+        _ => format!("{}; daemon sensor policy unavailable", local_status_line()),
+    }
+}
+
+pub(crate) fn run(args: &[String]) -> ExitCode {
+    let selected = match args {
+        [] => None,
+        [status] if status == "status" => None,
+        [mode] if mode == "dual" => Some(Policy::Dual),
+        [mode] if mode == "ir-only" => {
+            eprintln!("[sensor] {WARNING}\nTo accept: sudo irlume auth sensor ir-only --yes");
+            return ExitCode::from(2);
+        }
+        [mode, yes] if mode == "ir-only" && yes == "--yes" => Some(Policy::IrOnlyExperimental),
+        [preflight] if preflight == "preflight" => return preflight_for(crate::user_arg(&[])),
+        [preflight, user] if preflight == "preflight" && !user.starts_with('-') => {
+            return preflight_for(user.clone())
+        }
+        _ => {
+            eprintln!(
+                "[sensor] usage: irlume auth sensor <status|preflight [user]|dual|ir-only --yes>"
+            );
+            return ExitCode::from(2);
+        }
+    };
+    let Some(selected) = selected else {
+        println!("[sensor] {}", status_line());
+        println!("Sensor policy is separate from dual-camera scheduling, PAM wiring and per-attempt consent. Use `irlume auth sensor preflight` to check prerequisites.");
+        return ExitCode::SUCCESS;
+    };
+    if !crate::is_root() {
+        eprintln!("[sensor] changing the machine-wide sensor policy requires root");
+        return ExitCode::FAILURE;
+    }
+    let update = || -> std::io::Result<()> {
+        let _lock = config::lock_exclusive("settings.conf")?;
+        if matches!(
+            config::observe_face_sensor_policy(),
+            State::Unreadable | State::Invalid
+        ) {
+            return Err(std::io::Error::other("settings cannot be safely updated"));
+        }
+        config::write_kv(
+            "settings.conf",
+            "face_sensor_policy",
+            match selected {
+                Policy::Dual => "dual",
+                Policy::IrOnlyExperimental => "ir-only-experimental",
+            },
+        )
+    };
+    if update().is_err() {
+        eprintln!("[sensor] could not update settings.conf; inspect unreadable or invalid settings before changing the policy");
+        return ExitCode::FAILURE;
+    }
+    println!("[sensor] saved: {}", state_label(State::Explicit(selected)));
+    println!("Readiness is not established. Check `irlume auth sensor preflight`; face may fall back to password. PAM wiring, camera scheduling and consent settings are unchanged.");
+    if selected == Policy::IrOnlyExperimental {
+        println!("{WARNING}");
+    }
+    ExitCode::SUCCESS
+}
+
+fn preflight_for(user: String) -> ExitCode {
+    match crate::daemon_request(&Request::FaceSensorStatus { user: Some(user) }) {
+        Ok(Response::FaceSensorStatus {
+            policy,
+            ir_readiness: Some(readiness),
+        }) => {
+            println!("[sensor] daemon observed: {}", state_label(policy));
+            match policy.resolve() {
+                Ok(Policy::IrOnlyExperimental) => {}
+                Ok(Policy::Dual) => {
+                    eprintln!("[sensor] experimental IR-only preflight unavailable: IR-only is not selected. Dual-camera authentication remains selected; use your password if face authentication is unavailable.");
+                    return ExitCode::FAILURE;
+                }
+                Err(_) => {
+                    eprintln!("[sensor] sensor policy is invalid or unreadable; inspect settings.conf and use your password");
+                    return ExitCode::FAILURE;
+                }
+            }
+            use irlume_common::IrOnlyReadiness as Readiness;
+            let refusal = match readiness {
+                Readiness::ReadyForExperimentalAttempt => {
+                    println!("[sensor] EXPERIMENTAL IR-only prerequisites are ready for an attempt. This does not prove capture success or a usable login and is not qualified for authentication assurance; the service deadline still applies.");
+                    return ExitCode::SUCCESS;
+                }
+                Readiness::Unavailable => {
+                    "experimental IR-only preflight unavailable; check the daemon and use your password"
+                }
+                Readiness::InvalidPolicy => {
+                    "sensor policy is invalid; inspect and select dual or IR-only again, then use your password"
+                }
+                Readiness::TargetUnavailable => {
+                    "configured IR target is unavailable or unsupported; configure a supported IR target and use your password"
+                }
+                Readiness::BindingUnavailable => {
+                    "IR enrollment has no camera binding; add fresh scans with the configured camera and use your password"
+                }
+                Readiness::BindingMismatch => {
+                    "enrollment belongs to a different IR camera; use the enrolled camera or add fresh scans, then use your password"
+                }
+                Readiness::ModelsUnavailable => {
+                    "required face models are unavailable; repair the installed models, restart the daemon, and use your password"
+                }
+                Readiness::PadUnavailable => {
+                    "required IR anti-spoofing is unavailable; repair the IR PAD model, restart the daemon, and use your password"
+                }
+                Readiness::EnrollmentUnavailable => {
+                    "face enrollment is unavailable; enroll or restore the protected enrollment, then use your password"
+                }
+                Readiness::IncompatibleEnrollment => {
+                    "no compatible IR scans are enrolled; add fresh scans with the current setup, then use your password"
+                }
+            };
+            eprintln!("[sensor] {refusal}");
+        }
+        _ => eprintln!(
+            "[sensor] daemon could not establish experimental IR-only readiness; use your password"
+        ),
+    }
+    ExitCode::FAILURE
+}

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -186,6 +186,8 @@ enum SidebarRow {
 #[derive(Clone, Copy)]
 enum Click {
     Key(KeyCode),
+    DialogKey(KeyCode),
+    ActionRow(usize),
     Hub(usize),
     /// Select a row in the current screen's list. The screen is intentionally
     /// resolved when the click is handled: targets are cleared and rebuilt on
@@ -298,6 +300,7 @@ enum Suspend {
     /// Toggle the opt-in biopolicy operation-class gate (the bool is the target
     /// state). Root op; the daemon reads it live, no restart.
     Biopolicy(bool),
+    PrivilegedConsent(bool),
     /// IR liveness self-test via `sudo irlume selftest liveness` (the daemon
     /// root-gates it; the raw measurements are a spoof-tuning oracle).
     SelfTestLiveness,
@@ -629,6 +632,11 @@ struct App {
     /// Clickable content regions recorded each frame by `draw`, consulted by
     /// `on_click`. Interior mutability because `draw` takes `&self`.
     click_targets: std::cell::RefCell<Vec<(Rect, Click)>>,
+    /// Last rendered dialog bounds and scroll limit; controls stay outside the body.
+    dialog_view: std::cell::Cell<(Rect, u16)>,
+    dialog_scroll: std::cell::Cell<u16>,
+    /// Screen, paragraph bounds, scroll offset and maximum, rebuilt during render.
+    page_view: std::cell::Cell<(usize, Rect, u16, u16)>,
     /// The [?] full-keymap overlay (tier two of the disclosure ladder).
     show_help: bool,
     more_actions: Option<(String, usize)>,
@@ -1082,6 +1090,9 @@ impl App {
             confirm: None,
             mouse_select: false,
             click_targets: std::cell::RefCell::new(Vec::new()),
+            dialog_view: std::cell::Cell::new((Rect::default(), 0)),
+            dialog_scroll: std::cell::Cell::new(0),
+            page_view: std::cell::Cell::new((usize::MAX, Rect::default(), 0, 0)),
             show_help: false,
             more_actions: None,
             hub_sel: 0,
@@ -2712,16 +2723,19 @@ impl App {
                             self.on_key(k.code)
                         }
                     }
-                    // Wheel scrolls the Activity history; a left click (or a
-                    // touchscreen tap, delivered as the same event) on a sidebar
-                    // row jumps to that section.
                     Event::Mouse(m) => match m.kind {
-                        MouseEventKind::ScrollUp => {
-                            self.activity_open = true;
-                            self.act_scroll = (self.act_scroll + 1).min(self.act_max())
-                        }
-                        MouseEventKind::ScrollDown => {
-                            self.act_scroll = self.act_scroll.saturating_sub(1)
+                        MouseEventKind::ScrollUp | MouseEventKind::ScrollDown => {
+                            let size = terminal.size()?;
+                            self.on_scroll(
+                                m.column,
+                                m.row,
+                                Rect::new(0, 0, size.width, size.height),
+                                if m.kind == MouseEventKind::ScrollUp {
+                                    -1
+                                } else {
+                                    1
+                                },
+                            );
                         }
                         MouseEventKind::Down(ratatui::crossterm::event::MouseButton::Left) => {
                             let size = terminal.size()?;
@@ -3120,6 +3134,18 @@ impl App {
                 "refresh the pcrlock policy (re-predict the boot measurements)",
                 &["systemd-pcrlock", "make-policy"],
             ),
+            Suspend::PrivilegedConsent(required) => self.sudo_step(
+                if required {
+                    "require confirmation for privileged face authentication"
+                } else {
+                    "enable hands-free privileged face authentication"
+                },
+                if required {
+                    &["irlume", "auth", "consent", "required"]
+                } else {
+                    &["irlume", "auth", "consent", "hands-free", "--yes"]
+                },
+            ),
             Suspend::Biopolicy(on) => self.sudo_step(
                 if on {
                     "enable the biopolicy gate"
@@ -3193,6 +3219,7 @@ impl App {
     }
 
     fn on_key(&mut self, code: KeyCode) {
+        self.dialog_scroll.set(0);
         // A raised error banner says "press any key to dismiss", so it takes the
         // next key BEFORE anything else (including the activity scroll below).
         if self.error.is_some() {
@@ -3835,6 +3862,23 @@ impl App {
                 None => self.log('·', "Bitwarden is not installed on this system"),
             },
             // Settings.
+            (SC_SETTINGS, KeyCode::Char('p')) => {
+                if crate::consent::overridden() {
+                    self.log('·', "An environment override controls privileged consent; remove it before changing the saved setting.");
+                    return;
+                }
+                match irlume_common::config::privileged_face_consent_visible() {
+                    Some(true) => {
+                        self.confirm = Some((
+                            format!("Enable hands-free privileged face authentication? {} {}", crate::consent::SCOPE, crate::consent::WARNING),
+                            "Enable",
+                            ConfirmAct::Sus(Suspend::PrivilegedConsent(false)),
+                        ));
+                    }
+                    Some(false) => self.suspend = Some(Suspend::PrivilegedConsent(true)),
+                    None => self.log('·', "Cannot read privileged consent settings. Run sudo irlume tui or sudo irlume auth consent status."),
+                }
+            }
             // Biopolicy gate: enabling changes the security posture (restricts
             // which services a face may satisfy), so it is confirmed; disabling
             // just relaxes back to default and goes straight through.
@@ -4011,7 +4055,7 @@ impl App {
                 .join(" ");
             self.confirm = Some((
                 format!(
-                    "{}\n{scope}\n{}\nRun: {}irlume {command}",
+                    "{}\n\n{scope}\n\n{}\n\nRun: {}irlume {command}",
                     invocation.action.label,
                     invocation.action.description,
                     if invocation.action.root { "sudo " } else { "" }
@@ -4022,35 +4066,60 @@ impl App {
         }
     }
 
-    fn draw_more_actions(&self, f: &mut Frame, query: &str, selected: usize) {
-        let area = f.area();
+    fn more_actions_rect(area: Rect) -> Rect {
         let width = area.width.saturating_sub(2).min(100);
         let height = area.height.saturating_sub(2).min(24);
-        let rect = Rect::new(
+        Rect::new(
             area.x + area.width.saturating_sub(width) / 2,
             area.y + area.height.saturating_sub(height) / 2,
             width,
             height,
-        );
+        )
+    }
+
+    fn draw_more_actions(&self, f: &mut Frame, query: &str, selected: usize) {
+        self.click_targets.borrow_mut().clear();
+        let rect = Self::more_actions_rect(f.area());
         f.render_widget(Clear, rect);
         let block = Block::bordered()
-            .title(" More actions (F2 / Esc closes) ")
+            .title(" More actions ")
+            .padding(ratatui::widgets::Padding::horizontal(1))
             .border_style(Style::new().fg(th().accent));
         let inner = block.inner(rect);
         f.render_widget(block, rect);
         let rows = Layout::vertical([
-            Constraint::Length(2),
-            Constraint::Min(1),
             Constraint::Length(3),
+            Constraint::Min(1),
+            Constraint::Length(4),
+            Constraint::Length(1),
         ])
         .split(inner);
         f.render_widget(
             Paragraph::new(format!(
-                "Search: {query}▏\nType to filter; arrows select; Enter opens"
+                "Search: {query}▏\nType to filter; click or arrows select; Open continues"
             )),
             rows[0],
         );
         let matches = actions::matching(query);
+        let [close, open] =
+            Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
+                .areas(rows[3]);
+        for (cell, label, key) in [
+            (close, "[Esc] Close", KeyCode::Esc),
+            (open, "[Enter] Open", KeyCode::Enter),
+        ] {
+            if key == KeyCode::Enter && matches.is_empty() {
+                continue;
+            }
+            let button = Rect::new(
+                cell.x,
+                cell.y,
+                cell.width.min(label.len() as u16),
+                cell.height,
+            );
+            f.render_widget(Paragraph::new(label).style(selected_style()), button);
+            self.hit(button, Click::DialogKey(key));
+        }
         if matches.is_empty() {
             f.render_widget(
                 Paragraph::new("No matching actions. Backspace to change the search."),
@@ -4067,9 +4136,18 @@ impl App {
             rows[1],
             &mut state,
         );
+        for (row, index) in (state.offset()..matches.len())
+            .take(rows[1].height as usize)
+            .enumerate()
+        {
+            self.hit(
+                Rect::new(rows[1].x, rows[1].y + row as u16, rows[1].width, 1),
+                Click::ActionRow(index),
+            );
+        }
         if let Some(action) = matches.get(selected) {
             f.render_widget(
-                Paragraph::new(action.description).wrap(Wrap { trim: true }),
+                Paragraph::new(format!("\n{}", action.description)).wrap(Wrap { trim: true }),
                 rows[2],
             );
         }
@@ -4164,10 +4242,16 @@ impl App {
                     "SealPassword",
                     OpTag::Generic,
                     Box::new(move || {
+                        let wallet_salt = match irlume_common::client::read_wallet_salt(&user) {
+                            Ok(salt) => salt,
+                            Err(e) => return (false, format!("keyring arm failed: {e}")),
+                        };
                         let req = Request::SealPassword {
                             kind: None, // let the daemon judge from what the user has
                             user: user.clone(),
                             password: irlume_common::SecretBytes::new(pw.to_vec()),
+                            wallet_salt,
+                            wallet_salt_checked: true,
                         };
                         match crate::daemon_request(&req) {
                             Ok(Response::TokenSealed { token, minted }) => {
@@ -4302,7 +4386,15 @@ impl App {
             };
             // Prompt in the wrapping body (a long name/prompt would truncate as a
             // border title); the typed field on its own line below it.
-            self.modal(f, "Input", &format!("{prompt}\n{shown}▏"));
+            self.modal(
+                f,
+                "Input",
+                &format!("{prompt}\n\n{shown}▏"),
+                &[
+                    ("[Esc] Cancel", KeyCode::Esc),
+                    ("[Enter] Continue", KeyCode::Enter),
+                ],
+            );
         } else if let Some((what, _, _)) = &self.confirm {
             // Question in the body so a long target name isn't clipped by the
             // single-line border title.
@@ -4310,19 +4402,31 @@ impl App {
             self.modal(
                 f,
                 "Confirm",
-                &format!("{what}\n[n]/Esc Cancel    [y] {verb}"),
+                what,
+                &[
+                    ("[Esc] Cancel", KeyCode::Esc),
+                    (&format!("[y] {verb}"), KeyCode::Char('y')),
+                ],
             );
         } else if let Some(prompt) = self.enroll.as_ref().and_then(|e| e.session_merge.as_ref()) {
             self.modal(f, "Already enrolled", &format!(
-                "This capture matches '{}'. Improve Recognition for this person?\n\nNo scans have been saved. Continue with up to {} more scans, then save the completed capture.\n\n[y] Continue    [n]/Esc Cancel", prompt.profile, prompt.remaining));
+                "This capture matches '{}'. Improve Recognition for this person?\n\nNo scans have been saved. Continue with up to {} more scans, then save the completed capture.", prompt.profile, prompt.remaining), &[("[Esc] Cancel", KeyCode::Esc), ("[y] Continue", KeyCode::Char('y'))]);
         } else if let Some(mc) = &self.enroll_merge {
             // Keep the message in the wrapping body, not the border title (which
             // is a single line clamped to the box width and would truncate).
             let body = format!(
-                "This capture matches '{}' on this account. Improve Recognition for this person instead of creating another profile?\n\nOne scan has been added; [y] keeps it and captures up to {} more. [n]/Esc cancels and removes that scan.\n\n[y] add scans   [n]/Esc cancel",
+                "This capture matches '{}' on this account. Improve Recognition for this person instead of creating another profile?\n\nOne scan has been added; [y] keeps it and captures up to {} more. [n]/Esc cancels and removes that scan.",
                 mc.profile, mc.remaining
             );
-            self.modal(f, "Already enrolled", &body);
+            self.modal(
+                f,
+                "Already enrolled",
+                &body,
+                &[
+                    ("[Esc] Cancel", KeyCode::Esc),
+                    ("[y] add scans", KeyCode::Char('y')),
+                ],
+            );
         }
         // Tier two of the key-disclosure ladder; drawn last so it sits above
         // everything except nothing (help is always answerable).
@@ -4330,43 +4434,22 @@ impl App {
             self.draw_more_actions(f, query, *selected);
         }
         if self.show_help {
-            self.modal(f, "Keys  ([?] or Esc to close)", &self.help_body());
+            self.modal(
+                f,
+                "Keyboard and mouse",
+                &self.help_body(),
+                &[("[Esc] Close", KeyCode::Esc)],
+            );
         }
     }
 
     /// A red, dismissible error banner centred on screen.
     fn error_modal(&self, f: &mut Frame, msg: &str) {
-        let area = f.area();
-        // Both dimensions are capped by the frame: the 30-column floor and the
-        // fixed 7 rows are bigger than a small terminal, and a rect that reaches
-        // past the buffer is not something a draw may produce.
-        let w = area
-            .width
-            .saturating_sub(8)
-            .clamp(30, 78)
-            .min(area.width.max(1));
-        let h = 7u16.min(area.height.max(1));
-        let rect = Rect {
-            x: area.width.saturating_sub(w) / 2,
-            y: area.height.saturating_sub(h) / 2,
-            width: w,
-            height: h,
-        };
-        f.render_widget(Clear, rect);
-        let blk = Block::bordered()
-            .title(" ⚠ Problem ")
-            .border_type(BorderType::Rounded)
-            .border_style(Style::new().fg(th().err).add_modifier(Modifier::BOLD))
-            .padding(ratatui::widgets::Padding::horizontal(1));
-        let body = vec![
-            Line::raw(""),
-            Line::from(Span::styled(msg.to_string(), Style::new().fg(th().err))),
-            Line::raw(""),
-            Line::from(Span::styled("[any key] dismiss", Style::new().dim())),
-        ];
-        f.render_widget(
-            Paragraph::new(body).block(blk).wrap(Wrap { trim: true }),
-            rect,
+        self.modal(
+            f,
+            "⚠ Problem",
+            &format!("{msg}\n\n[any key] dismiss"),
+            &[("[Esc] Dismiss", KeyCode::Esc)],
         );
     }
 
@@ -4559,11 +4642,119 @@ impl App {
         self.click_targets.borrow_mut().push((rect, c));
     }
 
+    fn dialog_open(&self) -> bool {
+        self.error.is_some()
+            || self.input.is_some()
+            || self.confirm.is_some()
+            || self.enroll_merge.is_some()
+            || self.show_help
+            || self
+                .enroll
+                .as_ref()
+                .is_some_and(|e| e.session_merge.is_some())
+    }
+
+    fn on_scroll(&mut self, col: u16, row: u16, area: Rect, direction: i32) {
+        if self.dialog_open() {
+            let (bounds, max) = self.dialog_view.get();
+            if bounds.contains((col, row).into()) {
+                let scroll = self.dialog_scroll.get();
+                self.dialog_scroll.set(
+                    if direction < 0 {
+                        scroll.saturating_sub(1)
+                    } else {
+                        scroll.saturating_add(1)
+                    }
+                    .min(max),
+                );
+            }
+            return;
+        }
+        if self.more_actions.is_some() {
+            if Self::more_actions_rect(area).contains((col, row).into()) {
+                self.on_key(if direction < 0 {
+                    KeyCode::Up
+                } else {
+                    KeyCode::Down
+                });
+            }
+            return;
+        }
+        let [_, _, body, activity, _] = self.frame_rows(area);
+        if activity.contains((col, row).into()) {
+            if direction < 0 {
+                self.activity_open = true;
+                self.act_scroll = (self.act_scroll + 1).min(self.act_max());
+            } else {
+                self.act_scroll = self.act_scroll.saturating_sub(1);
+            }
+            return;
+        }
+        if self.op.is_some() || self.enroll.is_some() {
+            return;
+        }
+        let (_, content) = self.body_split(body);
+        if !content.contains((col, row).into()) {
+            return;
+        }
+        let (screen, bounds, scroll, max) = self.page_view.get();
+        if screen == self.screen && bounds.contains((col, row).into()) {
+            let next = if direction < 0 {
+                scroll.saturating_sub(1)
+            } else {
+                scroll.saturating_add(1)
+            }
+            .min(max);
+            self.page_view.set((screen, bounds, next, max));
+            return;
+        }
+        let (selected, len) = match self.screen {
+            SC_PROFILES => {
+                let len = self.rows().len();
+                (&mut self.sel, len)
+            }
+            SC_CAMERAS => (&mut self.cam_sel, self.pairs.len()),
+            SC_REPAIR => (&mut self.repair_sel, self.repair.len()),
+            SC_WELCOME => {
+                let len = self.hub_rows().len();
+                (&mut self.hub_sel, len)
+            }
+            _ => return,
+        };
+        *selected = if direction < 0 {
+            selected.saturating_sub(1)
+        } else {
+            selected.saturating_add(1)
+        }
+        .min(len.saturating_sub(1));
+    }
+
     /// Map a mouse click (or touchscreen tap, delivered as the same left-click)
     /// to an action: a sidebar row jumps to that screen, a footer chip or the
     /// first-run button replays its key. Clicks while a modal/flow owns the
     /// screen are ignored.
     fn on_click(&mut self, col: u16, row: u16, area: Rect) {
+        // Only the top overlay registers targets; background clicks never
+        // dismiss a warning, approve an action or navigate behind a dialog.
+        if self.dialog_open() || self.more_actions.is_some() {
+            let target = self
+                .click_targets
+                .borrow()
+                .iter()
+                .find_map(|(r, c)| r.contains((col, row).into()).then_some(*c));
+            match target {
+                Some(Click::DialogKey(key)) => self.on_key(key),
+                Some(Click::ActionRow(index)) => {
+                    if let Some((query, selected)) = self.more_actions.as_mut() {
+                        if index < actions::matching(query).len() {
+                            *selected = index;
+                        }
+                    }
+                }
+                _ => {}
+            }
+            return;
+        }
         // Activity remains usable while a camera/daemon operation owns normal
         // input, matching PgUp and [A]. Resolve that one safe disclosure before
         // the flow gate; it never starts, cancels, or confirms an operation.
@@ -4607,6 +4798,7 @@ impl App {
         if let Some(c) = hit {
             match c {
                 Click::Key(kc) => self.on_key(kc),
+                Click::DialogKey(_) | Click::ActionRow(_) => {}
                 Click::Hub(i) => {
                     if let Some((_, _, target)) = self.hub_rows().get(i).copied() {
                         self.hub_sel = i;
@@ -4775,6 +4967,8 @@ impl App {
     }
 
     fn draw_content(&self, f: &mut Frame, area: Rect) {
+        let (screen, _, scroll, max) = self.page_view.get();
+        self.page_view.set((screen, Rect::default(), scroll, max));
         let blk = Block::bordered()
             .border_type(BorderType::Rounded)
             .border_style(Style::new().fg(th().accent))
@@ -4782,7 +4976,7 @@ impl App {
             // the frame.
             .padding(ratatui::widgets::Padding::new(2, 2, 1, 0));
         let inner = blk.inner(area);
-        f.render_widget(blk, area);
+        f.render_widget(blk.clone(), area);
         if self.enroll.is_some() {
             self.draw_enroll(f, inner);
             return;
@@ -4799,6 +4993,10 @@ impl App {
             SC_PAM => self.draw_pam(f, inner),
             SC_SETTINGS => self.draw_settings(f, inner),
             _ => self.draw_done(f, inner),
+        }
+        let (screen, _, _, max) = self.page_view.get();
+        if screen == self.screen && max > 0 {
+            f.render_widget(blk.title_bottom(" Scroll inside panel for more "), area);
         }
     }
 
@@ -5070,82 +5268,177 @@ impl App {
         }
     }
 
+    fn draw_action_paragraph(
+        &self,
+        f: &mut Frame,
+        area: Rect,
+        lines: Vec<Line<'_>>,
+        actions: &[(usize, KeyCode)],
+    ) {
+        let heights: Vec<u16> = lines
+            .iter()
+            .map(|line| {
+                Paragraph::new(line.clone())
+                    .wrap(Wrap { trim: false })
+                    .line_count(area.width)
+                    .min(u16::MAX as usize) as u16
+            })
+            .collect();
+        let total = heights.iter().fold(0u16, |sum, h| sum.saturating_add(*h));
+        let max = total.saturating_sub(area.height);
+        let (screen, _, old_scroll, _) = self.page_view.get();
+        let scroll = if screen == self.screen {
+            old_scroll.min(max)
+        } else {
+            0
+        };
+        self.page_view.set((self.screen, area, scroll, max));
+        let mut offset = 0u16;
+        for (index, (line, height)) in lines.into_iter().zip(heights).enumerate() {
+            let end = offset.saturating_add(height);
+            let skipped = scroll.saturating_sub(offset);
+            let y = area.y.saturating_add(offset.saturating_sub(scroll));
+            if end > scroll && y < area.bottom() {
+                let rect = Rect::new(
+                    area.x,
+                    y,
+                    area.width,
+                    height.saturating_sub(skipped).min(area.bottom() - y),
+                );
+                f.render_widget(
+                    Paragraph::new(line)
+                        .wrap(Wrap { trim: false })
+                        .scroll((skipped, 0)),
+                    rect,
+                );
+                if let Some((_, key)) = actions.iter().find(|(row, _)| *row == index) {
+                    self.hit(rect, Click::Key(*key));
+                }
+            }
+            offset = end;
+        }
+    }
+
     fn draw_settings(&self, f: &mut Frame, area: Rect) {
+        let mut page_actions = Vec::new();
         // The shared reader, which agrees with the daemon's truthy set (`yes` and
         // `on` count too) and admits when the root-only file cannot be read. The
         // local `biopolicy_on` accepted only `1`/`true`, so `enforce_biopolicy=yes`
         // drew "turn it on" while the daemon was already enforcing.
         let bio = irlume_common::config::enforce_biopolicy_visible();
-        f.render_widget(
-            Paragraph::new({
-                let mut v = Vec::new();
-                v.push(section("Face confirmation: keyboard required"));
-                v.extend(vec![
-                    section("Biopolicy operation-class gate"),
-                    {
-                        // The shared tri-state reader, not the raw config read the
-                        // [b] direction uses: settings.conf is 0600 root-only, so
-                        // the raw read showed "off (default)" here while the Done
-                        // dashboard said "◐ root-only" for the same key. Same
-                        // truthy set and env override as the daemon.
-                        let (icon, icon_style, label) =
-                            match irlume_common::config::enforce_biopolicy_visible() {
-                                Some(true) => (
-                                    "●",
-                                    Style::new().fg(th().ok).add_modifier(Modifier::BOLD),
-                                    "ENFORCING",
-                                ),
-                                Some(false) => ("○", Style::new().dim(), "off (default)"),
-                                None => (
-                                    "◐",
-                                    Style::new().fg(th().warn),
-                                    "on/off is root-only; run the TUI with sudo to see it",
-                                ),
-                            };
-                        Line::from(vec![
-                            Span::raw("  state  "),
-                            Span::styled(format!("{icon} "), icon_style),
-                            Span::styled(label, Style::new().dim()),
-                        ])
-                    },
-                    Line::from(Span::styled(
-                        "  When on: only Login/Elevation may release the keyring; lock-screen",
-                        Style::new().dim(),
-                    )),
-                    Line::from(Span::styled(
-                        "  is verify-only; remote/unknown services are denied. Advanced; the",
-                        Style::new().dim(),
-                    )),
-                    Line::from(Span::styled(
-                        "  password is always available, so this can restrict but never lock out.",
-                        Style::new().dim(),
-                    )),
+        let lines = {
+            let mut v = Vec::new();
+            let consent = irlume_common::config::privileged_face_consent_visible();
+            v.push(section("Face sensor policy"));
+            v.push(Line::raw(format!(
+                "  {}",
+                crate::sensor_policy::local_status_line()
+            )));
+            v.push(Line::raw("  Inspect the daemon: irlume auth sensor status"));
+            v.push(Line::raw(
+                "  Change as root: irlume auth sensor dual / ir-only --yes",
+            ));
+            v.push(Line::raw(
+                "  IR-only is experimental, not qualified; consent and PAM wiring are separate.",
+            ));
+            v.push(Line::raw(""));
+            v.push(section("Face authentication at privileged prompts"));
+            v.push(Line::raw(""));
+            v.push(Line::raw(format!(
+                "  {}",
+                crate::consent::state_label(consent)
+            )));
+            v.push(Line::raw(
+                "  Machine-wide for configured sudo/polkit and other privileged services.",
+            ));
+            v.push(Line::raw(
+                "  Login and lock-screen start behavior is separate.",
+            ));
+            v.push(Line::raw(""));
+            if crate::consent::overridden() {
+                v.push(Line::raw(
+                    "  Local environment override; daemon policy may differ.",
+                ));
+                v.push(Line::raw(
+                    "  Remove IRLUME_PRIVILEGED_FACE_CONSENT before changing this setting.",
+                ));
+            } else {
+                let action = match consent {
+                    Some(true) => "enable hands-free (asks first)",
+                    Some(false) => "restore required confirmation",
+                    None => "state unavailable; run sudo irlume tui to inspect settings",
+                };
+                push_page_actions(&mut v, &mut page_actions, &[("p", action)]);
+            }
+            v.push(Line::raw(""));
+            v.extend(vec![
+                section("Biopolicy operation-class gate"),
+                {
+                    // The shared tri-state reader, not the raw config read the
+                    // [b] direction uses: settings.conf is 0600 root-only, so
+                    // the raw read showed "off (default)" here while the Done
+                    // dashboard said "◐ root-only" for the same key. Same
+                    // truthy set and env override as the daemon.
+                    let (icon, icon_style, label) =
+                        match irlume_common::config::enforce_biopolicy_visible() {
+                            Some(true) => (
+                                "●",
+                                Style::new().fg(th().ok).add_modifier(Modifier::BOLD),
+                                "ENFORCING",
+                            ),
+                            Some(false) => ("○", Style::new().dim(), "off (default)"),
+                            None => (
+                                "◐",
+                                Style::new().fg(th().warn),
+                                "on/off is root-only; run the TUI with sudo to see it",
+                            ),
+                        };
                     Line::from(vec![
-                        Span::styled("  [b]", Style::new().fg(th().accent)),
-                        Span::styled(
-                            match bio {
-                                Some(true) => " turn it off (sudo)",
-                                Some(false) => " turn it on (sudo; asks first)",
-                                None => " on/off is root-only; run the TUI with sudo",
-                            },
-                            Style::new().dim(),
-                        ),
-                    ]),
-                    Line::raw(""),
-                    section("Match thresholds (read-only)"),
-                    Line::from(Span::styled(
-                        "  Calibrated per modality (RGB/IR), auto-scaled by enrolled scan count.",
-                        Style::new().dim(),
-                    )),
-                ]);
-                v
-            })
-            .wrap(Wrap { trim: false }),
-            area,
-        );
+                        Span::raw("  state  "),
+                        Span::styled(format!("{icon} "), icon_style),
+                        Span::styled(label, Style::new().dim()),
+                    ])
+                },
+                Line::from(Span::styled(
+                    "  When on: only Login/Elevation may release the keyring; lock-screen",
+                    Style::new().dim(),
+                )),
+                Line::from(Span::styled(
+                    "  is verify-only; remote/unknown services are denied. Advanced; the",
+                    Style::new().dim(),
+                )),
+                Line::from(Span::styled(
+                    "  password is always available, so this can restrict but never lock out.",
+                    Style::new().dim(),
+                )),
+            ]);
+            push_page_actions(
+                &mut v,
+                &mut page_actions,
+                &[(
+                    "b",
+                    match bio {
+                        Some(true) => "turn it off (sudo)",
+                        Some(false) => "turn it on (sudo; asks first)",
+                        None => "biopolicy state is root-only; run the TUI with sudo",
+                    },
+                )],
+            );
+            v.extend([
+                Line::raw(""),
+                section("Match thresholds (read-only)"),
+                Line::from(Span::styled(
+                    "  Calibrated per modality (RGB/IR), auto-scaled by enrolled scan count.",
+                    Style::new().dim(),
+                )),
+            ]);
+            v
+        };
+        self.draw_action_paragraph(f, area, lines, &page_actions);
     }
 
     fn draw_cameras(&self, f: &mut Frame, area: Rect) {
+        let mut page_actions = Vec::new();
         // The active pair comes from the daemon's Health, NOT from
         // select_pair(): that helper falls through to discovery when no
         // explicit pair is configured, and discovery opens every node. This
@@ -5169,8 +5462,7 @@ impl App {
         // space stays empty at the bottom (content near the top).
         let list_rows = self.nodes.len().max(pairs.len()).max(1) as u16 + 1;
         let [list_area, info_area] =
-            Layout::vertical([Constraint::Length(list_rows + 1), Constraint::Length(9)])
-                .areas(area);
+            Layout::vertical([Constraint::Length(list_rows + 1), Constraint::Min(9)]).areas(area);
 
         // ---- selectable list of trusted (physical) Hello camera pairs ----
         // No pair ≠ no camera: an RGB-only device still serves the convenience
@@ -5346,22 +5638,21 @@ impl App {
             "  your camera's USB descriptor documents, and never runs on its own.",
             Style::new().dim(),
         )));
-        lines.push(Line::from(vec![
-            Span::styled("  [s]", Style::new().fg(th().accent)),
-            Span::styled(" set up emitter   ", Style::new().dim()),
-            Span::styled("[t]", Style::new().fg(th().accent)),
-            Span::styled(
-                " tune capture (holds the camera ~1 min)   ",
-                Style::new().dim(),
-            ),
-            Span::styled("[p]", Style::new().fg(th().accent)),
-            Span::styled(" list units (writes nothing)", Style::new().dim()),
-        ]));
+        push_page_actions(
+            &mut lines,
+            &mut page_actions,
+            &[
+                ("s", "set up emitter"),
+                ("t", "tune capture (holds the camera ~1 min)"),
+                ("p", "list units (writes nothing)"),
+            ],
+        );
         // Borderless (no box-in-box); the content panel is the only frame.
-        f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), info_area);
+        self.draw_action_paragraph(f, info_area, lines, &page_actions);
     }
 
     fn draw_fingerprint(&self, f: &mut Frame, area: Rect) {
+        let mut page_actions = Vec::new();
         let reader = match (&self.fp.device, self.fp.available) {
             (Some(n), _) => Span::styled(format!("● {n}"), Style::new().fg(th().ok)),
             (None, true) => Span::styled("● present (unnamed)", Style::new().fg(th().ok)),
@@ -5420,25 +5711,34 @@ impl App {
                 }
             }
             lines.push(Line::raw(""));
-            lines.push(action_line(&[
-                ("a", "enroll a finger"),
-                ("t", "test a finger"),
-                ("x", "wipe all"),
-            ]));
-            lines.push(action_line(&[
-                ("e", "face OR fingerprint (sudo)"),
-                ("d", "remove from login"),
-            ]));
+            push_page_actions(
+                &mut lines,
+                &mut page_actions,
+                &[
+                    ("a", "enroll a finger"),
+                    ("t", "test a finger"),
+                    ("x", "wipe all"),
+                ],
+            );
+            push_page_actions(
+                &mut lines,
+                &mut page_actions,
+                &[
+                    ("e", "face OR fingerprint (sudo)"),
+                    ("d", "remove from login"),
+                ],
+            );
         } else {
             lines.push(Line::from(Span::styled(
                 "  No usable reader on this device; fingerprint unavailable.",
                 Style::new().dim(),
             )));
         }
-        f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), area);
+        self.draw_action_paragraph(f, area, lines, &page_actions);
     }
 
     fn draw_recovery(&self, f: &mut Frame, area: Rect) {
+        let mut page_actions = Vec::new();
         // None = RecoveryStatus never answered. The old default here claimed
         // "plaintext at rest" and "No TPM" about templates that are encrypted
         // on a TPM machine, one Tab away from the Keyring tab saying "TPM
@@ -5503,15 +5803,16 @@ impl App {
             }
         }
         lines.push(Line::raw(""));
-        lines.push(action_line(&[
-            ("s", "set passphrase"),
-            ("t", "restore"),
-            ("f", "forget"),
-        ]));
-        f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), area);
+        push_page_actions(
+            &mut lines,
+            &mut page_actions,
+            &[("s", "set passphrase"), ("t", "restore"), ("f", "forget")],
+        );
+        self.draw_action_paragraph(f, area, lines, &page_actions);
     }
 
     fn draw_keyring(&self, f: &mut Frame, area: Rect) {
+        let mut page_actions = Vec::new();
         let armed = self.keyring_armed.unwrap_or(false);
         let status = match self.keyring_armed {
             Some(true) => Span::styled(
@@ -5650,18 +5951,35 @@ impl App {
         // it re-enters the password and re-seals to the current PCRs, the CLI
         // `irlume reseal` a keyboard-only user would otherwise have no way to run.
         if armed {
-            lines.push(action_line(&[
-                ("a", "re-arm (new password)"),
-                ("r", "reseal (re-bind to current PCRs)"),
-                ("f", "forget"),
-            ]));
+            push_page_actions(
+                &mut lines,
+                &mut page_actions,
+                &[
+                    ("a", "re-arm (new password)"),
+                    ("r", "reseal (re-bind to current PCRs)"),
+                    ("f", "forget"),
+                ],
+            );
         } else {
-            lines.push(action_line(&[
-                ("a", "arm (enter your login password)"),
-                ("f", "forget"),
-            ]));
+            push_page_actions(
+                &mut lines,
+                &mut page_actions,
+                &[("a", "arm (enter your login password)"), ("f", "forget")],
+            );
         }
-        f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), area);
+        if armed
+            && self
+                .keyring_policy
+                .as_deref()
+                .is_some_and(|p| p.contains("Tier 2"))
+        {
+            push_page_actions(
+                &mut lines,
+                &mut page_actions,
+                &[("p", "refresh pcrlock policy")],
+            );
+        }
+        self.draw_action_paragraph(f, area, lines, &page_actions);
     }
 
     /// How many enrolled scans the LOADED recognizer can match, or `None`
@@ -5869,8 +6187,9 @@ impl App {
     /// advisory-only doctor lines (fingerprint
     /// vendor-stack, polkit sandbox, install hygiene) stay in `doctor`.
     fn draw_repair(&self, f: &mut Frame, area: Rect) {
+        let mut page_actions = Vec::new();
         let [list_area, info_area] =
-            Layout::vertical([Constraint::Min(4), Constraint::Length(12)]).areas(area);
+            Layout::vertical([Constraint::Min(4), Constraint::Length(26)]).areas(area);
 
         // ---- checklist --------------------------------------------------
         let ok = self.repair.iter().filter(|c| c.sev == Sev::Ok).count();
@@ -5913,11 +6232,14 @@ impl App {
             list_area,
             &mut st,
         );
-        for i in 0..self.repair.len().min(list_area.height as usize) {
+        for (row, i) in (st.offset()..self.repair.len())
+            .take(list_area.height as usize)
+            .enumerate()
+        {
             self.hit(
                 Rect::new(
                     list_area.x,
-                    list_area.y.saturating_add(i as u16),
+                    list_area.y.saturating_add(row as u16),
                     list_area.width,
                     1,
                 ),
@@ -5941,14 +6263,6 @@ impl App {
             Span::styled(format!("   {warn} warn"), Style::new().fg(th().warn)),
             Span::styled(format!("   {fail} fail"), Style::new().fg(th().err)),
         ])];
-        lines.push(action_line(&[
-            ("f", "fix selected"),
-            ("r", "re-check"),
-            ("l", "IR self-test"),
-            ("s", "support report"),
-            ("d", "doctor"),
-            ("g", "logs"),
-        ]));
         lines.push(Line::raw(""));
         if let Some(c) = self.repair.get(self.repair_sel) {
             let hint = match &c.fix {
@@ -6010,50 +6324,41 @@ impl App {
             ),
         ]));
         lines.push(Line::raw(""));
-        // The two action lines are click targets, not just text: register the
-        // rows they will occupy so a click fires the same key the hint names.
-        // Row math: each Line is one row, start at info_area.y + 1 (border).
-        let ir_line_row = info_area.y + 1 + (lines.len() as u16);
-        lines.push(Line::from(Span::styled(
-            "  IR test    press [l] to run the IR PAD self-test (sudo; look at the camera)",
-            Style::new().dim(),
-        )));
-        let support_line_row = info_area.y + 1 + (lines.len() as u16);
-        lines.push(Line::from(Span::styled(
-            "  Support    [s] Create Support Report (read-only; captures no camera data)",
-            Style::new().dim(),
-        )));
-        let mut reg = self.click_targets.borrow_mut();
-        reg.push((
-            Rect::new(
-                info_area.x + 1,
-                ir_line_row,
-                info_area.width.saturating_sub(2),
-                1,
-            ),
-            Click::Key(KeyCode::Char('l')),
-        ));
-        reg.push((
-            Rect::new(
-                info_area.x + 1,
-                support_line_row,
-                info_area.width.saturating_sub(2),
-                1,
-            ),
-            Click::Key(KeyCode::Char('s')),
-        ));
-        drop(reg);
+        push_page_action(
+            &mut lines,
+            &mut page_actions,
+            "l",
+            "IR test",
+            "press [l] to run the IR PAD self-test (sudo; look at the camera)",
+        );
+        push_page_action(
+            &mut lines,
+            &mut page_actions,
+            "s",
+            "Create Support Report",
+            "read-only; captures no camera data",
+        );
+        push_page_actions(
+            &mut lines,
+            &mut page_actions,
+            &[
+                ("f", "fix selected"),
+                ("r", "re-check"),
+                ("d", "doctor"),
+                ("g", "logs"),
+            ],
+        );
         let blk = Block::bordered()
             .border_type(BorderType::Rounded)
             .border_style(Style::new().dim())
             .title(" diagnosis ");
-        f.render_widget(
-            Paragraph::new(lines).block(blk).wrap(Wrap { trim: false }),
-            info_area,
-        );
+        let inner = blk.inner(info_area);
+        f.render_widget(blk, info_area);
+        self.draw_action_paragraph(f, inner, lines, &page_actions);
     }
 
     fn draw_identify(&self, f: &mut Frame, area: Rect) {
+        let mut page_actions = Vec::new();
         let mut lines = vec![
             section("1:N identify (\"who is this?\")"),
             Line::from(Span::styled(
@@ -6094,14 +6399,12 @@ impl App {
             ))),
         }
         lines.push(Line::raw(""));
-        lines.push(Line::from(vec![
-            Span::styled("  [i]", Style::new().fg(th().accent)),
-            Span::styled(" identify now", Style::new().dim()),
-        ]));
-        f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), area);
+        push_page_actions(&mut lines, &mut page_actions, &[("i", "identify now")]);
+        self.draw_action_paragraph(f, area, lines, &page_actions);
     }
 
     fn draw_pam(&self, f: &mut Frame, area: Rect) {
+        let mut page_actions = Vec::new();
         let mut lines = vec![section("PAM services (face auth wiring)")];
         // Everything below renders `self.pam_cache`, computed with the
         // diagnostics: draw used to re-read every PAM service file and probe
@@ -6230,50 +6533,55 @@ impl App {
         // verb-first label padded to a common width, then a dim detail column.
         // Scannable as a command list instead of a paragraph; the key never
         // wanders into the middle of a sentence.
-        let act = |key: &str, label: &str, detail: &str| {
-            Line::from(vec![
-                Span::styled(format!("  {key:<4}"), Style::new().fg(th().accent)),
-                Span::styled(format!("{label:<22}"), Style::new()),
-                Span::styled(detail.to_string(), Style::new().dim()),
-            ])
-        };
-        lines.push(act(
-            "[w]",
+        push_page_action(
+            &mut lines,
+            &mut page_actions,
+            "w",
             "Wire login + lock",
             "the core action; leave the password empty then Enter to use your face",
-        ));
-        lines.push(act(
-            "[u]",
+        );
+        push_page_action(
+            &mut lines,
+            &mut page_actions,
+            "u",
             "Wire face-sudo",
             "opt-in; type yes for one face attempt at sudo prompts",
-        ));
-        lines.push(act(
-            "[p]",
+        );
+        push_page_action(
+            &mut lines,
+            &mut page_actions,
+            "p",
             "Wire app prompts",
             "opt-in; type yes for one face attempt at app prompts",
-        ));
+        );
         // [b] is an ACTION only when Bitwarden is installed without its polkit
         // action; otherwise its state shows as a status line below.
         if matches!(
             self.heavy.clone(),
             Some(crate::bitwarden::TuiState::NeedsSetup)
         ) {
-            lines.push(act(
-                "[b]",
+            push_page_action(
+                &mut lines,
+                &mut page_actions,
+                "b",
                 "Set up Bitwarden",
                 "installs its polkit action so your face unlocks the vault",
-            ));
+            );
         }
-        lines.push(act(
-            "[x]",
+        push_page_action(
+            &mut lines,
+            &mut page_actions,
+            "x",
             "Un-wire everything",
             "removes face auth from login/lock/sudo/apps; asks first",
-        ));
-        lines.push(act(
-            "[s]",
+        );
+        push_page_action(
+            &mut lines,
+            &mut page_actions,
+            "s",
             "Show full status",
             "opens the detailed console status view",
-        ));
+        );
         // Bitwarden status line (not an action): only when installed and the
         // action is present or snapd owns it. Set apart by a blank line.
         match &self.heavy {
@@ -6301,16 +6609,17 @@ impl App {
             }
             _ => {}
         }
-        f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), area);
+        self.draw_action_paragraph(f, area, lines, &page_actions);
     }
 
     fn draw_done(&self, f: &mut Frame, area: Rect) {
+        let mut page_actions = Vec::new();
         let scans: usize = self.profiles.iter().map(|p| p.scans.len()).sum();
         // Tri-state, not the raw probe bool: before the first sweep lands the
         // bool is a default, and this screen must not read a default as "one
         // step left" (nor as done).
         let wired = self.login_wired_known();
-        let lines = vec![
+        let mut lines = vec![
             section("Setup dashboard"),
             Line::raw(""),
             Line::from(vec![
@@ -6387,19 +6696,16 @@ impl App {
                 },
                 Style::new().dim(),
             )),
-            if !self.profiles.is_empty() && wired == Some(false) {
-                Line::from(vec![
-                    Span::styled("  [w]", Style::new().fg(th().accent)),
-                    Span::styled(" wire login    [r] refresh    [q] quit", Style::new().dim()),
-                ])
-            } else {
-                Line::from(vec![
-                    Span::styled("  [r]", Style::new().fg(th().accent)),
-                    Span::styled(" refresh    [q] quit", Style::new().dim()),
-                ])
-            },
         ];
-        f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), area);
+        if !self.profiles.is_empty() && wired == Some(false) {
+            push_page_actions(&mut lines, &mut page_actions, &[("w", "wire login")]);
+        }
+        push_page_actions(
+            &mut lines,
+            &mut page_actions,
+            &[("r", "refresh"), ("q", "quit")],
+        );
+        self.draw_action_paragraph(f, area, lines, &page_actions);
     }
 
     fn draw_activity(&self, f: &mut Frame, area: Rect) {
@@ -6577,7 +6883,7 @@ impl App {
                 ("x", "Disconnect…"),
                 ("s", "Show Status"),
             ],
-            SC_SETTINGS => &[("b", "Biopolicy…")],
+            SC_SETTINGS => &[("p", "Privileged consent…"), ("b", "Biopolicy…")],
             // [w] only while wiring is OBSERVED missing: the body hides its
             // [w] line on a wired box, and a footer still offering it invites
             // a needless `sudo irlume login enable --apply` re-run. Unknown
@@ -6714,7 +7020,8 @@ impl App {
         b
     }
 
-    fn modal(&self, f: &mut Frame, title: &str, body: &str) {
+    fn modal(&self, f: &mut Frame, title: &str, body: &str, buttons: &[(&str, KeyCode)]) {
+        self.click_targets.borrow_mut().clear();
         let area = f.area();
         let w = area.width.saturating_sub(4).clamp(20, 72).min(area.width);
         // Grow the box to fit the wrapped body so a long message never clips,
@@ -6727,7 +7034,10 @@ impl App {
         // Cap the floor by what the frame actually has, so a tiny frame gets a
         // cramped box instead of a crash.
         let max_h = area.height.max(1);
-        let h = (lines + 2).clamp(3.min(max_h), max_h);
+        let controls = if buttons.is_empty() { 0 } else { 2 };
+        let h = lines
+            .saturating_add(2 + controls)
+            .clamp(3.min(max_h), max_h);
         let rect = Rect {
             x: area.width.saturating_sub(w) / 2,
             y: area.height.saturating_sub(h) / 2,
@@ -6738,14 +7048,54 @@ impl App {
         let blk = Block::bordered()
             .title(format!(" {title} "))
             .border_type(BorderType::Rounded)
-            .border_style(Style::new().fg(th().accent))
+            .border_style(Style::new().fg(if title == "⚠ Problem" {
+                th().err
+            } else {
+                th().accent
+            }))
             .padding(ratatui::widgets::Padding::horizontal(1));
+        let inner = blk.inner(rect);
+        f.render_widget(blk, rect);
+        let [body_area, _, button_area] = Layout::vertical([
+            Constraint::Min(0),
+            Constraint::Length(controls.saturating_sub(1)),
+            Constraint::Length(u16::from(!buttons.is_empty())),
+        ])
+        .areas(inner);
+        let max_scroll = lines.saturating_sub(body_area.height);
+        self.dialog_view.set((rect, max_scroll));
+        let scroll = self.dialog_scroll.get().min(max_scroll);
+        self.dialog_scroll.set(scroll);
         f.render_widget(
             Paragraph::new(body.to_string())
-                .block(blk)
-                .wrap(Wrap { trim: true }),
-            rect,
+                .wrap(Wrap { trim: true })
+                .scroll((scroll, 0)),
+            body_area,
         );
+        if max_scroll > 0 {
+            let hint = Rect::new(inner.x, button_area.y.saturating_sub(1), inner.width, 1)
+                .intersection(inner);
+            f.render_widget(
+                Paragraph::new("Scroll to read more").style(Style::new().dim()),
+                hint,
+            );
+        }
+        let cells = Layout::horizontal(
+            buttons
+                .iter()
+                .map(|_| Constraint::Ratio(1, buttons.len() as u32)),
+        )
+        .split(button_area);
+        for ((label, key), cell) in buttons.iter().zip(cells.iter()) {
+            let button = Rect::new(
+                cell.x,
+                cell.y,
+                cell.width.min(label.chars().count() as u16),
+                cell.height,
+            );
+            f.render_widget(Paragraph::new(*label).style(selected_style()), button);
+            self.hit(button, Click::DialogKey(*key));
+        }
     }
 }
 
@@ -6849,19 +7199,42 @@ fn state_row(label: &str, w: usize, value: Span<'static>) -> Line<'static> {
     Line::from(vec![Span::raw(format!("  {label:<w$}")), value])
 }
 
-/// An action line: accent `[key]` chips with dim labels, 2-space indent, a
-/// gap between actions. THE way action keys render, so a key is never a dim
-/// mid-sentence token or a whole dim line.
-fn action_line(items: &[(&str, &str)]) -> Line<'static> {
-    let mut spans = vec![Span::raw("  ")];
-    for (i, (k, d)) in items.iter().enumerate() {
-        if i > 0 {
-            spans.push(Span::raw("   "));
-        }
-        spans.push(Span::styled(format!("[{k}]"), Style::new().fg(th().accent)));
-        spans.push(Span::styled(format!(" {d}"), Style::new().dim()));
+/// Explicit authored actions: one separated row per action. The row metadata
+/// travels with the text so labels and wrapped continuations share one target.
+fn push_page_actions(
+    lines: &mut Vec<Line<'_>>,
+    actions: &mut Vec<(usize, KeyCode)>,
+    items: &[(&str, &str)],
+) {
+    for (key, label) in items {
+        push_page_action(lines, actions, key, label, "");
     }
-    Line::from(spans)
+}
+
+fn push_page_action(
+    lines: &mut Vec<Line<'_>>,
+    actions: &mut Vec<(usize, KeyCode)>,
+    key: &str,
+    label: &str,
+    detail: &str,
+) {
+    if actions
+        .last()
+        .is_some_and(|(row, _)| *row + 1 == lines.len())
+    {
+        lines.push(Line::raw(""));
+    }
+    if let Some(code) = footer_keycode(key) {
+        actions.push((lines.len(), code));
+    }
+    let mut spans = vec![Span::styled(
+        format!("  [{key}] {label}"),
+        Style::new().fg(th().accent),
+    )];
+    if !detail.is_empty() {
+        spans.push(Span::styled(format!("  {detail}"), Style::new().dim()));
+    }
+    lines.push(Line::from(spans));
 }
 
 /// Human label for the stored auth method string (`Method::as_str()`): the raw
@@ -7476,7 +7849,7 @@ mod tests {
         let mut app = test_app();
         app.screen = SC_SETTINGS;
         let text = draw_text(&app);
-        assert!(text.contains("Face confirmation: keyboard required"));
+        assert!(text.contains("Face authentication at privileged prompts"));
         for removed in [
             "head gesture",
             "keyring gesture",
@@ -8539,6 +8912,9 @@ mod tests {
             confirm: None,
             mouse_select: false,
             click_targets: std::cell::RefCell::new(Vec::new()),
+            dialog_view: std::cell::Cell::new((Rect::default(), 0)),
+            dialog_scroll: std::cell::Cell::new(0),
+            page_view: std::cell::Cell::new((usize::MAX, Rect::default(), 0, 0)),
             show_help: false,
             more_actions: None,
             hub_sel: 0,
@@ -8767,6 +9143,426 @@ mod tests {
     // Regression: f00f316. A long modal body must be fully visible: the box
     // grows to the wrapped line count instead of clipping at the old fixed
     // height of 5 (three body rows).
+    /// Click text as displayed, independently of the registered hit targets.
+    fn click_text(app: &mut App, text: &str) {
+        let mut term = Terminal::new(TestBackend::new(120, 50)).unwrap();
+        term.draw(|f| app.draw(f)).unwrap();
+        let screen = rendered(&term);
+        let (y, x) = screen
+            .lines()
+            .enumerate()
+            .find_map(|(y, line)| {
+                line.find(text)
+                    .map(|byte| (y, line[..byte].chars().count()))
+            })
+            .unwrap_or_else(|| panic!("missing {text:?}:\n{screen}"));
+        app.on_click(x as u16, y as u16, Rect::new(0, 0, 120, 50));
+    }
+
+    #[test]
+    fn page_actions_wallet_and_recovery_click_existing_safe_flows() {
+        let mut app = test_app();
+        app.screen = SC_KEYRING;
+        app.keyring_armed = Some(true);
+        app.keyring_kind = Some(irlume_common::KeyringSecretKind::LoginPassword);
+        click_text(&mut app, "[a] re-arm");
+        assert!(matches!(app.input, Some((_, _, Pending::KeyringPw(_)))));
+        app.on_key(KeyCode::Esc);
+        click_text(&mut app, "[r] reseal");
+        assert!(matches!(app.input, Some((_, _, Pending::KeyringPw(_)))));
+        app.on_key(KeyCode::Esc);
+        click_text(&mut app, "[f] forget");
+        assert!(app.confirm.is_some());
+        assert!(app.op.is_none(), "forget must wait for confirmation");
+        app.on_key(KeyCode::Esc);
+        app.screen = SC_RECOVERY;
+        click_text(&mut app, "[s] set passphrase");
+        assert!(app.input.is_some());
+        app.on_key(KeyCode::Esc);
+        click_text(&mut app, "[t] restore");
+        assert!(app.input.is_some());
+        app.on_key(KeyCode::Esc);
+        click_text(&mut app, "[f] forget");
+        assert!(app.confirm.is_some());
+        assert!(app.op.is_none());
+    }
+
+    #[test]
+    fn page_actions_explicit_rows_cover_other_pages_without_launching_operations() {
+        let _guard = dead_socket();
+        for (screen, labels) in [
+            (
+                SC_FINGERPRINT,
+                vec![
+                    ("[a] enroll", 'a'),
+                    ("[t] test", 't'),
+                    ("[x] wipe", 'x'),
+                    ("[e] face", 'e'),
+                    ("[d] remove", 'd'),
+                ],
+            ),
+            (
+                SC_CAMERAS,
+                vec![
+                    ("[s] set up", 's'),
+                    ("[t] tune", 't'),
+                    ("[p] list units", 'p'),
+                ],
+            ),
+            (
+                SC_REPAIR,
+                vec![
+                    ("[f] fix selected", 'f'),
+                    ("[r] re-check", 'r'),
+                    ("[d] doctor", 'd'),
+                    ("[g] logs", 'g'),
+                ],
+            ),
+            (SC_IDENTIFY, vec![("[i] identify now", 'i')]),
+            (SC_SETTINGS, vec![("[p]", 'p'), ("[b]", 'b')]),
+            (SC_DONE, vec![("[r] refresh", 'r'), ("[q] quit", 'q')]),
+            (SC_KEYRING, vec![("[p] refresh pcrlock", 'p')]),
+        ] {
+            let mut app = test_app();
+            app.screen = screen;
+            app.fp.available = true;
+            app.keyring_armed = Some(true);
+            app.keyring_policy = Some("Tier 2".into());
+            let mut term = Terminal::new(TestBackend::new(160, 90)).unwrap();
+            term.draw(|f| app.draw(f)).unwrap();
+            for (label, key) in labels {
+                for _ in 0..200 {
+                    if rendered(&term).contains(label) {
+                        break;
+                    }
+                    let (_, bounds, _, _) = app.page_view.get();
+                    app.on_scroll(bounds.x, bounds.y, Rect::new(0, 0, 160, 90), 1);
+                    term.draw(|f| app.draw(f)).unwrap();
+                }
+                let text = rendered(&term);
+                let (y, x) = text
+                    .lines()
+                    .enumerate()
+                    .find_map(|(y, line)| {
+                        line.find(label).map(|at| (y, line[..at].chars().count()))
+                    })
+                    .unwrap_or_else(|| panic!("missing {label} on {screen}"));
+                assert!(
+                    app.click_targets
+                        .borrow()
+                        .iter()
+                        .any(|(r, c)| r.contains((x as u16, y as u16).into())
+                            && matches!(c, Click::Key(KeyCode::Char(k)) if *k == key)),
+                    "{label} on {screen} must be clickable"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn page_actions_wrapped_scrolled_rows_and_blank_space_have_correct_targets() {
+        let mut app = test_app();
+        app.screen = SC_PAM;
+        let area = Rect::new(0, 0, 40, 16);
+        let mut term = Terminal::new(TestBackend::new(40, 16)).unwrap();
+        term.draw(|f| app.draw(f)).unwrap();
+        for _ in 0..200 {
+            if rendered(&term).contains("Show full status") {
+                break;
+            }
+            app.on_scroll(20, 5, area, 1);
+            term.draw(|f| app.draw(f)).unwrap();
+        }
+        let text = rendered(&term);
+        let (y, x) = text
+            .lines()
+            .enumerate()
+            .find_map(|(y, line)| {
+                line.find("Show full status")
+                    .map(|at| (y, line[..at].chars().count()))
+            })
+            .unwrap_or_else(|| {
+                panic!(
+                    "last action reachable by scrolling: {:?}\n{text}",
+                    app.page_view.get()
+                )
+            });
+        app.on_click(x as u16, y as u16, area);
+        assert!(matches!(app.suspend, Some(Suspend::LoginStatus)));
+        assert!(!app.activity_open);
+        assert!(app.confirm.is_none());
+    }
+
+    #[test]
+    fn page_actions_blank_rows_and_unmarked_text_never_become_commands() {
+        let app = test_app();
+        let mut lines = vec![Line::raw("界界界界界界 [f] plain information")];
+        let mut actions = Vec::new();
+        push_page_action(
+            &mut lines,
+            &mut actions,
+            "w",
+            "Wire login",
+            "wrapped explanation continued below",
+        );
+        push_page_action(&mut lines, &mut actions, "s", "Show full status", "");
+        let mut term = Terminal::new(TestBackend::new(24, 16)).unwrap();
+        term.draw(|f| app.draw_action_paragraph(f, f.area(), lines.clone(), &actions))
+            .unwrap();
+        let text = rendered(&term);
+        for (y, line) in text.lines().enumerate() {
+            if line.trim().is_empty() || line.contains("plain information") || line.contains("[f]")
+            {
+                assert!(
+                    !app.click_targets
+                        .borrow()
+                        .iter()
+                        .any(|(r, _)| r.contains((0, y as u16).into())),
+                    "unmarked text/spacing must stay inert"
+                );
+            }
+        }
+        let y = text
+            .lines()
+            .position(|line| line.contains("continued below"))
+            .unwrap();
+        assert!(app
+            .click_targets
+            .borrow()
+            .iter()
+            .any(|(r, c)| r.contains((0, y as u16).into())
+                && matches!(c, Click::Key(KeyCode::Char('w')))));
+    }
+
+    #[test]
+    fn page_actions_scrolled_diagnostic_row_selects_the_visible_check() {
+        let mut app = test_app();
+        app.screen = SC_REPAIR;
+        app.repair = (0..30)
+            .map(|i| check_row(&format!("check-{i:02}"), Sev::Ok, Fix::None))
+            .collect();
+        app.repair_sel = 29;
+        let text = draw_text(&app);
+        let y = text
+            .lines()
+            .position(|line| line.contains("check-29"))
+            .unwrap();
+        assert!(
+            app.click_targets
+                .borrow()
+                .iter()
+                .any(|(r, c)| r.contains((26, y as u16).into()) && matches!(c, Click::Select(29))),
+            "scrolled list must select the displayed check, not the same row number from the top"
+        );
+    }
+
+    #[test]
+    fn page_actions_login_clicks_reuse_wiring_and_unwire_confirmation() {
+        for (label, key) in [
+            ("Wire login + lock", 'w'),
+            ("Wire face-sudo", 'u'),
+            ("Wire app prompts", 'p'),
+            ("Un-wire everything", 'x'),
+            ("Show full status", 's'),
+        ] {
+            let mut app = test_app();
+            app.screen = SC_PAM;
+            click_text(&mut app, label);
+            if key == 'x' {
+                assert!(app.confirm.is_some(), "unwire asks first");
+                assert!(app.suspend.is_none());
+            } else {
+                assert!(
+                    app.suspend.is_some(),
+                    "{label} must schedule the existing CLI flow"
+                );
+            }
+            assert!(app.op.is_none());
+        }
+    }
+
+    #[test]
+    fn mouse_dialog_confirmation_and_cancel_use_the_same_actions() {
+        let mut app = test_app();
+        for accept in [false, true] {
+            app.confirm = Some((
+                "Change policy?".into(),
+                "Enable",
+                ConfirmAct::Sus(Suspend::PrivilegedConsent(false)),
+            ));
+            click_text(&mut app, if accept { "[y] Enable" } else { "Cancel" });
+            assert!(app.confirm.is_none(), "click must resolve the confirmation");
+            assert_eq!(app.suspend.is_some(), accept);
+        }
+    }
+
+    #[test]
+    fn mouse_input_cancel_and_submit_preserve_typed_confirmation() {
+        let mut app = test_app();
+        app.input = Some((
+            "Type uninstall".into(),
+            "uninstall".into(),
+            Pending::UninstallConfirm,
+        ));
+        click_text(&mut app, "Cancel");
+        assert!(app.input.is_none());
+        assert!(app.suspend.is_none());
+        app.input = Some((
+            "Type uninstall".into(),
+            "wrong".into(),
+            Pending::UninstallConfirm,
+        ));
+        click_text(&mut app, "Continue");
+        assert!(app.input.is_none());
+        assert!(
+            app.suspend.is_none(),
+            "click must not bypass typed confirmation"
+        );
+        app.input = Some((
+            "Type uninstall".into(),
+            "uninstall".into(),
+            Pending::UninstallConfirm,
+        ));
+        click_text(&mut app, "Continue");
+        assert!(matches!(app.suspend, Some(Suspend::Uninstall)));
+    }
+
+    #[test]
+    fn mouse_help_and_error_have_explicit_close_controls() {
+        let mut app = test_app();
+        app.show_help = true;
+        click_text(&mut app, "Close");
+        assert!(!app.show_help);
+        app.error = Some("Something failed".into());
+        click_text(&mut app, "Dismiss");
+        assert!(app.error.is_none());
+    }
+
+    #[test]
+    fn mouse_action_menu_selects_before_opening_and_can_close_without_keyboard() {
+        let mut app = test_app();
+        app.more_actions = Some((String::new(), 0));
+        click_text(&mut app, "Enroll with a chosen scan count");
+        assert_eq!(app.more_actions.as_ref().unwrap().1, 1);
+        assert!(app.input.is_none(), "first click selects and explains");
+        click_text(&mut app, "[Enter] Open");
+        assert!(app.more_actions.is_none());
+        assert!(app.input.is_some(), "open uses the guided argument flow");
+        click_text(&mut app, "Cancel");
+        app.more_actions = Some(("no such action xyz".into(), 0));
+        click_text(&mut app, "Close");
+        assert!(
+            app.more_actions.is_none(),
+            "empty search still has a close control"
+        );
+    }
+
+    #[test]
+    fn mouse_wheel_targets_content_and_does_not_wrap_or_activate() {
+        let mut app = test_app();
+        app.screen = SC_PROFILES;
+        app.profiles = vec![profile("one", &["a"]), profile("two", &["b"])];
+        let area = Rect::new(0, 0, 120, 50);
+        let [_, _, body, activity, _] = app.frame_rows(area);
+        let (_, content) = app.body_split(body);
+        app.on_scroll(content.x, content.y, area, 1);
+        assert_eq!(app.sel, 1);
+        assert!(!app.activity_open);
+        app.on_scroll(content.x, content.y, area, -1);
+        app.on_scroll(content.x, content.y, area, -1);
+        assert_eq!(app.sel, 0, "wheel stops at top rather than wrapping");
+        app.on_scroll(0, 0, area, -1);
+        assert!(
+            !app.activity_open,
+            "header scrolling must not affect Activity"
+        );
+        app.on_scroll(activity.x, activity.y, area, -1);
+        assert!(app.activity_open);
+        assert!(app.op.is_none());
+        assert!(app.suspend.is_none());
+    }
+
+    #[test]
+    fn mouse_modal_blocks_background_clicks_and_wheel() {
+        let mut app = test_app();
+        app.screen = SC_PROFILES;
+        app.profiles = vec![profile("one", &["a"])];
+        app.confirm = Some((
+            "Confirm?".into(),
+            "Enable",
+            ConfirmAct::Sus(Suspend::PrivilegedConsent(false)),
+        ));
+        draw_text(&app);
+        let area = Rect::new(0, 0, 120, 50);
+        app.on_click(1, 49, area);
+        app.on_scroll(1, 46, area, -1);
+        assert!(app.confirm.is_some());
+        assert!(app.suspend.is_none());
+        assert!(!app.activity_open);
+    }
+
+    #[test]
+    fn mouse_long_dialog_scroll_keeps_close_control_visible() {
+        let mut app = test_app();
+        app.error = Some(format!(
+            "{}\nEND OF MESSAGE",
+            "Read this explanation.\n".repeat(30)
+        ));
+        let mut term = Terminal::new(TestBackend::new(40, 12)).unwrap();
+        term.draw(|f| app.draw(f)).unwrap();
+        assert!(!rendered(&term).contains("END OF MESSAGE"));
+        for _ in 0..50 {
+            app.on_scroll(20, 5, Rect::new(0, 0, 40, 12), 1);
+        }
+        term.draw(|f| app.draw(f)).unwrap();
+        let text = rendered(&term);
+        assert!(
+            text.contains("END OF MESSAGE"),
+            "message must be readable by scrolling"
+        );
+        assert!(
+            text.contains("Dismiss"),
+            "close remains visible at the bottom"
+        );
+        assert!(app.error.is_some(), "scrolling does not dismiss the error");
+        assert!(!app.activity_open);
+    }
+
+    #[test]
+    fn mouse_action_rows_follow_scrolled_and_filtered_menu() {
+        let mut app = test_app();
+        let last = actions::ACTIONS.len() - 1;
+        app.more_actions = Some((String::new(), last));
+        click_text(&mut app, actions::ACTIONS[last - 1].label);
+        assert_eq!(app.more_actions.as_ref().unwrap().1, last - 1);
+        app.on_key(KeyCode::Char('z'));
+        assert_eq!(app.more_actions.as_ref().unwrap().1, 0);
+        app.more_actions = Some(("chosen scan count".into(), 0));
+        click_text(&mut app, "Enroll with a chosen scan count");
+        click_text(&mut app, "[Enter] Open");
+        assert!(matches!(app.input, Some((_, _, Pending::ActionField(_)))));
+        assert!(app.op.is_none());
+    }
+
+    #[test]
+    fn mouse_wheel_in_action_menu_is_bounded_and_ignores_background() {
+        let mut app = test_app();
+        app.more_actions = Some((String::new(), 0));
+        let area = Rect::new(0, 0, 120, 50);
+        app.on_scroll(0, 0, area, 1);
+        assert_eq!(app.more_actions.as_ref().unwrap().1, 0);
+        for _ in 0..100 {
+            app.on_scroll(60, 25, area, 1);
+        }
+        assert_eq!(
+            app.more_actions.as_ref().unwrap().1,
+            actions::ACTIONS.len() - 1
+        );
+        assert!(!app.activity_open);
+        assert!(app.input.is_none());
+        assert!(app.confirm.is_none());
+    }
+
     #[test]
     fn modal_grows_to_fit_long_body() {
         let app = test_app();
@@ -8774,7 +9570,7 @@ mod tests {
         // ~8 wrapped lines at the modal's inner width; the last word is the
         // sentinel that the fixed-height modal used to clip away.
         let body = format!("{} ENDBODY", ["lorem"; 40].join(" "));
-        term.draw(|f| app.modal(f, "Confirm", &body)).unwrap();
+        term.draw(|f| app.modal(f, "Confirm", &body, &[])).unwrap();
         let text = rendered(&term);
         assert!(
             text.contains("ENDBODY"),
@@ -12333,6 +13129,111 @@ mod tests {
             None => std::env::remove_var("IRLUME_ENFORCE_BIOPOLICY"),
         }
         assert!(row_with(&text, "biopolicy").contains("● yes"), "{text}");
+    }
+
+    #[test]
+    fn settings_sensor_policy_is_explicitly_local_experimental_and_read_only() {
+        let _guard = dead_socket();
+        let old_cfg = std::env::var_os("IRLUME_CONFIG_DIR");
+        let dir = std::env::temp_dir().join(format!("irlume-tui-sensor-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::env::set_var("IRLUME_CONFIG_DIR", &dir);
+        let original = "face_sensor_policy=ir-only-experimental\n";
+        std::fs::write(dir.join("settings.conf"), original).unwrap();
+        let mut app = test_app();
+        app.screen = SC_SETTINGS;
+        let text = draw_text(&app);
+        assert!(text.contains("local saved: EXPERIMENTAL IR-only"), "{text}");
+        assert!(text.contains("not qualified"), "{text}");
+        assert!(app.confirm.is_none() && app.suspend.is_none());
+        assert_eq!(
+            std::fs::read_to_string(dir.join("settings.conf")).unwrap(),
+            original
+        );
+        match old_cfg {
+            Some(value) => std::env::set_var("IRLUME_CONFIG_DIR", value),
+            None => std::env::remove_var("IRLUME_CONFIG_DIR"),
+        }
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn settings_consent_enable_requires_confirmation_and_cancel_keeps_policy() {
+        let _guard = dead_socket();
+        let old_env = std::env::var_os("IRLUME_PRIVILEGED_FACE_CONSENT");
+        let old_cfg = std::env::var_os("IRLUME_CONFIG_DIR");
+        let dir = std::env::temp_dir().join(format!("irlume-tui-consent-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::env::set_var("IRLUME_CONFIG_DIR", &dir);
+        std::env::remove_var("IRLUME_PRIVILEGED_FACE_CONSENT");
+        std::fs::write(dir.join("settings.conf"), "privileged_face_consent=1\n").unwrap();
+        let mut app = test_app();
+        app.screen = SC_SETTINGS;
+        app.on_key(KeyCode::Char('p'));
+        assert!(
+            app.confirm.is_some() && app.suspend.is_none(),
+            "enabling must first explain the change"
+        );
+        app.on_key(KeyCode::Esc);
+        assert!(app.confirm.is_none() && app.suspend.is_none());
+        assert_eq!(
+            std::fs::read_to_string(dir.join("settings.conf")).unwrap(),
+            "privileged_face_consent=1\n"
+        );
+        app.on_key(KeyCode::Char('p'));
+        app.on_key(KeyCode::Char('y'));
+        assert!(
+            matches!(app.suspend, Some(Suspend::PrivilegedConsent(false))),
+            "acceptance schedules the privileged CLI operation"
+        );
+        app.suspend = None;
+        std::fs::write(dir.join("settings.conf"), "privileged_face_consent=0\n").unwrap();
+        app.on_key(KeyCode::Char('p'));
+        assert!(
+            app.confirm.is_none() && matches!(app.suspend, Some(Suspend::PrivilegedConsent(true))),
+            "restoring confirmation is direct"
+        );
+        app.suspend = None;
+        std::fs::remove_file(dir.join("settings.conf")).unwrap();
+        std::fs::create_dir(dir.join("settings.conf")).unwrap();
+        app.on_key(KeyCode::Char('p'));
+        assert!(
+            app.confirm.is_none() && app.suspend.is_none(),
+            "unknown state must not guess a toggle direction"
+        );
+        drain_loads(&mut app);
+        match old_env {
+            Some(v) => std::env::set_var("IRLUME_PRIVILEGED_FACE_CONSENT", v),
+            None => std::env::remove_var("IRLUME_PRIVILEGED_FACE_CONSENT"),
+        }
+        match old_cfg {
+            Some(v) => std::env::set_var("IRLUME_CONFIG_DIR", v),
+            None => std::env::remove_var("IRLUME_CONFIG_DIR"),
+        }
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn settings_consent_reflects_policy_and_cannot_hide_an_override() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let old = std::env::var_os("IRLUME_PRIVILEGED_FACE_CONSENT");
+        for (v, expected) in [("0", "hands-free"), ("1", "required"), ("typo", "required")] {
+            std::env::set_var("IRLUME_PRIVILEGED_FACE_CONSENT", v);
+            let mut app = test_app();
+            app.screen = SC_SETTINGS;
+            let text = draw_text(&app);
+            assert!(
+                text.contains(expected) && text.contains("privileged"),
+                "{text}"
+            );
+            assert!(text.contains("environment override"), "{text}");
+            app.on_key(KeyCode::Char('p'));
+            assert!(app.suspend.is_none() && app.confirm.is_none());
+        }
+        match old {
+            Some(v) => std::env::set_var("IRLUME_PRIVILEGED_FACE_CONSENT", v),
+            None => std::env::remove_var("IRLUME_PRIVILEGED_FACE_CONSENT"),
+        }
     }
 
     #[test]

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -301,6 +301,7 @@ enum Suspend {
     /// state). Root op; the daemon reads it live, no restart.
     Biopolicy(bool),
     PrivilegedConsent(bool),
+    FaceSensorPolicy(bool),
     /// IR liveness self-test via `sudo irlume selftest liveness` (the daemon
     /// root-gates it; the raw measurements are a spoof-tuning oracle).
     SelfTestLiveness,
@@ -325,6 +326,7 @@ enum Sev {
     Ok,
     Warn,
     Fail,
+    Unknown,
 }
 
 /// What can be done about a failing/■warning check.
@@ -340,6 +342,7 @@ enum Fix {
     /// and open it (`apply_fix` routes through the same key handlers the
     /// screen's own button uses, so every gate still applies).
     Goto(GotoFix),
+    Action(&'static actions::Action),
 }
 
 /// In-TUI fix destinations. Each pairs a screen with the key that opens the
@@ -351,6 +354,8 @@ enum GotoFix {
     Enroll,
     /// Recovery screen, \[s]: set the recovery passphrase.
     RecoveryPass,
+    RecoveryRestore,
+    KeyringReseal,
     /// Password Wallet screen, \[a\]: (re-)arm the keyring seal.
     KeyringArm,
 }
@@ -683,6 +688,7 @@ struct App {
     /// ground truth for the Repair rows (static path probes lie when the daemon
     /// runs with its own env, e.g. a packaged install).
     health: Option<HealthInfo>,
+    preferences: Option<irlume_common::PreferencesState>,
     /// Activity panel scroll offset (lines up from the bottom; 0 = follow newest).
     act_scroll: usize,
     /// Whether the activity history is expanded. The default is a one-line
@@ -889,6 +895,7 @@ struct LightState {
     /// seconds from ready) and EACCES must not read as "not reachable".
     reach: crate::commands::DaemonReach,
     health: Option<HealthInfo>,
+    preferences: Option<irlume_common::PreferencesState>,
     keyring_armed: Option<bool>,
     keyring_policy: Option<String>,
     keyring_drift: Option<bool>,
@@ -918,12 +925,16 @@ impl LightState {
             daemon_up,
             reach,
             health: None,
+            preferences: None,
             keyring_armed: prev_armed,
             keyring_policy: None,
             keyring_drift: None,
             keyring_kind: None,
             recovery: None,
         };
+        if daemon_up || reach == crate::commands::DaemonReach::Starting {
+            out.preferences = crate::preferences::daemon_state();
+        }
         if !daemon_up {
             return out;
         }
@@ -1114,6 +1125,7 @@ impl App {
             daemon_reach: crate::commands::DaemonReach::Down,
             enroll_error: None,
             health: None,
+            preferences: None,
             act_scroll: 0,
             activity_open: false,
             reduce_motion: std::env::var_os("IRLUME_REDUCE_MOTION")
@@ -1324,6 +1336,7 @@ impl App {
         // Daemon down/unresponsive: show the down state; the local probes
         // still land via the heavy sweep so Repair can diagnose.
         self.health = l.health;
+        self.preferences = l.preferences;
         // The daemon is the authority on cameras while it is reachable.
         if let Some(h) = self.health.as_ref() {
             self.caps = Self::caps_from_health(h);
@@ -1509,9 +1522,7 @@ impl App {
                         "running, but this user may not connect (EACCES on {})",
                         irlume_common::client::socket_path().display()
                     ),
-                    Fix::Manual(
-                        "see the SELinux policy row below; sudo irlume selinux status".into(),
-                    ),
+                    Fix::Action(&actions::SELINUX_STATUS),
                 ),
                 // Name the socket the ping actually used: with IRLUME_SOCKET
                 // set, "/run/irlume.sock" described a path nobody probed.
@@ -1727,25 +1738,15 @@ impl App {
                 .any(|(_, r)| matches!(r, irlume_camera::Role::Ir));
             let priv_on = self.pairs.iter().any(|p| p.privacy);
             let (csev, cdetail, cfix) = if self.nodes.is_empty() {
-                // NOTHING was probed, which is not the same as nothing being
-                // there. `nodes` is only ever filled by a classifying scan, and
-                // this screen deliberately does not run one: classifying opens
-                // every node, which is the device contention #187 is about, so
-                // the daemon's Health is where camera facts normally come from
-                // and the daemon is what is down in this branch. The old text
-                // read the empty list as proof and told everyone with a working
-                // camera that face auth was unavailable, on the one screen they
-                // opened to find out what was wrong.
-                (
-                    Sev::Warn,
-                    "cannot check the cameras while the daemon is down (start it with: \
-                     sudo systemctl start irlumed)"
-                        .to_string(),
-                    // The RestartDaemon fix is exactly this command via sudo;
-                    // a Manual string made the row describe a fix the TUI
-                    // already knew how to run.
-                    Fix::Root(RootFix::RestartDaemon),
-                )
+                // No observation is not proof of missing cameras. In particular,
+                // restarting cannot fix a still-loading or inaccessible daemon.
+                use crate::commands::DaemonReach as R;
+                match self.daemon_reach {
+                    R::Starting => (Sev::Warn, "camera status pending while models load; wait or re-check".into(), Fix::None),
+                    R::AccessDenied => (Sev::Warn, "camera status unknown: this account cannot access the daemon; inspect the access-policy diagnosis".into(), Fix::None),
+                    R::Running => (Sev::Warn, "camera status not reported by the daemon; re-check or inspect Full Diagnostics".into(), Fix::None),
+                    R::Down => (Sev::Warn, "cannot check the cameras while the daemon is down; use Fix Selected Issue to start it".into(), Fix::Root(RootFix::RestartDaemon)),
+                }
             } else if !rgb && !ir {
                 (
                     Sev::Warn,
@@ -1824,7 +1825,7 @@ impl App {
             // state nobody has observed yet.
             v.push(mk(
                 "Enrollment",
-                Sev::Ok,
+                Sev::Unknown,
                 "loading profiles…".into(),
                 Fix::None,
             ));
@@ -1835,7 +1836,7 @@ impl App {
             // unanswered question renders as unknown, never as a negative.
             v.push(mk(
                 "Enrollment",
-                Sev::Warn,
+                Sev::Unknown,
                 "unknown (profile list not read yet)".into(),
                 Fix::None,
             ));
@@ -1931,7 +1932,7 @@ impl App {
                         "Method wiring",
                         Sev::Fail,
                         "method is fingerprint but pam_fprintd is not wired".into(),
-                        Fix::Manual("Fingerprint → [e] unlock with face OR fingerprint".into()),
+                        Fix::Action(&actions::FINGERPRINT_ONLY),
                     ));
                 } else if self.fp.enrolled.is_empty() {
                     v.push(mk(
@@ -1965,9 +1966,7 @@ impl App {
                             "FP keyring unlock",
                             Sev::Warn,
                             "wallet won't auto-unlock on fingerprint login; arm the keyring".into(),
-                            Fix::Manual(
-                                "Password Wallet → [a] connect (seal your login password)".into(),
-                            ),
+                            Fix::Goto(GotoFix::KeyringArm),
                         ));
                     } else if self.keyring_armed == Some(true) && !wired {
                         v.push(mk(
@@ -2125,7 +2124,7 @@ impl App {
                 "Keyring seal",
                 Sev::Warn,
                 "PCRs drifted since sealing; the wallet won't auto-unlock until re-bound".into(),
-                Fix::Manual("Password Wallet → [r] reseal (re-bind to current PCRs)".into()),
+                Fix::Goto(GotoFix::KeyringReseal),
             ));
         }
 
@@ -2153,25 +2152,29 @@ impl App {
             ));
         }
         if let Some(r) = self.recovery {
-            if r.encrypted && !r.recovery_set {
+            if r.encrypted && !r.key_present {
+                v.push(mk(
+                    "Recovery backstop",
+                    Sev::Fail,
+                    if r.recovery_set {
+                        "template key is MISSING; restore it using the existing recovery passphrase"
+                            .into()
+                    } else {
+                        "template key is MISSING and no recovery is set; re-enrollment is required"
+                            .into()
+                    },
+                    if r.recovery_set {
+                        Fix::Goto(GotoFix::RecoveryRestore)
+                    } else {
+                        Fix::Goto(GotoFix::Enroll)
+                    },
+                ));
+            } else if r.encrypted && !r.recovery_set {
                 v.push(mk(
                     "Recovery backstop",
                     Sev::Warn,
                     "templates encrypted but no recovery passphrase".into(),
                     Fix::Goto(GotoFix::RecoveryPass),
-                ));
-            } else if r.encrypted && !r.key_present {
-                // Encrypted with the key gone: no passphrase and no reseal opens
-                // it, so this is not a backstop question at all. The Cameras-side
-                // row already says this loudly; the check said "encrypted +
-                // recovery set" and passed.
-                v.push(mk(
-                    "Recovery backstop",
-                    Sev::Fail,
-                    "templates encrypted but the template key is MISSING: nothing can \
-                     open them"
-                        .into(),
-                    Fix::Goto(GotoFix::Enroll),
                 ));
             } else {
                 v.push(mk(
@@ -2197,7 +2200,9 @@ impl App {
             .recovery
             .map(|r| r.tpm_present)
             .unwrap_or(self.probes.tpm_present);
-        if !tpm {
+        if self.recovery.is_none() && !self.probes_landed {
+            v.push(mk("TPM", Sev::Unknown, "not checked yet".into(), Fix::None));
+        } else if !tpm {
             v.push(mk("TPM", Sev::Warn,
                 "no TPM: templates stored root-only plaintext; keyring auto-unlock unavailable (face login/sudo still work)".into(),
                 Fix::Manual("optional: enable the firmware TPM (fTPM/PTT) in BIOS, then re-enroll to encrypt at rest".into())));
@@ -2232,7 +2237,20 @@ impl App {
             }
         };
         match fix {
-            Fix::None => self.log('·', "nothing to fix on this row"),
+            Fix::None => self.log(
+                '·',
+                if self.repair[idx].sev == Sev::Ok {
+                    "nothing to fix on this row"
+                } else if self.repair[idx].sev == Sev::Unknown {
+                    "this check has not completed; wait or re-check"
+                } else {
+                    "no automatic repair; review the selected diagnosis and Full Diagnostics"
+                },
+            ),
+            Fix::Action(action) => self.prepare_action(actions::Invocation {
+                action,
+                values: Vec::new(),
+            }),
             Fix::Manual(cmd) => self.log('·', format!("manual fix → {cmd}")),
             // Navigate-and-open: the destination screen's own key handler runs
             // (with all of its gating), so the fix is the same flow the user
@@ -2240,6 +2258,10 @@ impl App {
             Fix::Goto(g) => {
                 let (screen, key, what) = match g {
                     GotoFix::Enroll => (SC_PROFILES, KeyCode::Char('e'), "enroll a face"),
+                    GotoFix::RecoveryRestore => {
+                        (SC_RECOVERY, KeyCode::Char('t'), "restore the template key")
+                    }
+                    GotoFix::KeyringReseal => (SC_KEYRING, KeyCode::Char('r'), "reseal the wallet"),
                     GotoFix::RecoveryPass => (
                         SC_RECOVERY,
                         KeyCode::Char('s'),
@@ -2947,6 +2969,8 @@ impl App {
         if status.is_ok() {
             // A child can change app policy before failing. Refresh after any
             // exit, since the exit status alone says nothing about rollback.
+            self.preferences = None;
+            self.light_load = None; // discard observations begun before the mutation
             self.refresh_heavy();
         }
         match status {
@@ -3133,6 +3157,18 @@ impl App {
             Suspend::PcrlockMakePolicy => self.sudo_step(
                 "refresh the pcrlock policy (re-predict the boot measurements)",
                 &["systemd-pcrlock", "make-policy"],
+            ),
+            Suspend::FaceSensorPolicy(ir_only) => self.sudo_step(
+                if ir_only {
+                    "enable experimental IR-only"
+                } else {
+                    "restore dual-camera authentication"
+                },
+                if ir_only {
+                    &["irlume", "auth", "sensor", "ir-only", "--yes"]
+                } else {
+                    &["irlume", "auth", "sensor", "dual"]
+                },
             ),
             Suspend::PrivilegedConsent(required) => self.sudo_step(
                 if required {
@@ -3490,6 +3526,9 @@ impl App {
     }
 
     fn move_sel(&mut self, d: i32) {
+        if self.screen == SC_REPAIR {
+            self.page_view.set((usize::MAX, Rect::default(), 0, 0));
+        }
         let len = match self.screen {
             SC_REPAIR => self.repair.len(),
             SC_CAMERAS => self.pairs.len(),
@@ -3716,37 +3755,15 @@ impl App {
                 self.log('→', "sudo systemd-pcrlock make-policy: refreshes the boot-measurement policy your seal is bound to");
                 self.suspend = Some(Suspend::PcrlockMakePolicy);
             }
-            // Reseal: re-bind the sealed password to the current PCRs (the CLI
-            // `irlume reseal`). Same masked-prompt + SealPassword path as arm;
-            // the distinct entry point and copy are the discoverability the
-            // drift-recovery workflow needs.
+            // The CLI owns seal-kind recovery (token seals must not be re-armed here).
             (SC_KEYRING, KeyCode::Char('r')) if self.keyring_armed == Some(true) => {
-                self.input = Some((
-                    "Login password to re-seal to current PCRs (••):".into(),
-                    String::new(),
-                    Pending::KeyringPw(None),
-                ));
+                self.prepare_action(actions::Invocation { action: &actions::WALLET_RESEAL, values: Vec::new() });
             }
             (SC_KEYRING, KeyCode::Char('f')) => {
-                // A token arm (#250) must re-key the login keyring back to the
-                // password before the envelope is erased; a bare forget here
-                // would delete the keyring's live credential. That flow needs
-                // a password prompt and the control socket, so route it to the
-                // CLI rather than duplicating it in TUI state.
-                // Anything other than a confirmed non-token refuses here.
-                // `None` means an older daemon or an envelope it could not
-                // parse, and erasing a token envelope on that reading leaves
-                // the login keyring encrypted under a secret nothing can
-                // reproduce. The CLI has the re-key flow and the --force
-                // escape; this screen has neither, so it defers.
-                if self.keyring_kind != Some(irlume_common::KeyringSecretKind::LoginPassword)
-                    && self.keyring_kind != Some(irlume_common::KeyringSecretKind::KdeWalletKey)
-                {
-                    self.log(
-                        '!',
-                        "cannot confirm this is safe to erase from here; run `irlume keyring \
-                         forget` in a terminal (it re-keys a token back to your password first)",
-                    );
+                // The CLI performs the password rekey before deleting token seals and
+                // refuses unknown formats; never offer its force option implicitly.
+                if !matches!(self.keyring_kind, Some(irlume_common::KeyringSecretKind::LoginPassword | irlume_common::KeyringSecretKind::KdeWalletKey)) {
+                    self.prepare_action(actions::Invocation { action: &actions::WALLET_FORGET, values: Vec::new() });
                     return;
                 }
                 self.confirm = Some((
@@ -3861,13 +3878,26 @@ impl App {
                 }
                 None => self.log('·', "Bitwarden is not installed on this system"),
             },
+            // Sensor selection is explicit; an unknown observation never guesses a toggle.
+            (SC_SETTINGS, KeyCode::Char('i')) => {
+                use irlume_common::config::FaceSensorPolicy;
+                match self.preference_state().face_sensor_policy.resolve() {
+                    Ok(FaceSensorPolicy::IrOnlyExperimental) => self.suspend = Some(Suspend::FaceSensorPolicy(false)),
+                    Ok(FaceSensorPolicy::Dual) => self.confirm = Some((
+                        format!("Enable experimental IR-only? {}", crate::sensor_policy::WARNING),
+                        "Enable", ConfirmAct::Sus(Suspend::FaceSensorPolicy(true)),
+                    )),
+                    Err(_) => self.log('·', "Sensor policy is unavailable or invalid. Open Repair and inspect the settings before changing it."),
+                }
+            }
+            (SC_SETTINGS, KeyCode::Char('r')) => self.prepare_action(actions::Invocation { action: &actions::SENSOR_PREFLIGHT, values: Vec::new() }),
             // Settings.
             (SC_SETTINGS, KeyCode::Char('p')) => {
-                if crate::consent::overridden() {
+                if crate::consent::overridden() || self.preference_state().consent_overridden {
                     self.log('·', "An environment override controls privileged consent; remove it before changing the saved setting.");
                     return;
                 }
-                match irlume_common::config::privileged_face_consent_visible() {
+                match self.preference_state().privileged_face_consent {
                     Some(true) => {
                         self.confirm = Some((
                             format!("Enable hands-free privileged face authentication? {} {}", crate::consent::SCOPE, crate::consent::WARNING),
@@ -3876,18 +3906,21 @@ impl App {
                         ));
                     }
                     Some(false) => self.suspend = Some(Suspend::PrivilegedConsent(true)),
-                    None => self.log('·', "Cannot read privileged consent settings. Run sudo irlume tui or sudo irlume auth consent status."),
+                    None => self.log('·', "Preferences are unavailable. Open Repair to check the daemon, then refresh; no setting was changed."),
                 }
             }
             // Biopolicy gate: enabling changes the security posture (restricts
             // which services a face may satisfy), so it is confirmed; disabling
             // just relaxes back to default and goes straight through.
             (SC_SETTINGS, KeyCode::Char('b')) => {
-                let Some(on) = irlume_common::config::enforce_biopolicy_visible() else {
+                if self.preference_state().biopolicy_overridden || std::env::var_os("IRLUME_ENFORCE_BIOPOLICY").is_some() {
+                    self.log('·', "An environment override controls biopolicy; remove it before changing the saved setting.");
+                    return;
+                }
+                let Some(on) = self.preference_state().enforce_biopolicy else {
                     self.log(
                         '·',
-                        "the biopolicy gate is a root-only setting; run the TUI with sudo, \
-                         or check it with: irlume biopolicy status",
+                        "Preferences are unavailable. Open Repair to check the daemon, then refresh; no setting was changed.",
                     );
                     return;
                 };
@@ -4721,12 +4754,16 @@ impl App {
             }
             _ => return,
         };
+        let previous = *selected;
         *selected = if direction < 0 {
             selected.saturating_sub(1)
         } else {
             selected.saturating_add(1)
         }
         .min(len.saturating_sub(1));
+        if self.screen == SC_REPAIR && *selected != previous {
+            self.page_view.set((usize::MAX, Rect::default(), 0, 0));
+        }
     }
 
     /// Map a mouse click (or touchscreen tap, delivered as the same left-click)
@@ -4813,6 +4850,7 @@ impl App {
                             self.on_key(KeyCode::Enter);
                         } else {
                             self.repair_sel = i;
+                            self.page_view.set((usize::MAX, Rect::default(), 0, 0));
                         }
                     }
                     SC_CAMERAS if i < self.pairs.len() => {
@@ -5319,33 +5357,61 @@ impl App {
         }
     }
 
+    fn preference_state(&self) -> irlume_common::PreferencesState {
+        self.preferences
+            .unwrap_or_else(irlume_common::PreferencesState::observe)
+    }
+
     fn draw_settings(&self, f: &mut Frame, area: Rect) {
         let mut page_actions = Vec::new();
         // The shared reader, which agrees with the daemon's truthy set (`yes` and
         // `on` count too) and admits when the root-only file cannot be read. The
         // local `biopolicy_on` accepted only `1`/`true`, so `enforce_biopolicy=yes`
         // drew "turn it on" while the daemon was already enforcing.
-        let bio = irlume_common::config::enforce_biopolicy_visible();
+        let bio = self.preference_state().enforce_biopolicy;
         let lines = {
             let mut v = Vec::new();
-            let consent = irlume_common::config::privileged_face_consent_visible();
+            let consent = self.preference_state().privileged_face_consent;
+            let state = self.preference_state();
+            v.push(Line::raw(if self.preferences.is_some() {
+                "  State: daemon observed (refreshes automatically)"
+            } else {
+                "  State: local observation; daemon preferences unavailable"
+            }));
+            v.push(Line::raw(""));
             v.push(section("Face sensor policy"));
+            let ir_only = state.face_sensor_policy.resolve().ok().map(|policy| {
+                policy == irlume_common::config::FaceSensorPolicy::IrOnlyExperimental
+            });
             v.push(Line::raw(format!(
-                "  {}",
-                crate::sensor_policy::local_status_line()
+                "  IR-only: {} — {}",
+                crate::preferences::toggle_label(ir_only),
+                crate::sensor_policy::state_label(state.face_sensor_policy)
             )));
-            v.push(Line::raw("  Inspect the daemon: irlume auth sensor status"));
+            push_page_actions(
+                &mut v,
+                &mut page_actions,
+                &[
+                    (
+                        "i",
+                        match ir_only {
+                            Some(true) => "turn IR-only off (use dual cameras)",
+                            Some(false) => "turn IR-only on (experimental; asks first)",
+                            None => "IR-only unavailable (inspect settings)",
+                        },
+                    ),
+                    ("r", "check IR-only readiness for this account"),
+                ],
+            );
             v.push(Line::raw(
-                "  Change as root: irlume auth sensor dual / ir-only --yes",
-            ));
-            v.push(Line::raw(
-                "  IR-only is experimental, not qualified; consent and PAM wiring are separate.",
+                "  Enabled policy does not guarantee readiness or a successful login.",
             ));
             v.push(Line::raw(""));
             v.push(section("Face authentication at privileged prompts"));
             v.push(Line::raw(""));
             v.push(Line::raw(format!(
-                "  {}",
+                "  Hands-free: {} — {}",
+                crate::preferences::toggle_label(consent.map(|required| !required)),
                 crate::consent::state_label(consent)
             )));
             v.push(Line::raw(
@@ -5355,9 +5421,16 @@ impl App {
                 "  Login and lock-screen start behavior is separate.",
             ));
             v.push(Line::raw(""));
-            if crate::consent::overridden() {
+            if crate::consent::overridden() || self.preference_state().consent_overridden {
                 v.push(Line::raw(
-                    "  Local environment override; daemon policy may differ.",
+                    if self
+                        .preferences
+                        .is_some_and(|state| state.consent_overridden)
+                    {
+                        "  Daemon environment override controls this setting."
+                    } else {
+                        "  Local environment override; daemon policy may differ."
+                    },
                 ));
                 v.push(Line::raw(
                     "  Remove IRLUME_PRIVILEGED_FACE_CONSENT before changing this setting.",
@@ -5366,7 +5439,7 @@ impl App {
                 let action = match consent {
                     Some(true) => "enable hands-free (asks first)",
                     Some(false) => "restore required confirmation",
-                    None => "state unavailable; run sudo irlume tui to inspect settings",
+                    None => "state unavailable; open Repair to check the daemon",
                 };
                 push_page_actions(&mut v, &mut page_actions, &[("p", action)]);
             }
@@ -5379,20 +5452,20 @@ impl App {
                     // the raw read showed "off (default)" here while the Done
                     // dashboard said "◐ root-only" for the same key. Same
                     // truthy set and env override as the daemon.
-                    let (icon, icon_style, label) =
-                        match irlume_common::config::enforce_biopolicy_visible() {
-                            Some(true) => (
-                                "●",
-                                Style::new().fg(th().ok).add_modifier(Modifier::BOLD),
-                                "ENFORCING",
-                            ),
-                            Some(false) => ("○", Style::new().dim(), "off (default)"),
-                            None => (
-                                "◐",
-                                Style::new().fg(th().warn),
-                                "on/off is root-only; run the TUI with sudo to see it",
-                            ),
-                        };
+                    let (icon, icon_style, label) = match self.preference_state().enforce_biopolicy
+                    {
+                        Some(true) => (
+                            "●",
+                            Style::new().fg(th().ok).add_modifier(Modifier::BOLD),
+                            "ON — ENFORCING",
+                        ),
+                        Some(false) => ("○", Style::new().dim(), "OFF — off (default)"),
+                        None => (
+                            "◐",
+                            Style::new().fg(th().warn),
+                            "UNKNOWN — settings unavailable",
+                        ),
+                    };
                     Line::from(vec![
                         Span::raw("  state  "),
                         Span::styled(format!("{icon} "), icon_style),
@@ -5412,6 +5485,10 @@ impl App {
                     Style::new().dim(),
                 )),
             ]);
+            if state.biopolicy_overridden || std::env::var_os("IRLUME_ENFORCE_BIOPOLICY").is_some()
+            {
+                v.push(Line::raw(if self.preferences.is_some_and(|state| state.biopolicy_overridden) { "  Daemon environment override controls biopolicy; the saved value has no effect." } else { "  Local environment override; daemon policy may differ. Remove it before changing this setting." }));
+            }
             push_page_actions(
                 &mut v,
                 &mut page_actions,
@@ -5420,7 +5497,7 @@ impl App {
                     match bio {
                         Some(true) => "turn it off (sudo)",
                         Some(false) => "turn it on (sudo; asks first)",
-                        None => "biopolicy state is root-only; run the TUI with sudo",
+                        None => "state unavailable; open Repair to check the daemon",
                     },
                 )],
             );
@@ -5748,11 +5825,12 @@ impl App {
                 "● encrypted",
                 Style::new().fg(th().ok).add_modifier(Modifier::BOLD),
             ),
-            // Encrypted with the key gone: safe from a stolen disk and
-            // unreadable by its owner. Neither a reseal nor a recovery
-            // passphrase brings it back, so say re-enroll and say it loudly.
             Some(r) if r.encrypted => Span::styled(
-                "✗ encrypted, TEMPLATE KEY MISSING (re-enroll)",
+                if r.recovery_set {
+                    "✗ encrypted, TEMPLATE KEY MISSING (restore with passphrase)"
+                } else {
+                    "✗ encrypted, TEMPLATE KEY MISSING (re-enroll; no recovery set)"
+                },
                 Style::new().fg(th().err).add_modifier(Modifier::BOLD),
             ),
             Some(_) => Span::styled("○ plaintext at rest", Style::new().dim()),
@@ -5787,6 +5865,13 @@ impl App {
                     "  No TPM on this host: templates stay plaintext; recovery N/A.",
                     Style::new().fg(th().err),
                 )));
+            }
+            Some(r) if r.encrypted && !r.key_present => {
+                lines.push(Line::raw(if r.recovery_set {
+                    "  Restore the existing backup with [t]; the passphrase is entered privately."
+                } else {
+                    "  No template key or recovery backup remains. Open Faces to re-enroll."
+                }));
             }
             Some(r) if r.encrypted && !r.recovery_set => {
                 lines.push(Line::from(Span::styled(
@@ -6005,13 +6090,19 @@ impl App {
     /// sidebar instead of turning the summary into a second copy of navigation.
     fn hub_rows(&self) -> Vec<(&'static str, Option<bool>, usize)> {
         let scans: usize = self.profiles.iter().map(|p| p.scans.len()).sum();
-        let diagnostics = (!self.repair.is_empty() || self.probes_landed).then_some(
-            self.daemon_up
-                && !self
-                    .repair
-                    .iter()
-                    .any(|c| c.sev == Sev::Fail || c.sev == Sev::Warn),
-        );
+        let diagnostics = if self
+            .repair
+            .iter()
+            .any(|c| matches!(c.sev, Sev::Fail | Sev::Warn))
+        {
+            Some(false)
+        } else if self.repair.iter().any(|c| c.sev == Sev::Unknown)
+            || (!self.probes_landed && self.repair.is_empty())
+        {
+            None
+        } else {
+            Some(self.daemon_up)
+        };
         // None means not observed yet, never "no". These rows express outcomes
         // in user language and follow the setup order in the sidebar.
         let all: [(&'static str, Option<bool>, usize); 6] = [
@@ -6188,13 +6279,17 @@ impl App {
     /// vendor-stack, polkit sandbox, install hygiene) stay in `doctor`.
     fn draw_repair(&self, f: &mut Frame, area: Rect) {
         let mut page_actions = Vec::new();
-        let [list_area, info_area] =
-            Layout::vertical([Constraint::Min(4), Constraint::Length(26)]).areas(area);
+        let [list_area, info_area] = Layout::vertical([
+            Constraint::Min(4),
+            Constraint::Length((area.height.saturating_mul(3) / 5).clamp(8, 26)),
+        ])
+        .areas(area);
 
         // ---- checklist --------------------------------------------------
         let ok = self.repair.iter().filter(|c| c.sev == Sev::Ok).count();
         let fail = self.repair.iter().filter(|c| c.sev == Sev::Fail).count();
         let warn = self.repair.iter().filter(|c| c.sev == Sev::Warn).count();
+        let unknown = self.repair.iter().filter(|c| c.sev == Sev::Unknown).count();
         let items: Vec<ListItem> = self
             .repair
             .iter()
@@ -6203,12 +6298,14 @@ impl App {
                     Sev::Ok => ("✓", th().ok),
                     Sev::Warn => ("⚠", th().warn),
                     Sev::Fail => ("✗", th().err),
+                    Sev::Unknown => ("◐", th().warn),
                 };
                 let tag = match &c.fix {
                     Fix::None => "",
                     Fix::Manual(_) => " · manual",
                     Fix::Root(_) => " · [f] fix (sudo)",
                     Fix::Goto(_) => " · [f] fix",
+                    Fix::Action(_) => " · [f] review action",
                 };
                 ListItem::new(Line::from(vec![
                     Span::styled(
@@ -6249,7 +6346,9 @@ impl App {
 
         // ---- info / platform / live test --------------------------------
         let (sb_present, sb_enabled, sb_setup) = self.probes.secureboot;
-        let sb = if sb_enabled {
+        let sb = if !self.probes_landed {
+            ("unknown", th().warn)
+        } else if sb_enabled {
             ("enabled", th().ok)
         } else if sb_setup {
             ("setup mode", th().warn)
@@ -6262,12 +6361,29 @@ impl App {
             Span::styled(format!("  {ok} ok"), Style::new().fg(th().ok)),
             Span::styled(format!("   {warn} warn"), Style::new().fg(th().warn)),
             Span::styled(format!("   {fail} fail"), Style::new().fg(th().err)),
+            Span::styled(format!("   {unknown} unknown"), Style::new().fg(th().warn)),
         ])];
         lines.push(Line::raw(""));
+        if !self.probes_landed {
+            lines.push(Line::raw(
+                "  System checks pending; setup state is not fully established.",
+            ));
+        } else if self.probes_load.is_some() {
+            lines.push(Line::raw(
+                "  Refreshing; showing the last completed system checks.",
+            ));
+        }
         if let Some(c) = self.repair.get(self.repair_sel) {
+            lines.push(section(&c.label));
+            lines.push(Line::raw(format!("  {}", c.detail)));
             let hint = match &c.fix {
-                // "no action needed" next to a non-zero fail count reads as a
-                // contradiction; point at the failing rows instead.
+                Fix::None if c.sev == Sev::Unknown => {
+                    "This check has not completed; wait or re-check.".to_string()
+                }
+                Fix::None if c.sev != Sev::Ok => {
+                    "No automatic repair for this row; use its explanation and Full Diagnostics."
+                        .to_string()
+                }
                 Fix::None if fail > 0 => {
                     "this row is fine; ↑↓ select a failing row for its fix".to_string()
                 }
@@ -6275,6 +6391,7 @@ impl App {
                 Fix::Manual(cmd) => format!("manual: {cmd}"),
                 Fix::Root(_) => "press [f]: irlume runs the fix with sudo".to_string(),
                 Fix::Goto(_) => "press [f]: opens the fixing flow here in the TUI".to_string(),
+                Fix::Action(_) => "press [f]: review and run the guided action here".to_string(),
             };
             lines.push(Line::from(vec![
                 Span::styled("  → ", Style::new().fg(th().accent)),
@@ -6289,7 +6406,9 @@ impl App {
             Span::styled(
                 format!(
                     "TPM {} · ",
-                    if self.probes.tpm_present {
+                    if !self.probes_landed {
+                        "unknown"
+                    } else if self.probes.tpm_present {
                         "✓"
                     } else {
                         "✗"
@@ -6669,7 +6788,7 @@ impl App {
                 // this in `status` (settings.conf is 0600 root-only, so an
                 // unreadable key must not print as off), and the two surfaces
                 // must agree on the daemon's truthy set and env override.
-                match irlume_common::config::enforce_biopolicy_visible() {
+                match self.preference_state().enforce_biopolicy {
                     Some(v) => onoff(v),
                     None => Span::styled("◐ root-only", Style::new().fg(th().warn)),
                 },
@@ -6883,7 +7002,12 @@ impl App {
                 ("x", "Disconnect…"),
                 ("s", "Show Status"),
             ],
-            SC_SETTINGS => &[("p", "Privileged consent…"), ("b", "Biopolicy…")],
+            SC_SETTINGS => &[
+                ("i", "IR-only…"),
+                ("r", "Readiness…"),
+                ("p", "Privileged consent…"),
+                ("b", "Biopolicy…"),
+            ],
             // [w] only while wiring is OBSERVED missing: the body hides its
             // [w] line on a wired box, and a footer still offering it invites
             // a needless `sudo irlume login enable --apply` re-run. Unknown
@@ -8936,6 +9060,7 @@ mod tests {
             daemon_reach: crate::commands::DaemonReach::Down,
             enroll_error: None,
             health: None,
+            preferences: None,
             act_scroll: 0,
             activity_open: false,
             reduce_motion: false,
@@ -9169,7 +9294,13 @@ mod tests {
         assert!(matches!(app.input, Some((_, _, Pending::KeyringPw(_)))));
         app.on_key(KeyCode::Esc);
         click_text(&mut app, "[r] reseal");
-        assert!(matches!(app.input, Some((_, _, Pending::KeyringPw(_)))));
+        assert!(
+            matches!(&app.confirm, Some((_, _, ConfirmAct::Sus(Suspend::MoreAction(invocation)))) if invocation.action.args == ["reseal"])
+        );
+        assert!(
+            app.input.is_none(),
+            "the CLI must select the correct seal recovery path first"
+        );
         app.on_key(KeyCode::Esc);
         click_text(&mut app, "[f] forget");
         assert!(app.confirm.is_some());
@@ -10776,31 +10907,32 @@ mod tests {
             _ => panic!("expected the keyring password prompt"),
         }
         app.input = None;
-        // [r] reseal opens the masked prompt ONLY when armed (re-bind needs an
-        // existing seal); the CLI `irlume reseal` reachable from the TUI.
+        // Reseal delegates credential handling to the shared CLI only when armed.
         app.keyring_armed = Some(false);
         app.on_key(KeyCode::Char('r'));
-        assert!(app.input.is_none(), "reseal is inert when not armed");
+        assert!(app.input.is_none() && app.confirm.is_none());
         app.keyring_armed = Some(true);
         app.on_key(KeyCode::Char('r'));
-        match &app.input {
-            Some((prompt, _, p @ Pending::KeyringPw(None))) => {
-                assert!(p.masked() && prompt.contains("re-seal"), "got: {prompt}");
-            }
-            _ => panic!("expected the reseal password prompt"),
-        }
-        app.input = None;
-
-        // An unidentified arm must NOT offer the plain erase: `None` is what an
-        // older daemon reports and what an unparseable envelope reports, and
-        // erasing a GNOME keyring token on that reading leaves the login
-        // keyring encrypted under a secret nothing can reproduce.
-        app.keyring_kind = None;
-        app.on_key(KeyCode::Char('f'));
         assert!(
-            app.confirm.is_none(),
-            "an unknown keyring kind must not reach the erase confirm"
+            matches!(&app.confirm, Some((_, _, ConfirmAct::Sus(Suspend::MoreAction(invocation)))) if invocation.args("bob") == ["reseal", "--user", "bob"])
         );
+        assert!(app.input.is_none(), "must not re-arm a token seal");
+        app.on_key(KeyCode::Esc);
+        for kind in [
+            None,
+            Some(irlume_common::KeyringSecretKind::GnomeKeyringToken),
+        ] {
+            app.keyring_kind = kind;
+            app.on_key(KeyCode::Char('f'));
+            assert!(
+                matches!(&app.confirm, Some((_, _, ConfirmAct::Sus(Suspend::MoreAction(invocation)))) if invocation.args("bob") == ["keyring", "forget", "--user", "bob"])
+            );
+            assert!(
+                app.op.is_none(),
+                "no bare ForgetPassword or implicit force deletion"
+            );
+            app.on_key(KeyCode::Esc);
+        }
 
         // A confirmed password arm is safe to erase from here.
         app.keyring_kind = Some(irlume_common::KeyringSecretKind::LoginPassword);
@@ -11924,6 +12056,7 @@ mod tests {
             daemon_up: true,
             reach: crate::commands::DaemonReach::Running,
             health: None,
+            preferences: None,
             keyring_armed: None,
             keyring_policy: None,
             keyring_drift: None,
@@ -12495,7 +12628,7 @@ mod tests {
             (SC_RECOVERY, "Set Recovery", "Forget"),
             (SC_FINGERPRINT, "Enroll Finger", "Reset"),
             (SC_PAM, "Connect Login", "Disconnect"),
-            (SC_SETTINGS, "Biopolicy", "Biopolicy"),
+            (SC_SETTINGS, "IR-only", "Biopolicy"),
             (SC_DONE, "Connect Login", "Refresh Status"),
         ];
         for (screen, primary, in_overlay) in cases {
@@ -12617,6 +12750,7 @@ mod tests {
             daemon_up: false,
             reach: crate::commands::DaemonReach::Down,
             health: None,
+            preferences: None,
             keyring_armed: None,
             keyring_policy: None,
             keyring_drift: None,
@@ -12818,6 +12952,120 @@ mod tests {
     }
 
     #[test]
+    fn diagnostics_wheel_selection_restarts_the_selected_explanation() {
+        let mut app = test_app();
+        app.screen = SC_REPAIR;
+        app.repair = vec![
+            check_row("First", Sev::Warn, Fix::None),
+            check_row("Second", Sev::Warn, Fix::None),
+        ];
+        app.repair[0].detail = "Long first diagnosis. ".repeat(80);
+        let area = Rect::new(0, 0, 120, 50);
+        let text = draw_text(&app);
+        let y = text
+            .lines()
+            .position(|line| line.contains("First"))
+            .unwrap() as u16;
+        let (screen, bounds, _, max) = app.page_view.get();
+        assert!(
+            max > 0,
+            "the first diagnosis must have real scroll overflow"
+        );
+        app.page_view.set((screen, bounds, max.min(3), max));
+        app.on_scroll(30, y, area, 1);
+        assert_eq!(app.repair_sel, 1);
+        assert_eq!(app.page_view.get().2, 0);
+    }
+
+    #[test]
+    fn diagnostics_pending_checks_never_make_the_overview_healthy() {
+        let mut app = test_app();
+        app.daemon_up = true;
+        app.visible = (0..SCREENS.len()).collect();
+        app.repair = vec![check_row("Pending", Sev::Unknown, Fix::None)];
+        let health = |app: &App| {
+            app.hub_rows()
+                .into_iter()
+                .find(|(_, _, screen)| *screen == SC_REPAIR)
+                .unwrap()
+                .1
+        };
+        assert_eq!(health(&app), None);
+        app.repair.push(check_row("Failure", Sev::Fail, Fix::None));
+        assert_eq!(health(&app), Some(false));
+        app.repair = vec![check_row("Passed", Sev::Ok, Fix::None)];
+        assert_eq!(health(&app), Some(true));
+    }
+
+    #[test]
+    fn diagnostics_camera_row_never_restarts_a_starting_or_access_denied_daemon() {
+        let _guard = dead_socket();
+        for reach in [
+            crate::commands::DaemonReach::Starting,
+            crate::commands::DaemonReach::AccessDenied,
+        ] {
+            let mut app = test_app();
+            app.daemon_reach = reach;
+            app.daemon_up = false;
+            app.health = None;
+            app.run_checks();
+            let row = app.repair.iter().find(|c| c.label == "Cameras").unwrap();
+            assert!(
+                !matches!(row.fix, Fix::Root(RootFix::RestartDaemon)),
+                "{}",
+                row.detail
+            );
+        }
+    }
+
+    #[test]
+    fn diagnostics_missing_template_key_offers_existing_recovery_before_reenrollment() {
+        let _guard = dead_socket();
+        let mut app = test_app();
+        app.recovery = Some(RecoveryInfo {
+            encrypted: true,
+            key_present: false,
+            recovery_set: true,
+            tpm_present: true,
+        });
+        app.run_checks();
+        let index = app
+            .repair
+            .iter()
+            .position(|c| c.label == "Recovery backstop")
+            .unwrap();
+        assert!(app.repair[index].sev == Sev::Fail);
+        app.apply_fix(index);
+        assert_eq!(app.screen, SC_RECOVERY);
+        assert!(matches!(
+            app.input,
+            Some((_, _, Pending::RecoveryRestorePw))
+        ));
+        drain_loads(&mut app);
+    }
+
+    #[test]
+    fn diagnostics_selected_failure_explains_full_reason_without_claiming_it_is_fine() {
+        let mut app = test_app();
+        app.screen = SC_REPAIR;
+        app.repair = vec![Check {
+            label: "Camera prerequisite".into(),
+            sev: Sev::Fail,
+            detail: format!(
+                "{} DIAGNOSTIC_TAIL_READABLE",
+                "Long diagnostic explanation. ".repeat(8)
+            ),
+            fix: Fix::None,
+        }];
+        let text = draw_text(&app);
+        assert!(text.contains("DIAGNOSTIC_TAIL_READABLE"), "{text}");
+        assert!(
+            !text.contains("this row is fine") && !text.contains("no action needed"),
+            "{text}"
+        );
+    }
+
+    #[test]
     fn repair_surfaces_keyring_drift_with_the_reseal_fix() {
         // A TUI-only user never runs `doctor`; PCR drift must show on Repair
         // and point at the reseal action (the newly-added parity fix).
@@ -12836,10 +13084,17 @@ mod tests {
             .find(|c| c.label == "Keyring seal")
             .expect("drift must surface on Repair");
         assert!(row.sev == Sev::Warn);
-        match &row.fix {
-            Fix::Manual(m) => assert!(m.contains("reseal"), "fix points at reseal: {m}"),
-            _ => panic!("expected a manual fix pointing at reseal"),
-        }
+        assert!(matches!(row.fix, Fix::Goto(GotoFix::KeyringReseal)));
+        app.keyring_armed = Some(true);
+        let index = app
+            .repair
+            .iter()
+            .position(|c| c.label == "Keyring seal")
+            .unwrap();
+        app.apply_fix(index);
+        assert!(
+            matches!(&app.confirm, Some((_, _, ConfirmAct::Sus(Suspend::MoreAction(invocation)))) if invocation.args("bob") == ["reseal", "--user", "bob"])
+        );
     }
 
     // ---- an unanswered question renders as unknown, never as a negative ----
@@ -13143,7 +13398,11 @@ mod tests {
         let mut app = test_app();
         app.screen = SC_SETTINGS;
         let text = draw_text(&app);
-        assert!(text.contains("local saved: EXPERIMENTAL IR-only"), "{text}");
+        assert!(
+            text.contains("local observation; daemon preferences unavailable")
+                && text.contains("EXPERIMENTAL IR-only"),
+            "{text}"
+        );
         assert!(text.contains("not qualified"), "{text}");
         assert!(app.confirm.is_none() && app.suspend.is_none());
         assert_eq!(
@@ -13227,6 +13486,10 @@ mod tests {
                 "{text}"
             );
             assert!(text.contains("environment override"), "{text}");
+            assert!(
+                !text.contains("Daemon environment override"),
+                "local fallback must not claim a daemon observation: {text}"
+            );
             app.on_key(KeyCode::Char('p'));
             assert!(app.suspend.is_none() && app.confirm.is_none());
         }
@@ -13234,6 +13497,110 @@ mod tests {
             Some(v) => std::env::set_var("IRLUME_PRIVILEGED_FACE_CONSENT", v),
             None => std::env::remove_var("IRLUME_PRIVILEGED_FACE_CONSENT"),
         }
+    }
+
+    fn preference_fixture(ir_only: bool) -> irlume_common::PreferencesState {
+        irlume_common::PreferencesState {
+            face_sensor_policy: irlume_common::config::FaceSensorPolicyObservation::Explicit(
+                if ir_only {
+                    irlume_common::config::FaceSensorPolicy::IrOnlyExperimental
+                } else {
+                    irlume_common::config::FaceSensorPolicy::Dual
+                },
+            ),
+            privileged_face_consent: Some(false),
+            enforce_biopolicy: Some(true),
+            consent_overridden: false,
+            biopolicy_overridden: false,
+        }
+    }
+
+    #[test]
+    fn preferences_daemon_state_drives_rendering_and_keyboard_mouse_toggles() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        for mouse in [false, true] {
+            let mut app = test_app();
+            app.screen = SC_SETTINGS;
+            app.preferences = Some(preference_fixture(true));
+            let text = draw_text(&app);
+            assert!(text.contains("daemon observed"), "{text}");
+            assert!(row_with(&text, "IR-only:").contains("ON"), "{text}");
+            assert!(row_with(&text, "Hands-free:").contains("ON"), "{text}");
+            assert!(text.contains("ON — ENFORCING"), "{text}");
+            if mouse {
+                click_text(&mut app, "[i] turn IR-only off");
+            } else {
+                app.on_key(KeyCode::Char('i'));
+            }
+            assert!(matches!(
+                app.suspend,
+                Some(Suspend::FaceSensorPolicy(false))
+            ));
+            assert!(app.confirm.is_none());
+            app.suspend = None;
+            app.preferences = Some(preference_fixture(false));
+            if mouse {
+                click_text(&mut app, "[i] turn IR-only on");
+            } else {
+                app.on_key(KeyCode::Char('i'));
+            }
+            assert!(app.suspend.is_none());
+            assert!(app.confirm.as_ref().unwrap().0.contains("not qualified"));
+            app.on_key(KeyCode::Esc);
+            assert!(app.suspend.is_none() && app.confirm.is_none());
+            app.on_key(KeyCode::Char('i'));
+            app.on_key(KeyCode::Char('y'));
+            assert!(matches!(app.suspend, Some(Suspend::FaceSensorPolicy(true))));
+        }
+    }
+
+    #[test]
+    fn preferences_unknown_and_daemon_overrides_never_guess_or_write() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let mut app = test_app();
+        app.screen = SC_SETTINGS;
+        let mut state = preference_fixture(true);
+        state.face_sensor_policy = irlume_common::config::FaceSensorPolicyObservation::Unreadable;
+        state.privileged_face_consent = None;
+        state.enforce_biopolicy = None;
+        app.preferences = Some(state);
+        let text = draw_text(&app);
+        assert!(row_with(&text, "IR-only:").contains("UNKNOWN"));
+        assert!(row_with(&text, "Hands-free:").contains("UNKNOWN"));
+        for key in ['i', 'p', 'b'] {
+            app.on_key(KeyCode::Char(key));
+            assert!(app.confirm.is_none() && app.suspend.is_none());
+        }
+        state = preference_fixture(true);
+        state.consent_overridden = true;
+        state.biopolicy_overridden = true;
+        app.preferences = Some(state);
+        for key in ['p', 'b'] {
+            app.on_key(KeyCode::Char(key));
+            assert!(app.confirm.is_none() && app.suspend.is_none());
+        }
+        assert!(draw_text(&app).contains("environment override"));
+        app.on_key(KeyCode::Char('r'));
+        assert!(
+            matches!(&app.confirm, Some((_, _, ConfirmAct::Sus(Suspend::MoreAction(invocation)))) if invocation.args("bob") == ["auth", "sensor", "preflight", "--user", "bob"])
+        );
+    }
+
+    #[test]
+    fn preferences_offer_sensor_controls_without_command_instructions() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let mut app = test_app();
+        app.screen = SC_SETTINGS;
+        let text = draw_text(&app);
+        assert!(
+            text.contains("[i]"),
+            "IR-only needs an in-app control: {text}"
+        );
+        assert!(
+            text.contains("[r]"),
+            "readiness needs an in-app control: {text}"
+        );
+        assert!(!text.contains("Change as root:"), "{text}");
     }
 
     #[test]
@@ -13670,7 +14037,7 @@ mod tests {
     /// An encrypted enrollment whose template key is gone must not read as a
     /// completed step anywhere.
     ///
-    /// Nothing opens it: no recovery passphrase, no reseal, only a re-enrol. The
+    /// Recovery may restore it, but a missing key is still a failure. The
     /// Recovery tab said so loudly while the Repair check passed it as
     /// "encrypted + recovery set", the Done row drew a green yes, and the hub
     /// badge counted the step done.
@@ -13685,7 +14052,7 @@ mod tests {
         });
         app.run_checks();
 
-        // Repair: a failure with a re-enrol remedy, not an OK.
+        // Repair: a failure with a recovery remedy, not an OK.
         let backstop = app
             .repair
             .iter()

--- a/crates/irlume-cli/src/tui/actions.rs
+++ b/crates/irlume-cli/src/tui/actions.rs
@@ -102,6 +102,19 @@ const TRANSACTION: Field = Field {
     optional: false,
 };
 
+pub(super) const FINGERPRINT_ONLY: Action = Action { label: "Enable fingerprint-only login", description: "Changes system login to fingerprint with password fallback, disabling face authentication. Existing CLI checks must pass.", args: &["fingerprint", "enable", "--fingerprint-only"], root: true, per_user: true, fields: &[] };
+pub(super) const SELINUX_STATUS: Action = Action {
+    label: "Show SELinux status",
+    description: "Shows the installed policy and labeling status; no change.",
+    args: &["selinux", "status"],
+    root: false,
+    per_user: false,
+    fields: &[],
+};
+pub(super) const SENSOR_PREFLIGHT: Action = Action { label: "Check IR-only readiness", description: "Checks this account's IR-only prerequisites without opening the camera or attempting authentication.", args: &["auth", "sensor", "preflight"], root: false, per_user: true, fields: &[] };
+pub(super) const WALLET_FORGET: Action = Action { label: "Forget wallet secret safely", description: "For a token-based wallet, asks for your password privately and rekeys the wallet before forgetting its sealed secret.", args: &["keyring", "forget"], root: false, per_user: true, fields: &[] };
+pub(super) const WALLET_RESEAL: Action = Action { label: "Reseal wallet secret", description: "Uses the existing seal type to choose the safe recovery path after boot measurements change; may ask for your password privately.", args: &["reseal"], root: false, per_user: true, fields: &[] };
+
 pub(super) static ACTIONS: &[Action] = &[
     Action { label: "Test authentication for this account", description: "Engages the camera. Verifies this account without releasing a password; Shows whether this account was recognized. This does not test a system approval dialog.", args: &["auth", "test", "--events=jsonl"], root: false, per_user: true, fields: &[] },
     Action { label: "Enroll with a chosen scan count", description: "Captures a face profile. Approve the OS authorization prompt when asked.", args: &["enroll"], root: false, per_user: true, fields: &[NAME, SCANS] },
@@ -119,7 +132,7 @@ pub(super) static ACTIONS: &[Action] = &[
     Action { label: "Create a support report with options", description: "Read-only report from share-safe facts. No camera capture. Output must end in .txt; existing files are preserved.", args: &["support-report"], root: false, per_user: false, fields: &[OUTPUT, SINCE] },
     Action { label: "Create a support report with camera probe", description: "Engages the camera for one bounded probe. Requires administrator access. Review the report before sharing.", args: &["support-report", "--probe"], root: true, per_user: false, fields: &[OUTPUT, SINCE] },
     Action { label: "Follow authentication logs", description: "Shows live system logs until Ctrl-C. Debug logs may contain sensitive measurements. Returns to the TUI afterward.", args: &["logs", "-f"], root: true, per_user: false, fields: &[Field { label: "Since, e.g. 10 min ago (blank uses the CLI default)", flag: Some("--since"), optional: true }] },
-    Action { label: "Enable fingerprint-only login", description: "Changes system login to fingerprint with password fallback, disabling face authentication. Existing CLI checks must pass.", args: &["fingerprint", "enable", "--fingerprint-only"], root: true, per_user: true, fields: &[] },
+    FINGERPRINT_ONLY,
     Action { label: "Reconcile login wiring", description: "Reapplies saved system login wiring after distribution PAM regeneration. Requires administrator access.", args: &["login", "reconcile"], root: true, per_user: false, fields: &[] },
     Action { label: "Preview login wiring", description: "Read-only preview of the default login integration, without applying it.", args: &["login", "enable"], root: true, per_user: false, fields: &[] },
     Action { label: "Verify a login transaction", description: "Checks whether a recorded login transaction still matches the system. Displays a JSON report.", args: &["login", "verify", "--json"], root: true, per_user: false, fields: &[TRANSACTION] },
@@ -133,7 +146,7 @@ pub(super) static ACTIONS: &[Action] = &[
     Action { label: "Connect login, sudo and app prompts", description: "Applies login wiring with both optional sudo and polkit integration. Requires administrator access; retains password fallback.", args: &["login", "enable", "--with-sudo", "--with-polkit", "--apply"], root: true, per_user: false, fields: &[] },
     Action { label: "Preview a login transaction", description: "Produces a machine-readable plan ID without applying a change.", args: &["login", "plan", "--json"], root: true, per_user: false, fields: &[Field { label: "Action: enable or disable", flag: Some("--action"), optional: false }] },
     Action { label: "Apply a prepared login transaction", description: "Applies a previously reviewed plan with the CLI's freshness and rollback checks. Requires administrator access.", args: &["login", "apply", "--json"], root: true, per_user: false, fields: &[Field { label: "Action: enable or disable", flag: Some("--action"), optional: false }, Field { label: "Plan ID from login plan", flag: Some("--plan-id"), optional: false }] },
-    Action { label: "Show SELinux status", description: "Shows the installed policy and labeling status; no change.", args: &["selinux", "status"], root: false, per_user: false, fields: &[] },
+    SELINUX_STATUS,
     Action { label: "Show recovery status", description: "Shows this account's template encryption and recovery state. Available even when a camera is disconnected.", args: &["recovery", "status"], root: false, per_user: true, fields: &[] },
     Action { label: "Set a recovery passphrase", description: "Asks for the passphrase privately in the terminal and creates a recovery wrap for this account.", args: &["recovery", "setup"], root: false, per_user: true, fields: &[] },
     Action { label: "Restore the enrollment key", description: "Asks for the recovery passphrase privately in the terminal and restores this account's template key.", args: &["recovery", "restore"], root: false, per_user: true, fields: &[] },
@@ -141,6 +154,15 @@ pub(super) static ACTIONS: &[Action] = &[
     Action { label: "Rename a profile or scan", description: "Renames the selected account's profile, or the named scan within it. No camera required.", args: &["profiles", "rename"], root: false, per_user: true, fields: &[PROFILE, Field { label: "Scan name (blank renames the whole profile)", flag: Some("--scan"), optional: true }, Field { label: "New name", flag: Some("--name"), optional: false }] },
     Action { label: "Delete a profile or scan", description: "Permanently deletes the specified profile or scan for this account. A blank scan field means the WHOLE profile and all its scans.", args: &["profiles", "delete"], root: false, per_user: true, fields: &[PROFILE, Field { label: "Scan name (blank deletes the WHOLE profile)", flag: Some("--scan"), optional: true }] },
     Action { label: "Forget wallet secret without rekeying", description: "Force-forgets the sealed wallet secret. For a token-based keyring this skips rekeying and may leave the wallet inaccessible. Use ordinary Forget Wallet when possible.", args: &["keyring", "forget", "--force"], root: false, per_user: true, fields: &[] },
+
+    SENSOR_PREFLIGHT,
+    WALLET_FORGET,
+    WALLET_RESEAL,
+    Action { label: "Face sensor policy status", description: "Show the sensor policy observed by the daemon. Does not open cameras.", args: &["auth", "sensor", "status"], root: false, per_user: false, fields: &[] },
+    Action { label: "Privileged face confirmation status", description: "Show whether configured privileged services require confirmation and whether an environment override applies.", args: &["auth", "consent", "status"], root: false, per_user: false, fields: &[] },
+    Action { label: "Face retry status", description: "Inspect the selected account's face retry budget and cooldown. Does not authenticate or reset state.", args: &["retry", "status"], root: false, per_user: true, fields: &[] },
+    Action { label: "Reset face retries with password", description: "Verifies the selected account's current local login password privately. An administrator running this TUI as root performs an administrator reset.", args: &["retry", "reset"], root: false, per_user: true, fields: &[] },
+    Action { label: "Administrator reset of face retries", description: "Requires administrator approval. Resets the selected account's retry state, including when password-verified recovery requires administrator repair. Does not change enrollment or the login password.", args: &["retry", "reset"], root: true, per_user: true, fields: &[] },
 
 ];
 

--- a/crates/irlume-cli/src/uninstall.rs
+++ b/crates/irlume-cli/src/uninstall.rs
@@ -309,10 +309,10 @@ fn remove_source_files() -> Result<String, String> {
     Ok(format!("removed {removed} source-installed file(s)"))
 }
 
-/// Remove irlume artifacts a package `remove` leaves behind, so "uninstall"
-/// leaves nothing: the admin-created `logs debug on` systemd drop-in (not
-/// package-owned), empty share dirs a package manager can leave, and the
-/// install channel (repo) the installer added. Runs for every install method.
+/// Remove irlume artifacts a package `remove` leaves behind: the admin-created
+/// `logs debug on` systemd drop-in (not package-owned), empty share dirs a
+/// package manager can leave, and the install channel the installer added.
+/// Runs for every install method.
 fn clean_residuals(origin: &InstallOrigin) {
     // `irlume logs debug on` drops this in; it survives a package remove.
     let _ = std::fs::remove_dir_all("/etc/systemd/system/irlumed.service.d");
@@ -321,40 +321,45 @@ fn clean_residuals(origin: &InstallOrigin) {
     for d in ["/usr/share/irlume", "/usr/local/share/irlume"] {
         let _ = std::fs::remove_dir_all(d);
     }
-    // The install channel the installer added, so nothing on the box still
-    // points at irlume. (A source install and an AUR/pacman install add no
-    // repo; the Fedora Copr repo and the Ubuntu PPA do.)
-    match origin {
-        InstallOrigin::Copr => remove_repo_files("/etc/yum.repos.d"),
-        InstallOrigin::Ppa => {
-            // The PPA leaves both a sources file and a signing key.
-            remove_repo_files("/etc/apt/sources.list.d");
-            for d in [
-                "/etc/apt/trusted.gpg.d",
-                "/etc/apt/keyrings",
-                "/usr/share/keyrings",
-            ] {
-                remove_repo_files(d);
-            }
-        }
-        _ => {}
+    // Ask the same channel manager that created the repository to remove its
+    // exact identity. Generated filenames vary by distro/release, and keyrings
+    // are shared ownership domains, so neither is safe to infer and unlink.
+    if let Err(e) = remove_install_channel(origin) {
+        eprintln!("[uninstall] warning: install channel may remain: {e}");
     }
 }
 
-/// Delete files under `dir` whose name mentions irlume: the Copr `.repo` or the
-/// PPA `.list` the installer added.
-fn remove_repo_files(dir: &str) {
-    if let Ok(entries) = std::fs::read_dir(dir) {
-        for e in entries.flatten() {
-            if e.file_name()
-                .to_string_lossy()
-                .to_lowercase()
-                .contains("irlume")
-            {
-                let _ = std::fs::remove_file(e.path());
-            }
-        }
+fn install_channel_command(
+    origin: &InstallOrigin,
+) -> Option<(&'static str, &'static [&'static str])> {
+    match origin {
+        InstallOrigin::Copr => Some(("dnf", &["-y", "copr", "remove", "archledger/irlume"])),
+        InstallOrigin::Ppa => Some((
+            "add-apt-repository",
+            &["-y", "--remove", "--ppa", "ppa:archledger/irlume"],
+        )),
+        _ => None,
     }
+}
+
+fn remove_install_channel_with(
+    origin: &InstallOrigin,
+    mut run: impl FnMut(&str, &[&str]) -> Result<(), String>,
+) -> Result<(), String> {
+    let Some((bin, args)) = install_channel_command(origin) else {
+        return Ok(());
+    };
+    run(bin, args)
+}
+
+fn remove_install_channel(origin: &InstallOrigin) -> Result<(), String> {
+    remove_install_channel_with(origin, |bin, args| {
+        match Command::new(bin).args(args).status() {
+            Ok(status) if status.success() => Ok(()),
+            Ok(status) => Err(format!("{bin} exited with {status}")),
+            Err(e) => Err(format!("could not run {bin} ({e})")),
+        }
+    })
 }
 
 /// Where systemd records each timer's last-trigger stamp.
@@ -469,29 +474,33 @@ fn dir_has_entry_named(dir: &Path, needle: &str) -> bool {
 }
 
 /// The closing line of a successful removal, pure over the teardown report and
-/// the snapshot evidence so every arm is unit tested. The old "no repo,
-/// drop-in, or data left behind" claim is retired for a wipe on purpose (#335,
-/// PR #337 review): this process cannot see inside snapshots or backups, so
-/// after a wipe it always says they may retain the deleted data, and positive
-/// tool evidence only appends the matching listing command. A failed wipe never
-/// borrows the deleted phrasing; it names the paths that still hold data.
+/// the snapshot evidence so every arm is unit tested. Repository-manager
+/// removal is reported before this line, and shared signing keys may remain, so
+/// no branch claims complete channel cleanup. After a wipe, this process also
+/// cannot see inside snapshots or backups. A failed wipe never borrows the
+/// deleted phrasing; it names the paths that still hold data.
 fn closing_line(report: &TeardownReport, snapshots: &SnapshotEvidence) -> String {
+    const CHANNEL_RESIDUAL_NOTE: &str =
+        "The install-channel removal is reported separately; shared signing keys may remain.";
     if !report.data_wipe_requested {
-        return "irlume is removed, with no repo or drop-in left behind; your enrolled \
-                faces, sealed secrets, models, and config were kept (--keep-data)."
-            .into();
+        return format!(
+            "irlume is removed; your enrolled faces, sealed secrets, models, and config \
+             were kept (--keep-data). {CHANNEL_RESIDUAL_NOTE}"
+        );
     }
     if !report.data_wiped {
         return format!(
             "irlume is removed, but the requested data wipe was incomplete: data \
-             remains at {}; filesystem snapshots and backups may also retain copies.",
-            report.data_left.join(", ")
+             remains at {}; filesystem snapshots and backups may also retain copies. \
+             {CHANNEL_RESIDUAL_NOTE}",
+            report.data_left.join(", "),
         );
     }
-    let mut line = "irlume is removed, with no repo or drop-in left behind. Live irlume \
-                    data was deleted, but filesystem snapshots and backups may still \
-                    contain the deleted templates and sealed secrets."
-        .to_string();
+    let mut line = format!(
+        "irlume is removed. Live irlume data was deleted, but filesystem snapshots and \
+         backups may still contain the deleted templates and sealed secrets. \
+         {CHANNEL_RESIDUAL_NOTE}"
+    );
     let mut list_cmds: Vec<&str> = Vec::new();
     if snapshots.snapper {
         list_cmds.push("`snapper list`");
@@ -784,53 +793,78 @@ mod tests {
         assert!(removal_hint(&InstallOrigin::Source).contains("source install"));
     }
 
-    // The repo-residual cleaner backs both the Copr and the PPA teardown; it
-    // must take everything the installers drop (repo file, sources file,
-    // signing keys, any capitalisation) and nothing else in the directory.
+    // Repository/key directories are shared ownership domains. A filename is
+    // not proof that irlume or either channel manager owns an entry.
     #[test]
-    fn remove_repo_files_deletes_only_irlume_named_entries() {
+    fn channel_cleanup_preserves_unknown_entries_with_irlume_in_their_names() {
         let dir = std::env::temp_dir().join(format!("irlume-repo-clean-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
-        let ours = [
+        let files = [
             "_copr:copr.fedorainfracloud.org:archledger:irlume.repo",
             "archledger-ubuntu-irlume-resolute.sources",
             "IRLUME-2026.gpg",
+            "administrator-irlume-notes.repo",
+            "shared-irlume-signing-key.gpg",
+            "other-product.repo",
         ];
-        let theirs = ["fedora.repo", "docker.list", "archledger-other.gpg"];
-        for f in ours.iter().chain(theirs.iter()) {
-            std::fs::write(dir.join(f), b"x").unwrap();
+        for (index, f) in files.iter().enumerate() {
+            std::fs::write(dir.join(f), format!("foreign bytes {index}\n")).unwrap();
         }
-        remove_repo_files(dir.to_str().unwrap());
-        for f in ours {
-            assert!(!dir.join(f).exists(), "{f} should have been removed");
-        }
-        for f in theirs {
-            assert!(dir.join(f).exists(), "{f} must be left alone");
-        }
-        let _ = std::fs::remove_dir_all(&dir);
-    }
+        std::os::unix::fs::symlink("other-product.repo", dir.join("irlume-current.repo")).unwrap();
+        std::fs::create_dir(dir.join("irlume-repository.d")).unwrap();
 
-    #[test]
-    fn remove_repo_files_tolerates_a_missing_directory() {
-        remove_repo_files("/nonexistent/irlume-repo-dir");
-    }
-
-    // remove_repo_files also backs the PPA teardown, which sweeps several key
-    // dirs; a nested subdir must be ignored (it only deletes files it names).
-    #[test]
-    fn remove_repo_files_ignores_subdirectories() {
-        let dir = std::env::temp_dir().join(format!("irlume-repo-sub-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(dir.join("irlume-subdir")).unwrap();
-        std::fs::write(dir.join("irlume.list"), b"x").unwrap();
-        remove_repo_files(dir.to_str().unwrap());
-        assert!(!dir.join("irlume.list").exists(), "file should be removed");
-        assert!(
-            dir.join("irlume-subdir").is_dir(),
-            "a same-named subdir must be left in place"
+        let mut invoked = None;
+        remove_install_channel_with(&InstallOrigin::Ppa, |bin, args| {
+            invoked = Some((
+                bin.to_owned(),
+                args.iter().map(|arg| (*arg).to_owned()).collect::<Vec<_>>(),
+            ));
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(
+            invoked,
+            Some((
+                "add-apt-repository".to_owned(),
+                vec![
+                    "-y".to_owned(),
+                    "--remove".to_owned(),
+                    "--ppa".to_owned(),
+                    "ppa:archledger/irlume".to_owned()
+                ]
+            ))
         );
+        for (index, f) in files.iter().enumerate() {
+            assert_eq!(
+                std::fs::read(dir.join(f)).unwrap(),
+                format!("foreign bytes {index}\n").as_bytes(),
+                "unknown entry {f} must remain byte-identical"
+            );
+        }
+        assert!(std::fs::symlink_metadata(dir.join("irlume-current.repo"))
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert!(dir.join("irlume-repository.d").is_dir());
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn install_channel_cleanup_uses_the_installer_repository_identity() {
+        assert_eq!(
+            install_channel_command(&InstallOrigin::Copr),
+            Some(("dnf", &["-y", "copr", "remove", "archledger/irlume"][..]))
+        );
+        assert_eq!(
+            install_channel_command(&InstallOrigin::Ppa),
+            Some((
+                "add-apt-repository",
+                &["-y", "--remove", "--ppa", "ppa:archledger/irlume"][..]
+            ))
+        );
+        assert_eq!(install_channel_command(&InstallOrigin::Source), None);
+        assert_eq!(install_channel_command(&InstallOrigin::LocalDeb), None);
     }
 
     #[test]
@@ -903,6 +937,15 @@ mod tests {
             "the retired all-gone claim must not come back: {line}"
         );
         assert!(
+            !line.contains("no repo or drop-in left behind"),
+            "channel cleanup can fail and shared key material may remain: {line}"
+        );
+        assert!(
+            line.contains("install-channel removal is reported separately")
+                && line.contains("shared signing keys may remain"),
+            "the closing copy must preserve the channel/key uncertainty: {line}"
+        );
+        assert!(
             !line.contains("snapper") && !line.contains("timeshift"),
             "no tool advice without evidence: {line}"
         );
@@ -951,6 +994,12 @@ mod tests {
         assert!(
             !line.contains("may still contain") && !line.contains("deleted"),
             "kept data needs no deletion talk: {line}"
+        );
+        assert!(
+            !line.contains("no repo or drop-in left behind")
+                && line.contains("install-channel removal is reported separately")
+                && line.contains("shared signing keys may remain"),
+            "a channel-manager failure must not be contradicted by the closing copy: {line}"
         );
     }
 
@@ -1071,6 +1120,11 @@ mod tests {
     // real package manager, which would touch the system).
     #[test]
     fn run_pkg_maps_exit_status_to_a_result() {
+        // Even read-only PATH consumers must share the lock: the TUI child-
+        // process fixtures temporarily replace PATH with a private tool tree.
+        let _guard = crate::testenv::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         assert_eq!(
             run_pkg("true", &["remove", "irlume"]).unwrap(),
             "removed the true package"

--- a/crates/irlume-cli/tests/cli.rs
+++ b/crates/irlume-cli/tests/cli.rs
@@ -1281,6 +1281,59 @@ fn sock(sb: &Sandbox) -> PathBuf {
 }
 
 #[test]
+fn wallet_forget_refuses_failed_or_unexpected_inspection_unless_force_is_explicit() {
+    for (tag, response) in [
+        ("error", Response::Error("fixture kind query failed".into())),
+        ("unexpected", Response::Pong),
+    ] {
+        let sb = Sandbox::new(&format!("forget-inspection-{tag}"));
+        let log = serve(&sock(&sb), move |request| match request {
+            Request::KeyringInfo { .. } => response.clone(),
+            Request::ForgetPassword { .. } => Response::PasswordForgotten,
+            _ => panic!("unexpected request"),
+        });
+        let (code, _, err) = run(&mut sb.cmd(&["keyring", "forget", "--user", "tester"]));
+        assert_ne!(code, 0);
+        assert!(err.contains("refusing to erase"), "{err}");
+        assert!(
+            matches!(log.lock().unwrap().as_slice(), [Request::KeyringInfo { user }] if user == "tester")
+        );
+        let (code, out, err) =
+            run(&mut sb.cmd(&["keyring", "forget", "--force", "--user", "tester"]));
+        assert_eq!(code, 0, "{out} {err}");
+        assert!(
+            matches!(log.lock().unwrap().last(), Some(Request::ForgetPassword { user }) if user == "tester")
+        );
+    }
+}
+
+#[test]
+fn biopolicy_write_refuses_unknown_content_and_preserves_other_preferences() {
+    let sb = Sandbox::new("biopolicy-preserve");
+    let original = "face_sensor_policy=ir-only-experimental\nprivileged_face_consent=0\n";
+    std::fs::write(sb.path("cfg/settings.conf"), original).unwrap();
+    let (code, _, _) = run(sb
+        .cmd(&["biopolicy", "on"])
+        .env_remove("IRLUME_ENFORCE_BIOPOLICY"));
+    let saved = std::fs::read_to_string(sb.path("cfg/settings.conf")).unwrap();
+    if is_root() {
+        assert_eq!(code, 0);
+        assert!(
+            saved.contains(original) && saved.contains("enforce_biopolicy=1"),
+            "{saved}"
+        );
+    } else {
+        assert_ne!(code, 0);
+        assert_eq!(saved, original);
+    }
+    std::fs::remove_file(sb.path("cfg/settings.conf")).unwrap();
+    std::fs::create_dir(sb.path("cfg/settings.conf")).unwrap();
+    let (code, _, _) = run(&mut sb.cmd(&["biopolicy", "off"]));
+    assert_ne!(code, 0);
+    assert!(sb.path("cfg/settings.conf").is_dir());
+}
+
+#[test]
 fn keyring_success_paths_with_a_live_daemon() {
     let sb = Sandbox::new("keyringok");
     let log = serve(&sock(&sb), |req| match req {
@@ -2269,6 +2322,126 @@ fn auth_sensor_malformed_key_cannot_silently_select_dual() {
 }
 
 #[test]
+fn diagnostics_missing_key_guidance_agrees_across_cli_views() {
+    for recovery_set in [true, false] {
+        let sb = Sandbox::new(if recovery_set {
+            "missing-key-recoverable"
+        } else {
+            "missing-key-no-backup"
+        });
+        serve(&sock(&sb), move |request| match request {
+            Request::Ping => Response::Pong,
+            Request::RecoveryStatus { .. } => Response::RecoveryStatus {
+                encrypted: true,
+                key_present: false,
+                recovery_set,
+                tpm_present: true,
+            },
+            _ => Response::Error("fixture unavailable".into()),
+        });
+        for args in [vec!["recovery", "status"], vec!["status"]] {
+            let (code, out, err) = run(&mut sb.cmd(&args));
+            assert_eq!(code, 0, "{out} {err}");
+            assert!(
+                out.contains(if recovery_set {
+                    "irlume recovery restore"
+                } else {
+                    "Re-enroll"
+                }),
+                "{out}"
+            );
+            assert!(
+                !out.contains("Set one now"),
+                "cannot create a backup from a missing key: {out}"
+            );
+        }
+        let (_, out, err) = run(&mut sb.cmd(&["doctor", "--json"]));
+        let report: serde_json::Value =
+            serde_json::from_str(&out).unwrap_or_else(|error| panic!("{error}: {out} {err}"));
+        let check = report["data"]["checks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|check| check["id"] == "templates")
+            .unwrap();
+        assert_eq!(check["state"], "fail");
+        assert!(check["detail"].as_str().unwrap().contains(if recovery_set {
+            "recovery restore"
+        } else {
+            "Re-enroll"
+        }));
+    }
+}
+
+#[test]
+fn preference_status_reads_daemon_instead_of_unreadable_local_settings() {
+    let sb = Sandbox::new("preferences-daemon");
+    std::fs::create_dir(sb.path("cfg/settings.conf")).unwrap();
+    let requests = serve(&sock(&sb), |request| {
+        assert!(matches!(request, Request::PreferencesStatus));
+        Response::PreferencesStatus(irlume_common::PreferencesState {
+            face_sensor_policy: irlume_common::config::FaceSensorPolicyObservation::DefaultDual,
+            privileged_face_consent: Some(false),
+            enforce_biopolicy: Some(true),
+            consent_overridden: true,
+            biopolicy_overridden: true,
+        })
+    });
+    for (args, expected) in [
+        (vec!["auth", "consent", "status"], "hands-free"),
+        (vec!["biopolicy", "status"], "ENFORCING"),
+    ] {
+        let (code, out, err) = run(&mut sb.cmd(&args));
+        assert_eq!(code, 0, "{out} {err}");
+        assert!(
+            out.contains(expected)
+                && out.contains("daemon observed")
+                && out.contains("environment override"),
+            "{out}"
+        );
+    }
+    assert_eq!(requests.lock().unwrap().len(), 2);
+    assert!(sb.path("cfg/settings.conf").is_dir());
+}
+
+#[test]
+fn sensor_preflight_rejects_ambiguous_or_missing_users_before_daemon_contact() {
+    let sb = Sandbox::new("sensor-invalid-users");
+    let requests = serve(&sock(&sb), |_| {
+        panic!("invalid arguments must not contact daemon")
+    });
+    for tail in [
+        vec!["--user"],
+        vec!["--user", ""],
+        vec!["--user="],
+        vec!["alice", "--user", "bob"],
+        vec!["--user", "--yes"],
+        vec!["--user=alice", "--user=bob"],
+    ] {
+        let mut args = vec!["auth", "sensor", "preflight"];
+        args.extend(tail);
+        let (code, _, _) = run(&mut sb.cmd(&args));
+        assert_eq!(code, 2, "{args:?}");
+    }
+    assert!(requests.lock().unwrap().is_empty());
+}
+
+#[test]
+fn auth_sensor_preflight_accepts_selected_user_flag() {
+    let sb = Sandbox::new("sensor-user-flag");
+    let requests = serve(&sock(&sb), |_| Response::FaceSensorStatus {
+        policy: irlume_common::config::FaceSensorPolicyObservation::DefaultDual,
+        ir_readiness: Some(irlume_common::IrOnlyReadiness::Unavailable),
+    });
+    let (_, _, err) = run(&mut sb.cmd(&["auth", "sensor", "preflight", "--user", "alice"]));
+    let requests = requests.lock().unwrap();
+    assert!(
+        matches!(requests.as_slice(), [Request::FaceSensorStatus { user: Some(user) }] if user == "alice"),
+        "{requests:?} {err}"
+    );
+}
+
+#[test]
 fn auth_sensor_status_uses_daemon_observation_and_preflight_is_explicit() {
     use irlume_common::config::{FaceSensorPolicy, FaceSensorPolicyObservation};
     let sb = Sandbox::new("sensor-daemon");
@@ -2506,7 +2679,7 @@ fn auth_sensor_and_consent_concurrent_writes_preserve_both_policies() {
 }
 
 #[test]
-fn auth_consent_status_reports_policy_without_contacting_daemon() {
+fn auth_consent_status_labels_local_fallback_when_daemon_is_unavailable() {
     let sb = Sandbox::new("consent-status");
     for (value, label) in [
         (None, "required"),

--- a/crates/irlume-cli/tests/cli.rs
+++ b/crates/irlume-cli/tests/cli.rs
@@ -7,13 +7,16 @@
 //! Every invocation runs inside a sandbox: `IRLUME_SOCKET` points at a path
 //! nothing listens on (so no request can ever reach a real `irlumed`),
 //! `IRLUME_CONFIG_DIR` / `IRLUME_STATE_DIR` / `IRLUME_KEYRING_DIR` point at a
-//! per-test temp tree, and system tools the CLI shells out to (journalctl,
-//! rpm, curl, semodule, ...) are PATH-shadowed with fake scripts. No test
-//! touches the network, a camera, the TPM, or the machine's package database.
+//! per-test temp tree, and system tools the CLI shells out to are fake scripts.
+//! Privileged fixed-path probes run in a Bubblewrap namespace with private
+//! `/usr/bin` and `/run`. No test touches the network, a camera, the TPM, or the
+//! machine's package database.
 
 use std::io::Write as _;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
+
+mod support;
 
 const BIN: &str = env!("CARGO_BIN_EXE_irlume");
 
@@ -36,6 +39,14 @@ impl Sandbox {
         for d in ["cfg", "state", "keyring", "bin", "work"] {
             std::fs::create_dir_all(root.join(d)).unwrap();
         }
+        let helper = root.join("wallet-salt-helper");
+        std::fs::write(
+            &helper,
+            "#!/bin/sh\n[ \"$1\" = --read-salt ] && [ \"$#\" -eq 2 ] || exit 1\nexit 3\n",
+        )
+        .unwrap();
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(&helper, std::fs::Permissions::from_mode(0o700)).unwrap();
         Sandbox { root }
     }
 
@@ -60,6 +71,7 @@ impl Sandbox {
             .env("IRLUME_STATE_DIR", self.root.join("state"))
             .env("IRLUME_KEYRING_DIR", self.root.join("keyring"))
             .env("IRLUME_METHOD_CONF", self.root.join("cfg").join("method"))
+            .env("IRLUME_KWALLET_INIT", self.root.join("wallet-salt-helper"))
             .env_remove("IRLUME_DEV")
             .env_remove("ORT_DYLIB_PATH")
             .env_remove("IRLUME_MODEL")
@@ -84,6 +96,10 @@ impl Sandbox {
             ),
         );
         c
+    }
+
+    fn isolated_root_cmd(&self, args: &[&str], tools: &[&str]) -> Command {
+        support::isolated_root_command(&self.root, BIN, args, tools)
     }
 }
 
@@ -188,6 +204,7 @@ fn help_lists_every_public_command_and_hides_dev_tools() {
             "keyring",
             "reseal",
             "recovery",
+            "retry",
             "diag",
             "login",
             "logs",
@@ -1005,20 +1022,24 @@ fn selinux_status_classifies_module_state_from_probe_output() {
         "ls",
         r#"printf 'system_u:object_r:irlume_runtime_t:s0 /run/irlume.sock\n'"#,
     );
-    let (code, out, _) = run(&mut sb.cmd_with_fakes(&["selinux", "status"]));
+    support::assert_system_command_isolation(&sb.root, &["semodule", "ls"]);
+    let (code, out, _) =
+        run(&mut sb.isolated_root_cmd(&["selinux", "status"], &["semodule", "ls"]));
     assert_eq!(code, 0);
     assert!(out.contains("module 'irlume': loaded"), "{out}");
 
     // Listed modules but ours absent, and no socket label: not loaded.
     sb.fake_tool("semodule", r#"printf 'somethingelse\n'"#);
     sb.fake_tool("ls", "exit 2");
-    let (code, out, _) = run(&mut sb.cmd_with_fakes(&["selinux", "status"]));
+    let (code, out, _) =
+        run(&mut sb.isolated_root_cmd(&["selinux", "status"], &["semodule", "ls"]));
     assert_eq!(code, 0);
     assert!(out.contains("not loaded"), "{out}");
 
     // semodule prints nothing (non-root): state is unknown, not "not loaded".
     sb.fake_tool("semodule", "exit 1");
-    let (code, out, _) = run(&mut sb.cmd_with_fakes(&["selinux", "status"]));
+    let (code, out, _) =
+        run(&mut sb.isolated_root_cmd(&["selinux", "status"], &["semodule", "ls"]));
     assert_eq!(code, 0);
     assert!(out.contains("unknown"), "{out}");
 
@@ -2169,4 +2190,897 @@ fn removed_gesture_commands_are_unknown() {
         let (code, _, _) = run(&mut cmd);
         assert_eq!(code, 2);
     }
+}
+
+// Consent control must use the same default and opt-out policy as PAM/daemon.
+#[test]
+fn auth_sensor_status_distinguishes_default_explicit_invalid_and_unreadable() {
+    let sb = Sandbox::new("sensor-status");
+    for (contents, expected) in [
+        (None, "dual (default)"),
+        (
+            Some(b"face_sensor_policy=ir-only-experimental\n".as_slice()),
+            "EXPERIMENTAL IR-only",
+        ),
+        (Some(b"face_sensor_policy=\n".as_slice()), "invalid"),
+        (Some(b"face_sensor_policy=typo\n".as_slice()), "invalid"),
+        (
+            Some(b"face_sensor_policy=dual\nface_sensor_policy=ir-only-experimental\n".as_slice()),
+            "invalid",
+        ),
+        (Some(b"\xff".as_slice()), "unreadable"),
+    ] {
+        if let Some(contents) = contents {
+            std::fs::write(sb.path("cfg/settings.conf"), contents).unwrap();
+        }
+        let (code, out, err) = run(&mut sb.cmd(&["auth", "sensor", "status"]));
+        assert_eq!(code, 0, "{out} {err}");
+        assert!(out.contains(expected), "{out} {err}");
+        assert!(
+            out.contains("local saved"),
+            "offline state must not claim daemon observation: {out}"
+        );
+    }
+}
+
+#[test]
+fn auth_sensor_malformed_key_cannot_silently_select_dual() {
+    let sb = Sandbox::new("sensor-malformed-key");
+    for contents in [
+        "face_sensor_policy ir-only-experimental\n",
+        "face_sensor_policy: ir-only-experimental\n",
+        "face_sensor_policy\tir-only-experimental\n",
+        "face_sensor_policy : ir-only-experimental\n",
+        "face_sensor_policy:=ir-only-experimental\n",
+        "face_sensor_policy ir-only-experimental=1\n",
+        "face_sensor_policy=dual\nface_sensor_policy: ir-only-experimental\n",
+    ] {
+        std::fs::write(sb.path("cfg/settings.conf"), contents).unwrap();
+        let (code, out, err) = run(&mut sb.cmd(&["auth", "sensor", "status"]));
+        assert_eq!(code, 0, "{out} {err}");
+        assert!(
+            out.contains("invalid sensor policy"),
+            "{contents:?}: {out} {err}"
+        );
+        assert!(!out.contains("dual (default)"), "{out}");
+        let (code, _, _) = run(&mut sb.isolated_root_cmd(&["auth", "sensor", "dual"], &[]));
+        assert_ne!(
+            code, 0,
+            "owner update must not silently retain malformed policy"
+        );
+        assert_eq!(
+            std::fs::read_to_string(sb.path("cfg/settings.conf")).unwrap(),
+            contents
+        );
+    }
+    for contents in [
+        "face_sensor_policy_extra=ir-only-experimental\n",
+        "face_sensor_policy_extra ir-only-experimental\n",
+        "# face_sensor_policy: ir-only-experimental\n",
+    ] {
+        std::fs::write(sb.path("cfg/settings.conf"), contents).unwrap();
+        let (code, out, err) = run(&mut sb.cmd(&["auth", "sensor", "status"]));
+        assert_eq!(code, 0, "{out} {err}");
+        assert!(
+            out.contains("dual (default)"),
+            "distinct key/comment: {out}"
+        );
+    }
+}
+
+#[test]
+fn auth_sensor_status_uses_daemon_observation_and_preflight_is_explicit() {
+    use irlume_common::config::{FaceSensorPolicy, FaceSensorPolicyObservation};
+    let sb = Sandbox::new("sensor-daemon");
+    std::fs::write(sb.path("cfg/settings.conf"), "face_sensor_policy=dual\n").unwrap();
+    let requests = serve(&sock(&sb), |req| match req {
+        Request::FaceSensorStatus { user } => Response::FaceSensorStatus {
+            policy: FaceSensorPolicyObservation::Explicit(FaceSensorPolicy::IrOnlyExperimental),
+            ir_readiness: user
+                .as_ref()
+                .map(|_| irlume_common::IrOnlyReadiness::Unavailable),
+        },
+        _ => Response::Error("unexpected request".into()),
+    });
+    let (code, out, err) = run(&mut sb.cmd(&["auth", "sensor", "status"]));
+    assert_eq!(code, 0, "{out} {err}");
+    assert!(
+        out.contains("daemon observed: EXPERIMENTAL IR-only"),
+        "{out}"
+    );
+    assert!(out.contains("not qualified"), "{out}");
+    let (code, out, err) = run(&mut sb.cmd(&["auth", "sensor", "preflight", "alice"]));
+    assert_ne!(code, 0);
+    assert!(err.contains("preflight unavailable"), "{out} {err}");
+    let requests = requests.lock().unwrap();
+    assert_eq!(requests.len(), 2);
+    assert!(matches!(
+        &requests[0],
+        Request::FaceSensorStatus { user: None }
+    ));
+    assert!(
+        matches!(&requests[1], Request::FaceSensorStatus { user: Some(user) } if user == "alice")
+    );
+    assert_eq!(
+        std::fs::read_to_string(sb.path("cfg/settings.conf")).unwrap(),
+        "face_sensor_policy=dual\n"
+    );
+}
+
+#[test]
+fn auth_sensor_preflight_renders_each_readiness_without_exposing_the_account() {
+    use irlume_common::config::{FaceSensorPolicy, FaceSensorPolicyObservation};
+    use irlume_common::IrOnlyReadiness;
+
+    let sb = Sandbox::new("sensor-preflight-readiness");
+    let requests = serve(&sock(&sb), |req| {
+        let Request::FaceSensorStatus { user: Some(user) } = req else {
+            return Response::Error("unexpected request".into());
+        };
+        let ir_readiness = match user.as_str() {
+            "ready-account" => IrOnlyReadiness::ReadyForExperimentalAttempt,
+            "unavailable-account" => IrOnlyReadiness::Unavailable,
+            "invalid-policy-account" => IrOnlyReadiness::InvalidPolicy,
+            "target-account" => IrOnlyReadiness::TargetUnavailable,
+            "binding-absent-account" => IrOnlyReadiness::BindingUnavailable,
+            "binding-mismatch-account" => IrOnlyReadiness::BindingMismatch,
+            "models-account" => IrOnlyReadiness::ModelsUnavailable,
+            "pad-account" => IrOnlyReadiness::PadUnavailable,
+            "enrollment-account" => IrOnlyReadiness::EnrollmentUnavailable,
+            "incompatible-account" => IrOnlyReadiness::IncompatibleEnrollment,
+            _ => return Response::Error("unknown fixture account".into()),
+        };
+        Response::FaceSensorStatus {
+            policy: FaceSensorPolicyObservation::Explicit(FaceSensorPolicy::IrOnlyExperimental),
+            ir_readiness: Some(ir_readiness),
+        }
+    });
+
+    for (account, success, expected) in [
+        ("ready-account", true, "prerequisites are ready"),
+        ("unavailable-account", false, "preflight unavailable"),
+        ("invalid-policy-account", false, "policy is invalid"),
+        (
+            "target-account",
+            false,
+            "configured IR target is unavailable",
+        ),
+        (
+            "binding-absent-account",
+            false,
+            "IR enrollment has no camera binding",
+        ),
+        ("binding-mismatch-account", false, "different IR camera"),
+        ("models-account", false, "face models are unavailable"),
+        ("pad-account", false, "IR anti-spoofing is unavailable"),
+        (
+            "enrollment-account",
+            false,
+            "face enrollment is unavailable",
+        ),
+        ("incompatible-account", false, "compatible IR scans"),
+    ] {
+        let (code, out, err) = run(&mut sb.cmd(&["auth", "sensor", "preflight", account]));
+        assert_eq!(code == 0, success, "{account}: {out} {err}");
+        let rendered = format!("{out}{err}");
+        assert!(rendered.contains(expected), "{account}: {rendered}");
+        assert!(!rendered.contains(account), "{account}: {rendered}");
+        assert!(
+            rendered.contains("daemon observed: EXPERIMENTAL IR-only"),
+            "{account}: {rendered}"
+        );
+        if success {
+            assert!(rendered.contains("EXPERIMENTAL"), "{rendered}");
+            assert!(rendered.contains("does not prove capture"), "{rendered}");
+            assert!(rendered.contains("not qualified"), "{rendered}");
+        } else {
+            assert!(rendered.contains("password"), "{account}: {rendered}");
+        }
+    }
+    assert_eq!(requests.lock().unwrap().len(), 10);
+}
+
+#[test]
+fn auth_sensor_preflight_fails_closed_for_missing_or_future_readiness() {
+    use irlume_common::config::{FaceSensorPolicy, FaceSensorPolicyObservation};
+
+    let sb = Sandbox::new("sensor-preflight-unknown");
+    let requests = serve(&sock(&sb), |_| Response::FaceSensorStatus {
+        policy: FaceSensorPolicyObservation::Explicit(FaceSensorPolicy::IrOnlyExperimental),
+        ir_readiness: None,
+    });
+    let (code, out, err) = run(&mut sb.cmd(&["auth", "sensor", "preflight", "missing-account"]));
+    assert_ne!(code, 0, "{out} {err}");
+    assert!(err.contains("could not establish"), "{out} {err}");
+    assert!(!format!("{out}{err}").contains("missing-account"));
+    drop(requests);
+
+    use std::io::{BufRead, BufReader};
+    let socket = sock(&sb);
+    let _ = std::fs::remove_file(&socket);
+    let listener = std::os::unix::net::UnixListener::bind(&socket).unwrap();
+    std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut request = String::new();
+        BufReader::new(&stream).read_line(&mut request).unwrap();
+        let reply = serde_json::to_string(&Response::FaceSensorStatus {
+            policy: FaceSensorPolicyObservation::Explicit(FaceSensorPolicy::IrOnlyExperimental),
+            ir_readiness: Some(irlume_common::IrOnlyReadiness::Unavailable),
+        })
+        .unwrap()
+        .replace("unavailable", "future_readiness");
+        writeln!(stream, "{reply}").unwrap();
+    });
+    let (code, out, err) = run(&mut sb.cmd(&["auth", "sensor", "preflight", "future-account"]));
+    assert_ne!(code, 0, "{out} {err}");
+    assert!(err.contains("could not establish"), "{out} {err}");
+    let rendered = format!("{out}{err}");
+    assert!(!rendered.contains("future-account"), "{rendered}");
+    assert!(!rendered.contains("future_readiness"), "{rendered}");
+}
+
+#[test]
+fn auth_sensor_owner_change_requires_ack_and_preserves_unrelated_settings() {
+    let sb = Sandbox::new("sensor-owner");
+    let original = "# retained\nprivileged_face_consent=1\ncapture_mode=sequential\n";
+    std::fs::write(sb.path("cfg/settings.conf"), original).unwrap();
+    let (code, _, err) = run(&mut sb.isolated_root_cmd(&["auth", "sensor", "ir-only"], &[]));
+    assert_eq!(code, 2, "{err}");
+    assert_eq!(
+        std::fs::read_to_string(sb.path("cfg/settings.conf")).unwrap(),
+        original
+    );
+    for (args, expected) in [
+        (
+            vec!["auth", "sensor", "ir-only", "--yes"],
+            "ir-only-experimental",
+        ),
+        (vec!["auth", "sensor", "dual"], "dual"),
+    ] {
+        let (code, out, err) = run(&mut sb.isolated_root_cmd(&args, &[]));
+        assert_eq!(code, 0, "{out} {err}");
+        let saved = std::fs::read_to_string(sb.path("cfg/settings.conf")).unwrap();
+        assert_eq!(saved, format!("{original}face_sensor_policy={expected}\n"));
+        assert!(out.contains("Readiness is not established"), "{out}");
+        assert!(!sb.path("cfg/cameras.conf").exists());
+        assert!(!sb.path("state/retry").exists());
+    }
+}
+
+#[test]
+fn auth_sensor_refuses_nonroot_invalid_args_and_unreadable_updates() {
+    let sb = Sandbox::new("sensor-refusals");
+    if !is_root() {
+        let (code, _, err) = run(&mut sb.cmd(&["auth", "sensor", "ir-only", "--yes"]));
+        assert_ne!(code, 0);
+        assert!(err.contains("root"), "{err}");
+        assert!(!sb.path("cfg/settings.conf").exists());
+    }
+    for args in [
+        vec!["auth", "sensor", "unknown"],
+        vec!["auth", "sensor", "dual", "--yes"],
+        vec!["auth", "sensor", "preflight", "--yes"],
+        vec!["auth", "sensor", "ir-only", "--yes", "extra"],
+    ] {
+        assert_eq!(run(&mut sb.cmd(&args)).0, 2);
+        assert!(!sb.path("cfg/settings.conf").exists());
+    }
+    let original = [0xff, 0xfe];
+    std::fs::write(sb.path("cfg/settings.conf"), original).unwrap();
+    let (code, _, _) = run(&mut sb.isolated_root_cmd(&["auth", "sensor", "dual"], &[]));
+    assert_ne!(code, 0);
+    assert_eq!(
+        std::fs::read(sb.path("cfg/settings.conf")).unwrap(),
+        original
+    );
+    let (code, out, err) = run(&mut sb.cmd(&["auth", "sensor", "preflight"]));
+    assert_ne!(code, 0);
+    assert!(err.contains("could not establish"), "{out} {err}");
+}
+
+#[test]
+fn auth_sensor_and_consent_concurrent_writes_preserve_both_policies() {
+    let sb = Sandbox::new("sensor-concurrent");
+    let sensor = sb
+        .isolated_root_cmd(&["auth", "sensor", "ir-only", "--yes"], &[])
+        .spawn()
+        .unwrap();
+    let consent = sb
+        .isolated_root_cmd(&["auth", "consent", "hands-free", "--yes"], &[])
+        .spawn()
+        .unwrap();
+    for child in [sensor, consent] {
+        let output = child.wait_with_output().unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    let saved = std::fs::read_to_string(sb.path("cfg/settings.conf")).unwrap();
+    assert!(
+        saved.contains("face_sensor_policy=ir-only-experimental\n"),
+        "{saved}"
+    );
+    assert!(saved.contains("privileged_face_consent=0\n"), "{saved}");
+}
+
+#[test]
+fn auth_consent_status_reports_policy_without_contacting_daemon() {
+    let sb = Sandbox::new("consent-status");
+    for (value, label) in [
+        (None, "required"),
+        (Some("0"), "hands-free"),
+        (Some("typo"), "required"),
+    ] {
+        if let Some(v) = value {
+            std::fs::write(
+                sb.path("cfg/settings.conf"),
+                format!("privileged_face_consent={v}\n"),
+            )
+            .unwrap();
+        }
+        let (code, out, err) = run(sb
+            .cmd(&["auth", "consent", "status"])
+            .env_remove("IRLUME_PRIVILEGED_FACE_CONSENT"));
+        assert_eq!(code, 0, "{out} {err}");
+        assert!(out.contains(label) && out.contains("privileged"), "{out}");
+    }
+}
+
+#[test]
+fn auth_consent_rejects_unknown_arguments_without_writing() {
+    let sb = Sandbox::new("consent-args");
+    for args in [
+        vec!["auth", "consent", "unknown"],
+        vec!["auth", "consent", "required", "--yes"],
+        vec!["auth", "consent", "hands-free", "--yes", "--user", "root"],
+    ] {
+        let (code, _, _) = run(&mut sb.cmd(&args));
+        assert_eq!(code, 2);
+        assert!(!sb.path("cfg/settings.conf").exists());
+    }
+}
+
+#[test]
+fn auth_consent_updates_are_authorized_explicit_and_preserve_other_settings() {
+    let sb = Sandbox::new("consent-write");
+    let original = "# keep this\nenforce_biopolicy=1\nprivileged_face_consent=1\n";
+    std::fs::write(sb.path("cfg/settings.conf"), original).unwrap();
+    let (code, _, _) = run(sb
+        .cmd(&["auth", "consent", "hands-free"])
+        .env_remove("IRLUME_PRIVILEGED_FACE_CONSENT"));
+    assert_ne!(code, 0);
+    assert_eq!(
+        std::fs::read_to_string(sb.path("cfg/settings.conf")).unwrap(),
+        original
+    );
+    let (code, out, err) = run(sb
+        .cmd(&["auth", "consent", "hands-free", "--yes"])
+        .env_remove("IRLUME_PRIVILEGED_FACE_CONSENT"));
+    if !is_root() {
+        assert_ne!(code, 0);
+        assert!(err.contains("root"), "{out} {err}");
+        assert_eq!(
+            std::fs::read_to_string(sb.path("cfg/settings.conf")).unwrap(),
+            original
+        );
+        return;
+    }
+    assert_eq!(code, 0, "{out} {err}");
+    let saved = std::fs::read_to_string(sb.path("cfg/settings.conf")).unwrap();
+    assert!(
+        saved.contains("enforce_biopolicy=1")
+            && saved.contains("# keep this")
+            && saved.contains("privileged_face_consent=0"),
+        "{saved}"
+    );
+    let (code, out, err) = run(sb
+        .cmd(&["auth", "consent", "required"])
+        .env_remove("IRLUME_PRIVILEGED_FACE_CONSENT"));
+    assert_eq!(code, 0, "{out} {err}");
+    assert!(std::fs::read_to_string(sb.path("cfg/settings.conf"))
+        .unwrap()
+        .contains("privileged_face_consent=1"));
+}
+
+#[test]
+fn auth_consent_override_is_visible_and_blocks_misleading_writes() {
+    let sb = Sandbox::new("consent-override");
+    let (code, out, err) = run(sb
+        .cmd(&["auth", "consent", "status"])
+        .env("IRLUME_PRIVILEGED_FACE_CONSENT", "0"));
+    assert_eq!(code, 0, "{out} {err}");
+    assert!(
+        out.contains("hands-free") && out.contains("environment override"),
+        "{out}"
+    );
+    let (code, _, err) = run(sb
+        .cmd(&["auth", "consent", "required"])
+        .env("IRLUME_PRIVILEGED_FACE_CONSENT", "0"));
+    assert_ne!(code, 0);
+    assert!(err.contains("override"), "{err}");
+    assert!(!sb.path("cfg/settings.conf").exists());
+}
+
+#[test]
+fn auth_consent_never_overwrites_unreadable_settings() {
+    let sb = Sandbox::new("consent-unreadable");
+    let original = [0xff, 0x00, 0xfe];
+    std::fs::write(sb.path("cfg/settings.conf"), original).unwrap();
+    let (code, out, err) = run(sb
+        .cmd(&["auth", "consent", "status"])
+        .env_remove("IRLUME_PRIVILEGED_FACE_CONSENT"));
+    assert_eq!(code, 0, "{out} {err}");
+    assert!(out.contains("unknown"), "{out}");
+    let (code, _, _) = run(sb
+        .cmd(&["auth", "consent", "hands-free", "--yes"])
+        .env_remove("IRLUME_PRIVILEGED_FACE_CONSENT"));
+    assert_ne!(code, 0);
+    assert_eq!(
+        std::fs::read(sb.path("cfg/settings.conf")).unwrap(),
+        original
+    );
+}
+
+// ------------------------------------------------------------- retry recovery
+
+fn retry_available() -> Response {
+    Response::RetryStatus {
+        face_budget: None, // Legacy daemon: cumulative enforcement is unknown.
+        failures: 4,
+        cooldown_seconds: 12,
+        recovery_failures: 2,
+        recovery_cooldown_seconds: 0,
+        recovery_required: false,
+        password_reset_available: true,
+    }
+}
+
+/// Execute the actual password prompt on a private controlling terminal. Input
+/// is synthetic and sent only after the prompt is visible AND ECHO is disabled.
+/// Waiting for ECHO avoids a race between rpassword's prompt write and tcsetattr.
+fn retry_terminal(cmd: &mut Command, input: Option<&str>) -> (i32, String) {
+    use std::io::Read as _;
+    use std::os::fd::{AsRawFd as _, FromRawFd as _};
+    use std::os::unix::process::CommandExt as _;
+    use std::time::{Duration, Instant};
+
+    let (mut master_fd, mut slave_fd) = (-1, -1);
+    assert_eq!(
+        // SAFETY: both output pointers are valid; null optional arguments select
+        // default terminal settings and no requested slave pathname.
+        unsafe {
+            libc::openpty(
+                &mut master_fd,
+                &mut slave_fd,
+                std::ptr::null_mut(),
+                std::ptr::null(),
+                std::ptr::null(),
+            )
+        },
+        0
+    );
+    // SAFETY: successful openpty transfers two valid, distinct descriptors.
+    let mut master = unsafe { std::fs::File::from_raw_fd(master_fd) };
+    // SAFETY: slave_fd is owned here exactly once, independently of master_fd.
+    let slave = unsafe { std::fs::File::from_raw_fd(slave_fd) };
+    for fd in [master.as_raw_fd(), slave.as_raw_fd()] {
+        assert_eq!(
+            // SAFETY: the descriptors remain open throughout this call.
+            unsafe { libc::fcntl(fd, libc::F_SETFD, libc::FD_CLOEXEC) },
+            0
+        );
+    }
+    cmd.stdin(slave.try_clone().unwrap())
+        .stdout(slave.try_clone().unwrap())
+        .stderr(slave.try_clone().unwrap());
+    // SAFETY: pre_exec uses only async-signal-safe libc operations. Descriptor
+    // zero has already been installed from the slave before this closure runs.
+    unsafe {
+        cmd.pre_exec(|| {
+            if libc::setsid() == -1 || libc::ioctl(0, libc::TIOCSCTTY, 0) == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let mut child = cmd.spawn().unwrap();
+    drop(slave);
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut transcript = Vec::new();
+    let mut sent = false;
+    let mut status = None;
+    loop {
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("retry command exceeded private terminal fixture deadline");
+        }
+        let mut poll = libc::pollfd {
+            fd: master.as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        // SAFETY: poll points to one initialized entry and the fd remains open.
+        let ready = unsafe { libc::poll(&mut poll, 1, 25) };
+        assert!(ready >= 0);
+        if ready > 0 && poll.revents & libc::POLLIN != 0 {
+            let mut buffer = [0; 1024];
+            match master.read(&mut buffer) {
+                Ok(0) => break,
+                Ok(n) => transcript.extend_from_slice(&buffer[..n]),
+                Err(error) if error.raw_os_error() == Some(libc::EIO) => break,
+                Err(error) => panic!("private terminal read: {error}"),
+            }
+        }
+        if !sent && String::from_utf8_lossy(&transcript).contains("Current login password: ") {
+            let mut termios = std::mem::MaybeUninit::<libc::termios>::uninit();
+            assert_eq!(
+                // SAFETY: tcgetattr initializes the valid output buffer on success.
+                unsafe { libc::tcgetattr(master.as_raw_fd(), termios.as_mut_ptr()) },
+                0
+            );
+            // SAFETY: the successful tcgetattr call initialized termios.
+            if unsafe { termios.assume_init() }.c_lflag & libc::ECHO == 0 {
+                if let Some(input) = input {
+                    master.write_all(input.as_bytes()).unwrap();
+                    sent = true;
+                }
+            }
+        }
+        status = status.or_else(|| child.try_wait().unwrap());
+        if status.is_some() && ready == 0 {
+            break;
+        }
+    }
+    let status = status.unwrap_or_else(|| child.wait().unwrap());
+    (
+        status.code().expect("fixture child terminated by signal"),
+        String::from_utf8(transcript).unwrap(),
+    )
+}
+
+#[test]
+fn retry_status_reports_daemon_state_without_camera_access() {
+    let sb = Sandbox::new("retry-status");
+    let requests = serve(&sock(&sb), |_| retry_available());
+    let (code, text, error) = run(&mut sb.cmd(&["retry", "--user", "alice", "status"]));
+    assert_eq!(code, 0, "{error}");
+    assert!(
+        text.contains("'alice': 4 recorded failures, 12s cooldown"),
+        "{text}"
+    );
+    assert!(text.contains("2 failed checks, 0s cooldown"), "{text}");
+    assert!(text.contains("Ordinary password login remains available"));
+    assert!(
+        text.contains("Cumulative face budget unavailable from this daemon; enforcement unknown.")
+    );
+    let requests = requests.lock().unwrap();
+    assert_eq!(requests.len(), 1);
+    assert!(matches!(&requests[0], Request::RetryStatus { user } if user == "alice"));
+}
+
+#[test]
+fn retry_reset_old_daemon_does_not_prompt_or_send_a_password() {
+    let sb = Sandbox::new("retry-old-daemon");
+    let requests = serve(&sock(&sb), |_| Response::Error("bad request".into()));
+    let (code, transcript) =
+        retry_terminal(&mut sb.cmd(&["retry", "reset", "--user", "alice"]), None);
+    assert_eq!(code, 1);
+    assert!(transcript.contains("support"), "{transcript}");
+    assert!(!transcript.contains("Current login password:"));
+    let requests = requests.lock().unwrap();
+    assert_eq!(requests.len(), 1);
+    assert!(matches!(&requests[0], Request::RetryStatus { .. }));
+}
+
+#[test]
+fn retry_status_distinguishes_prospective_and_exhausted_face_budget() {
+    for (tag, count, expected) in [
+        ("prospective", None, "earlier history unknown"),
+        (
+            "face-exhausted",
+            Some(50),
+            "50/50 consecutive unsuccessful; password-verified retry reset required",
+        ),
+    ] {
+        let sb = Sandbox::new(&format!("retry-{tag}"));
+        let _requests = serve(&sock(&sb), move |_| {
+            let Response::RetryStatus {
+                failures,
+                cooldown_seconds,
+                recovery_failures,
+                recovery_cooldown_seconds,
+                recovery_required,
+                password_reset_available,
+                ..
+            } = retry_available()
+            else {
+                unreachable!()
+            };
+            Response::RetryStatus {
+                failures,
+                cooldown_seconds,
+                recovery_failures,
+                recovery_cooldown_seconds,
+                recovery_required,
+                password_reset_available,
+                face_budget: Some(irlume_common::FaceRetryBudget {
+                    unsuccessful_requests: count,
+                    limit: 50,
+                    reset_required: count == Some(50),
+                }),
+            }
+        });
+        let (code, text, error) = run(&mut sb.cmd(&["retry", "status", "--user", "alice"]));
+        assert_eq!(code, 0, "{error}");
+        assert!(text.contains(expected), "{text}");
+        assert!(
+            text.contains("Password-verified retry reset: available"),
+            "{text}"
+        );
+        assert!(!text.contains("administrator reset required"), "{text}");
+    }
+}
+
+#[test]
+fn retry_reset_refuses_unavailable_limited_and_denied_status_before_prompting() {
+    if is_root() {
+        eprintln!("SKIP: non-root retry admission fixture; run default suite unprivileged");
+        return;
+    }
+    for (tag, response) in [
+        (
+            "unavailable",
+            Response::RetryStatus {
+                face_budget: None,
+                password_reset_available: false,
+                failures: 0,
+                cooldown_seconds: 0,
+                recovery_failures: 0,
+                recovery_cooldown_seconds: 0,
+                recovery_required: false,
+            },
+        ),
+        (
+            "cooldown",
+            Response::RetryStatus {
+                face_budget: None,
+                password_reset_available: true,
+                failures: 0,
+                cooldown_seconds: 0,
+                recovery_failures: 5,
+                recovery_cooldown_seconds: 30,
+                recovery_required: false,
+            },
+        ),
+        (
+            "exhausted",
+            Response::RetryStatus {
+                face_budget: None,
+                password_reset_available: true,
+                failures: 0,
+                cooldown_seconds: 0,
+                recovery_failures: 50,
+                recovery_cooldown_seconds: 0,
+                recovery_required: true,
+            },
+        ),
+        (
+            "denied",
+            Response::Error("permission denied: another account".into()),
+        ),
+    ] {
+        let sb = Sandbox::new(&format!("retry-{tag}"));
+        let requests = serve(&sock(&sb), move |_| response.clone());
+        let (code, transcript) =
+            retry_terminal(&mut sb.cmd(&["retry", "reset", "--user", "alice"]), None);
+        assert_eq!(code, 1, "{tag}: {transcript}");
+        assert!(!transcript.contains("Current login password:"), "{tag}");
+        assert_eq!(requests.lock().unwrap().len(), 1, "{tag}");
+    }
+}
+
+#[test]
+fn retry_reset_reads_password_without_echo_and_sends_exact_request() {
+    if is_root() {
+        eprintln!("SKIP: non-root password fixture; run default suite unprivileged");
+        return;
+    }
+    let sb = Sandbox::new("retry-password-pty");
+    let requests = serve(&sock(&sb), |request| match request {
+        Request::RetryStatus { .. } => retry_available(),
+        Request::RetryReset { .. } => Response::Ok("Retry state reset.".into()),
+        _ => Response::Error("unexpected".into()),
+    });
+    let (code, transcript) = retry_terminal(
+        &mut sb.cmd(&["retry", "reset", "--user", "alice"]),
+        Some("synthetic-retry-secret\n"),
+    );
+    assert_eq!(code, 0, "{transcript}");
+    assert!(transcript.contains("Current login password: "));
+    assert!(transcript.contains("Retry state reset."));
+    assert!(!transcript.contains("synthetic-retry-secret"));
+    let requests = requests.lock().unwrap();
+    assert_eq!(requests.len(), 2);
+    assert!(matches!(&requests[0], Request::RetryStatus { user } if user == "alice"));
+    assert!(
+        matches!(&requests[1], Request::RetryReset { user, password } if user == "alice" && password.expose() == b"synthetic-retry-secret")
+    );
+}
+
+#[test]
+fn retry_reset_rejection_and_unexpected_reply_never_report_success() {
+    if is_root() {
+        eprintln!("SKIP: non-root password fixture; run default suite unprivileged");
+        return;
+    }
+    for (tag, response) in [
+        (
+            "rejected",
+            Response::Error("password verification failed".into()),
+        ),
+        ("unexpected", Response::HasPassword(true)),
+    ] {
+        let sb = Sandbox::new(&format!("retry-reset-{tag}"));
+        let requests = serve(&sock(&sb), move |request| match request {
+            Request::RetryStatus { .. } => retry_available(),
+            _ => response.clone(),
+        });
+        let (code, out, error) = run_stdin(
+            &mut sb.cmd(&["retry", "reset", "--user", "alice"]),
+            "synthetic-retry-secret\n",
+        );
+        assert_eq!(code, 1, "{out} {error}");
+        assert!(out.is_empty());
+        assert!(!error.contains("synthetic-retry-secret"));
+        assert_eq!(requests.lock().unwrap().len(), 2);
+    }
+}
+
+#[test]
+fn retry_root_override_is_explicit_and_sends_no_password() {
+    if !is_root() {
+        eprintln!("SKIP: root-only synthetic fixture; rerun this exact test as root");
+        return;
+    }
+    let sb = Sandbox::new("retry-root");
+    let requests = serve(&sock(&sb), |request| match request {
+        Request::RetryStatus { .. } => Response::RetryStatus {
+            face_budget: None,
+            failures: 5,
+            cooldown_seconds: 30,
+            recovery_failures: 50,
+            recovery_cooldown_seconds: 30,
+            recovery_required: true,
+            password_reset_available: false,
+        },
+        Request::RetryReset { .. } => Response::Ok("Administrator retry reset.".into()),
+        _ => Response::Error("unexpected".into()),
+    });
+    let (code, transcript) =
+        retry_terminal(&mut sb.cmd(&["retry", "reset", "--user", "alice"]), None);
+    assert_eq!(code, 0, "{transcript}");
+    assert!(transcript.contains("Administrator reset for 'alice'"));
+    assert!(!transcript.contains("Current login password:"));
+    let requests = requests.lock().unwrap();
+    assert_eq!(requests.len(), 2);
+    assert!(
+        matches!(&requests[1], Request::RetryReset { user, password } if user == "alice" && password.is_empty())
+    );
+}
+
+#[test]
+fn retry_rejects_ambiguous_arguments_before_contacting_daemon() {
+    let sb = Sandbox::new("retry-invalid-args");
+    let requests = serve(&sock(&sb), |_| retry_available());
+    for args in [
+        vec!["retry", "reset", "--user", ""],
+        vec!["retry", "reset", "--user=alice", "--user=bob"],
+        vec!["retry", "reset", "status"],
+        vec!["retry", "reset", "--uesr", "alice"],
+        vec!["retry", "--user"],
+    ] {
+        let (code, _, _) = run(&mut sb.cmd(&args));
+        assert_eq!(code, 2, "{args:?}");
+    }
+    assert!(requests.lock().unwrap().is_empty());
+}
+
+#[test]
+fn retry_password_bounds_are_checked_before_reset_request() {
+    if is_root() {
+        eprintln!("SKIP: non-root password fixture; run default suite unprivileged");
+        return;
+    }
+    for (tag, input, valid) in [
+        ("empty", "\n".into(), false),
+        ("nul", "synthetic\0secret\n".into(), false),
+        ("long", format!("{}\n", "x".repeat(4097)), false),
+        ("maximum", format!("{}\n", "x".repeat(4096)), true),
+    ] {
+        let sb = Sandbox::new(&format!("retry-password-{tag}"));
+        let requests = serve(&sock(&sb), |request| match request {
+            Request::RetryStatus { .. } => retry_available(),
+            Request::RetryReset { .. } => Response::Ok("Retry state reset.".into()),
+            _ => Response::Error("unexpected".into()),
+        });
+        let (code, _, _) = run_stdin(&mut sb.cmd(&["retry", "reset", "--user=alice"]), &input);
+        assert_eq!(code, i32::from(!valid), "{tag}");
+        let requests = requests.lock().unwrap();
+        assert_eq!(requests.len(), if valid { 2 } else { 1 }, "{tag}");
+        if valid {
+            assert!(
+                matches!(&requests[1], Request::RetryReset { password, .. } if password.len() == 4096)
+            );
+        }
+    }
+}
+
+#[test]
+fn retry_bare_status_reports_unavailable_and_exhausted_recovery() {
+    for (tag, required, label) in [
+        ("unavailable", false, "unavailable on this installation"),
+        ("exhausted", true, "administrator reset required"),
+    ] {
+        let sb = Sandbox::new(&format!("retry-bare-status-{tag}"));
+        let requests = serve(&sock(&sb), move |_| Response::RetryStatus {
+            face_budget: None,
+            failures: 0,
+            cooldown_seconds: 0,
+            recovery_failures: if required { 50 } else { 0 },
+            recovery_cooldown_seconds: 0,
+            recovery_required: required,
+            password_reset_available: false,
+        });
+        let (code, out, err) = run(sb
+            .cmd(&["retry"])
+            .env("USER", "alice")
+            .env_remove("SUDO_USER"));
+        assert_eq!(code, 0, "{out} {err}");
+        assert!(out.contains(label), "{out}");
+        let requests = requests.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert!(matches!(&requests[0], Request::RetryStatus { user } if user == "alice"));
+    }
+}
+
+#[test]
+fn auth_sensor_preflight_requires_ir_policy_even_if_readiness_claims_ready() {
+    use irlume_common::config::{FaceSensorPolicy as Policy, FaceSensorPolicyObservation as State};
+    let sb = Sandbox::new("sensor-preflight-policy-consistency");
+    let requests = serve(&sock(&sb), |req| {
+        let Request::FaceSensorStatus { user: Some(user) } = req else {
+            return Response::Error("unexpected request".into());
+        };
+        let policy = match user.as_str() {
+            "default-account" => State::DefaultDual,
+            "dual-account" => State::Explicit(Policy::Dual),
+            "invalid-account" => State::Invalid,
+            "unreadable-account" => State::Unreadable,
+            _ => unreachable!("fixture account"),
+        };
+        Response::FaceSensorStatus {
+            policy,
+            ir_readiness: Some(irlume_common::IrOnlyReadiness::ReadyForExperimentalAttempt),
+        }
+    });
+    for (account, expected) in [
+        ("default-account", "IR-only is not selected"),
+        ("dual-account", "IR-only is not selected"),
+        ("invalid-account", "sensor policy is invalid or unreadable"),
+        (
+            "unreadable-account",
+            "sensor policy is invalid or unreadable",
+        ),
+    ] {
+        let (code, out, err) = run(&mut sb.cmd(&["auth", "sensor", "preflight", account]));
+        assert_ne!(code, 0, "{out} {err}");
+        assert!(err.contains(expected), "{out} {err}");
+        assert!(err.contains("password"), "{out} {err}");
+        assert!(!out.contains("prerequisites are ready"), "{out}");
+        assert!(!format!("{out}{err}").contains(account));
+    }
+    assert_eq!(requests.lock().unwrap().len(), 4);
 }

--- a/crates/irlume-cli/tests/cli_dispatch.rs
+++ b/crates/irlume-cli/tests/cli_dispatch.rs
@@ -14,12 +14,11 @@
 //! speaking the real line-JSON `Request`/`Response` protocol) that returns the
 //! exact canned answer the arm expects.
 //!
-//! Isolation is identical to `cli.rs`: `IRLUME_SOCKET` / `IRLUME_CONFIG_DIR` /
-//! `IRLUME_STATE_DIR` / `IRLUME_KEYRING_DIR` / `IRLUME_METHOD_CONF` all point
-//! into a per-test temp tree, shelled-out tools are PATH-shadowed with fakes,
-//! and nothing touches the network, a camera, the TPM, root, or the machine's
-//! package database. Every spawn is watchdogged: a child that has not exited
-//! after 30s is killed and the test fails, naming the command.
+//! Isolation is identical to `cli.rs`: state paths point into a per-test temp
+//! tree and shelled-out tools are fakes. Privileged fixed-path command tests add
+//! a Bubblewrap user/mount namespace with a private `/usr/bin` and `/run`, so
+//! they cannot reach host services. Every spawn is watchdogged: a child that
+//! has not exited after 30s is killed and the test fails, naming the command.
 
 use std::io::{Read as _, Write as _};
 use std::path::{Path, PathBuf};
@@ -27,6 +26,8 @@ use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
 use irlume_common::{ProfileSummary, Request, Response};
+
+mod support;
 
 const BIN: &str = env!("CARGO_BIN_EXE_irlume");
 const SPAWN_TIMEOUT: Duration = Duration::from_secs(30);
@@ -54,6 +55,14 @@ impl Sandbox {
         for d in ["cfg", "state", "keyring", "bin", "work"] {
             std::fs::create_dir_all(root.join(d)).unwrap();
         }
+        let helper = root.join("wallet-salt-helper");
+        std::fs::write(
+            &helper,
+            "#!/bin/sh\n[ \"$1\" = --read-salt ] && [ \"$#\" -eq 2 ] || exit 1\nexit 3\n",
+        )
+        .unwrap();
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(&helper, std::fs::Permissions::from_mode(0o700)).unwrap();
         Sandbox { root }
     }
 
@@ -82,6 +91,7 @@ impl Sandbox {
             .env("IRLUME_STATE_DIR", self.root.join("state"))
             .env("IRLUME_KEYRING_DIR", self.root.join("keyring"))
             .env("IRLUME_METHOD_CONF", self.root.join("cfg").join("method"))
+            .env("IRLUME_KWALLET_INIT", self.root.join("wallet-salt-helper"))
             .env_remove("IRLUME_DEV")
             .env_remove("IRLUME_CONSENT_GESTURE")
             .env_remove("ORT_DYLIB_PATH")
@@ -94,19 +104,8 @@ impl Sandbox {
         c
     }
 
-    /// Like `cmd`, but with the sandbox bin dir prepended to PATH so fake tools
-    /// shadow the real ones.
-    fn cmd_with_fakes(&self, args: &[&str]) -> Command {
-        let mut c = self.cmd(args);
-        c.env(
-            "PATH",
-            format!(
-                "{}:{}",
-                self.root.join("bin").display(),
-                std::env::var("PATH").unwrap_or_default()
-            ),
-        );
-        c
+    fn isolated_root_cmd(&self, args: &[&str], tools: &[&str]) -> Command {
+        support::isolated_root_command(&self.root, BIN, args, tools)
     }
 }
 
@@ -114,6 +113,35 @@ impl Drop for Sandbox {
     fn drop(&mut self) {
         let _ = std::fs::remove_dir_all(&self.root);
     }
+}
+
+#[test]
+fn privileged_command_namespace_masks_every_resolver_prefix() {
+    let sb = Sandbox::new("command-path-namespace");
+    support::assert_system_command_isolation(&sb.root, &[]);
+    let commands = [
+        "loginctl",
+        "gnome-shell",
+        "semodule",
+        "systemctl",
+        "restorecon",
+    ];
+    for command in commands {
+        sb.fake_tool(command, "exit 0");
+    }
+    support::assert_system_command_isolation(&sb.root, &commands);
+}
+
+#[test]
+fn privileged_command_namespace_restores_split_bin_script_interpreter() {
+    assert_eq!(
+        support::shell_bind_destinations(Path::new("/usr/bin"), Path::new("/usr/bin")),
+        &["/usr/bin/sh"]
+    );
+    assert_eq!(
+        support::shell_bind_destinations(Path::new("/usr/bin"), Path::new("/bin")),
+        &["/usr/bin/sh", "/bin/sh"]
+    );
 }
 
 /// Drain a spawned child under a 30s watchdog. stdout/stderr are read on their
@@ -608,7 +636,8 @@ fn diag_does_not_call_a_reachable_daemon_unreachable_when_its_reply_is_unexpecte
 // cwd-relative lookup is GONE (running `sudo irlume selinux load` from a
 // directory holding a packaging/selinux/irlume.pp used to install the
 // caller's file as system policy), and every tool the sequence runs is a
-// fake on PATH. The first version of this test faked only semodule, so on a
+// fake at its fixed resolver path inside a private mount namespace. The
+// first version of this test faked only semodule on PATH, so on a
 // host with the packaged .pp installed it found the REAL module and drove
 // the REAL systemctl through a try-restart of the host's daemon: a test
 // that touches the machine it runs on is the bug, not the coverage.
@@ -622,7 +651,7 @@ fn selinux_load_handles_missing_module_and_semodule_outcomes() {
     // short-circuits `load` on hosts without SELinux) out of the way, so
     // this still tests the .pp lookup path it was written for.
     sb.fake_tool("semodule", "exit 0");
-    let mut miss = sb.cmd_with_fakes(&["selinux", "load"]);
+    let mut miss = sb.isolated_root_cmd(&["selinux", "load"], &["semodule"]);
     miss.env("IRLUME_SELINUX_PP", sb.path("does-not-exist.pp"));
     let (code, _, err) = run(&mut miss, "selinux load");
     assert_eq!(code, 1);
@@ -631,7 +660,10 @@ fn selinux_load_handles_missing_module_and_semodule_outcomes() {
     let pp = sb.path("irlume.pp");
     std::fs::write(&pp, b"\x00").unwrap();
     let with_pp = |sb: &Sandbox| {
-        let mut c = sb.cmd_with_fakes(&["selinux", "load"]);
+        let mut c = sb.isolated_root_cmd(
+            &["selinux", "load"],
+            &["semodule", "systemctl", "restorecon"],
+        );
         c.env("IRLUME_SELINUX_PP", &pp);
         c
     };

--- a/crates/irlume-cli/tests/support/mod.rs
+++ b/crates/irlume-cli/tests/support/mod.rs
@@ -1,0 +1,146 @@
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+/// Run the CLI as namespace-root with a private fixed `/usr/bin`, so code that
+/// deliberately ignores PATH cannot reach the host's privileged tools.
+pub(crate) fn isolated_root_command(
+    root: &Path,
+    bin: &str,
+    args: &[&str],
+    tools: &[&str],
+) -> Command {
+    namespace_command(root, bin, args, tools)
+}
+
+fn namespace_command(root: &Path, bin: &str, args: &[&str], tools: &[&str]) -> Command {
+    let shell = std::fs::canonicalize("/bin/sh").expect("resolve /bin/sh for sandbox");
+    let usr_bin = std::fs::canonicalize("/usr/bin").expect("resolve /usr/bin for sandbox");
+    let bin_dir = std::fs::canonicalize("/bin").expect("resolve /bin for sandbox");
+    let mut masked = Vec::new();
+    for prefix in [
+        "/usr/bin",
+        "/usr/sbin",
+        "/bin",
+        "/sbin",
+        "/usr/local/bin",
+        "/usr/local/sbin",
+    ] {
+        // Bubblewrap refuses a mount whose destination spelling is a symlink.
+        // Canonicalising also deduplicates usr-merge aliases onto the directory
+        // they share. An absent optional prefix stays absent under the read-only
+        // root and therefore needs no mount.
+        if let Ok(canonical) = std::fs::canonicalize(prefix) {
+            if canonical.is_dir() && !masked.contains(&canonical) {
+                masked.push(canonical);
+            }
+        }
+    }
+    let mut command = Command::new("/usr/bin/bwrap");
+    command
+        .args([
+            "--die-with-parent",
+            "--unshare-user",
+            "--uid",
+            "0",
+            "--gid",
+            "0",
+            "--unshare-pid",
+            "--unshare-net",
+            "--unshare-ipc",
+            "--unshare-uts",
+            "--unshare-cgroup-try",
+            "--ro-bind",
+            "/",
+            "/",
+        ])
+        .args(["--tmpfs", "/run"]);
+    for prefix in masked {
+        command.args(["--tmpfs", prefix.to_str().unwrap()]);
+    }
+    for destination in shell_bind_destinations(&usr_bin, &bin_dir) {
+        command.args(["--ro-bind", shell.to_str().unwrap(), destination]);
+    }
+    for tool in tools {
+        let fake = root.join("bin").join(tool);
+        assert!(fake.is_file(), "missing sandbox fake: {}", fake.display());
+        command
+            .args(["--ro-bind", fake.to_str().unwrap()])
+            .arg(format!("/usr/bin/{tool}"));
+    }
+    command
+        .args(["--dev", "/dev", "--proc", "/proc"])
+        .args(["--bind", root.to_str().unwrap(), root.to_str().unwrap()])
+        .args(["--chdir", root.join("work").to_str().unwrap(), "--", bin])
+        .args(args)
+        .env("PATH", "/usr/bin")
+        .env("IRLUME_SOCKET", root.join("no-daemon.sock"))
+        .env("IRLUME_CONFIG_DIR", root.join("cfg"))
+        .env("IRLUME_STATE_DIR", root.join("state"))
+        .env("IRLUME_KEYRING_DIR", root.join("keyring"))
+        .env("IRLUME_METHOD_CONF", root.join("cfg").join("method"))
+        .env_remove("IRLUME_DEV")
+        .env_remove("IRLUME_CONSENT_GESTURE")
+        .env_remove("ORT_DYLIB_PATH")
+        .env_remove("IRLUME_MODEL")
+        .env_remove("IRLUME_DET_MODEL")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    command
+}
+
+/// Fixture scripts use `#!/bin/sh`. A split `/bin` needs its own restored
+/// interpreter; usr-merge reaches the `/usr/bin/sh` bind through the alias.
+pub(crate) fn shell_bind_destinations(usr_bin: &Path, bin: &Path) -> &'static [&'static str] {
+    if usr_bin == bin {
+        &["/usr/bin/sh"]
+    } else {
+        &["/usr/bin/sh", "/bin/sh"]
+    }
+}
+
+/// Prove the namespace contains none of the resolver's closed command set when
+/// no fixtures are supplied, and only fixture aliases when they are supplied.
+pub(crate) fn assert_system_command_isolation(root: &Path, tools: &[&str]) {
+    const CLOSED: [&str; 5] = [
+        "loginctl",
+        "gnome-shell",
+        "semodule",
+        "systemctl",
+        "restorecon",
+    ];
+    let supplied = tools.join(" ");
+    let script = format!(
+        r#"
+set -eu
+for name in {}; do
+    expected=0
+    case " {} " in *" $name "*) expected=1;; esac
+    found=0
+    for dir in /usr/bin /usr/sbin /bin /sbin /usr/local/bin /usr/local/sbin /run/current-system/sw/bin; do
+        candidate="$dir/$name"
+        if [ -e "$candidate" ]; then
+            [ "$expected" -eq 1 ]
+            [ "$candidate" -ef "/usr/bin/$name" ]
+            found=1
+        fi
+    done
+    [ "$found" -eq "$expected" ]
+done
+for name in {}; do
+    "/usr/bin/$name" >/dev/null
+done
+"#,
+        CLOSED.join(" "),
+        supplied,
+        supplied,
+    );
+    let output = namespace_command(root, "/usr/bin/sh", &["-c", &script], tools)
+        .output()
+        .expect("spawn isolated command-path assertion");
+    assert!(
+        output.status.success(),
+        "isolated command-path assertion failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/crates/irlume-common/src/client.rs
+++ b/crates/irlume-common/src/client.rs
@@ -36,6 +36,9 @@ const MAX_RESPONSE_BYTES: u64 = 64 * 1024;
 
 /// Default read/write timeout for management requests.
 const DEFAULT_RW_TIMEOUT: Duration = Duration::from_secs(30);
+/// Operator-selected ceiling that also covers a stalled NSS lookup or
+/// filesystem without hanging a login session.
+const WALLET_SALT_HELPER_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// Read an environment override that must NEVER be honoured in a
 /// secure-execution context. `pam_irlume` is linked into setuid-root PAM stacks
@@ -75,6 +78,147 @@ pub fn socket_path() -> PathBuf {
     secure_env("IRLUME_SOCKET")
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from(SOCKET_PATH))
+}
+
+/// Read the KDE wallet salt through the account-scoped helper.
+///
+/// `Ok(None)` has one narrow meaning: the helper proved the salt path absent.
+/// Permission, type, credential, timeout, malformed-output and execution
+/// failures remain errors, so automatic kind selection cannot silently fall
+/// back to a login password after a denied KDE lookup.
+///
+/// # Errors
+/// Returns a generic error without the target path or helper output.
+pub fn read_wallet_salt(user: &str) -> io::Result<Option<crate::WalletSalt>> {
+    read_wallet_salt_with_timeout(user, WALLET_SALT_HELPER_TIMEOUT)
+}
+
+fn read_wallet_salt_with_timeout(
+    user: &str,
+    timeout: Duration,
+) -> io::Result<Option<crate::WalletSalt>> {
+    read_wallet_salt_with_timeout_and_clock(user, timeout, |_| {}, std::time::Instant::now)
+}
+
+fn read_wallet_salt_with_timeout_and_clock(
+    user: &str,
+    timeout: Duration,
+    mut after_poll: impl FnMut(bool),
+    mut now: impl FnMut() -> std::time::Instant,
+) -> io::Result<Option<crate::WalletSalt>> {
+    use std::os::fd::AsRawFd as _;
+    use std::process::{Command, Stdio};
+
+    let helper = secure_env("IRLUME_KWALLET_INIT")
+        .filter(|path| !path.is_empty())
+        .unwrap_or_else(|| std::ffi::OsString::from(crate::KWALLET_INIT_PATH));
+    let mut child = Command::new(helper)
+        .args(["--read-salt", user])
+        .env_clear()
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|_| wallet_salt_error(io::ErrorKind::Other))?;
+    let Some(mut stdout) = child.stdout.take() else {
+        kill_wallet_salt_helper(&mut child);
+        return Err(wallet_salt_error(io::ErrorKind::Other));
+    };
+    let fd = stdout.as_raw_fd();
+    // SAFETY: both fcntl calls operate on the live stdout fd owned above and
+    // do not retain pointers or references.
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    // SAFETY: same owned fd; the only change is adding nonblocking mode.
+    if flags < 0 || unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0 {
+        kill_wallet_salt_helper(&mut child);
+        return Err(wallet_salt_error(io::ErrorKind::Other));
+    }
+
+    let deadline = now() + timeout;
+    let mut output = Zeroizing::new(Vec::with_capacity(crate::kwallet_wire::SALT_LEN));
+    let mut chunk = Zeroizing::new([0u8; 64]);
+    let status = loop {
+        if now() >= deadline {
+            kill_wallet_salt_helper(&mut child);
+            return Err(wallet_salt_error(io::ErrorKind::TimedOut));
+        }
+        let read = stdout.read(&mut chunk[..]);
+        after_poll(matches!(read, Ok(n) if n > 0));
+        if now() >= deadline {
+            kill_wallet_salt_helper(&mut child);
+            return Err(wallet_salt_error(io::ErrorKind::TimedOut));
+        }
+        match read {
+            Ok(0) => {
+                let waited = child.try_wait();
+                after_poll(false);
+                if now() >= deadline {
+                    kill_wallet_salt_helper(&mut child);
+                    return Err(wallet_salt_error(io::ErrorKind::TimedOut));
+                }
+                match waited {
+                    Ok(Some(status)) => break status,
+                    Ok(None) => {
+                        std::thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(_) => {
+                        kill_wallet_salt_helper(&mut child);
+                        return Err(wallet_salt_error(io::ErrorKind::Other));
+                    }
+                }
+            }
+            Ok(n) => {
+                if output.len() + n > crate::kwallet_wire::SALT_LEN {
+                    kill_wallet_salt_helper(&mut child);
+                    return Err(wallet_salt_error(io::ErrorKind::InvalidData));
+                }
+                output.extend_from_slice(&chunk[..n]);
+            }
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                if now() >= deadline {
+                    kill_wallet_salt_helper(&mut child);
+                    return Err(wallet_salt_error(io::ErrorKind::TimedOut));
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Err(_) => {
+                kill_wallet_salt_helper(&mut child);
+                return Err(wallet_salt_error(io::ErrorKind::Other));
+            }
+        }
+    };
+    if now() >= deadline {
+        kill_wallet_salt_helper(&mut child);
+        return Err(wallet_salt_error(io::ErrorKind::TimedOut));
+    }
+    if status.success() && output.len() == crate::kwallet_wire::SALT_LEN {
+        return crate::WalletSalt::new(std::mem::take(&mut *output))
+            .map(Some)
+            .ok_or_else(|| wallet_salt_error(io::ErrorKind::InvalidData));
+    }
+    if status.code() == Some(crate::kwallet_wire::SALT_ABSENT_EXIT) && output.is_empty() {
+        return Ok(None);
+    }
+    Err(wallet_salt_error(io::ErrorKind::InvalidData))
+}
+
+fn wallet_salt_error(kind: io::ErrorKind) -> io::Error {
+    io::Error::new(kind, "account-scoped wallet salt lookup failed")
+}
+
+fn kill_wallet_salt_helper(child: &mut std::process::Child) {
+    let _ = child.kill();
+    let deadline = std::time::Instant::now() + Duration::from_millis(200);
+    while std::time::Instant::now() < deadline {
+        match child.try_wait() {
+            Ok(Some(_)) | Err(_) => return,
+            Ok(None) => std::thread::sleep(Duration::from_millis(10)),
+        }
+    }
+    // As in the PAM helper path, an uninterruptible kernel sleep can outlive
+    // this bound. The caller must not trade a hung login for an unbounded reap;
+    // init reaps the process after the caller exits.
 }
 
 /// Send `req` with the default read/write timeout.
@@ -312,24 +456,17 @@ fn request_with_timeouts_inner(
     (&stream).write_all(&line).map_err(map_connect_failure)?;
     (&stream).flush().map_err(map_connect_failure)?;
 
-    // Capped, like the daemon caps requests. `SO_RCVTIMEO` restarts on every
-    // read, so the rw budget bounds one read and not the exchange: a peer that
-    // dribbles bytes with no newline holds the caller forever and grows the
-    // buffer without bound. That caller can be `pam_irlume` inside a login.
-    // The daemon is honest, but `IRLUME_SOCKET` redirects any non-setuid
-    // invocation, so the peer is not always the daemon.
-    let buf = if let Some(cancelled) = cancelled {
-        stream.set_read_timeout(Some(Duration::from_millis(100)))?;
-        let reader = CancellableReply {
-            stream: &stream,
-            cancelled,
-            deadline: std::time::Instant::now() + rw_timeout,
-        };
-        read_response_line(reader.take(MAX_RESPONSE_BYTES))
-    } else {
-        read_response_line((&stream).take(MAX_RESPONSE_BYTES))
-    }
-    .map_err(map_connect_failure)?;
+    // SO_RCVTIMEO restarts on each read. One monotonic reply deadline must
+    // cover every partial read, including ordinary PAM requests. Keep the
+    // existing wiping framing buffer; an unseal reply can contain a secret.
+    let never_cancelled = std::sync::atomic::AtomicBool::new(false);
+    let mut reader = CancellableReply {
+        stream: &stream,
+        cancelled: cancelled.unwrap_or(&never_cancelled),
+        deadline: std::time::Instant::now() + rw_timeout,
+    };
+    let buf = read_response_line(reader.by_ref().take(MAX_RESPONSE_BYTES))
+        .map_err(map_connect_failure)?;
     if buf.len() as u64 >= MAX_RESPONSE_BYTES {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -345,8 +482,10 @@ fn request_with_timeouts_inner(
     // The response may carry an unsealed secret. `buf` wipes itself when this
     // frame ends, and by then the bytes live inside a zeroizing `SecretBytes`
     // in the parsed value.
-    serde_json::from_slice(buf.trim_ascii())
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+    let response = serde_json::from_slice(buf.trim_ascii())
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    reader.check()?;
+    Ok(response)
 }
 
 struct CancellableReply<'a> {
@@ -355,22 +494,42 @@ struct CancellableReply<'a> {
     deadline: std::time::Instant,
 }
 
+impl CancellableReply<'_> {
+    fn check(&self) -> io::Result<()> {
+        if self.cancelled.load(std::sync::atomic::Ordering::Relaxed) {
+            return Err(io::Error::new(
+                io::ErrorKind::ConnectionAborted,
+                "request cancelled",
+            ));
+        }
+        if std::time::Instant::now() >= self.deadline {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "daemon reply timed out",
+            ));
+        }
+        Ok(())
+    }
+}
+
 impl Read for CancellableReply<'_> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         loop {
-            if self.cancelled.load(std::sync::atomic::Ordering::Relaxed) {
-                return Err(io::Error::new(
-                    io::ErrorKind::ConnectionAborted,
-                    "enrollment cancelled",
-                ));
+            self.check()?;
+            // Never spend a full cancellation poll after the remaining budget.
+            let remaining = self
+                .deadline
+                .saturating_duration_since(std::time::Instant::now());
+            if remaining.is_zero() {
+                continue;
             }
-            if std::time::Instant::now() >= self.deadline {
-                return Err(io::Error::new(
-                    io::ErrorKind::TimedOut,
-                    "enrollment reply timed out",
-                ));
-            }
-            match self.stream.read(buf) {
+            self.stream
+                .set_read_timeout(Some(remaining.min(Duration::from_millis(100))))?;
+            let result = self.stream.read(buf);
+            // A successful blocking read can itself finish after expiry or
+            // cancellation. Do not admit those bytes merely because it succeeded.
+            self.check()?;
+            match result {
                 Err(e)
                     if matches!(
                         e.kind(),
@@ -458,6 +617,35 @@ mod tests {
         let p = std::env::temp_dir().join(format!("irlume-cl-{tag}-{}.sock", std::process::id()));
         let _ = std::fs::remove_file(&p);
         p
+    }
+
+    #[test]
+    fn ordinary_reply_trickle_cannot_extend_overall_read_budget() {
+        let _guard = testenv::lock();
+        let path = sock("deadline-trickle");
+        let listener = UnixListener::bind(&path).unwrap();
+        std::env::set_var("IRLUME_SOCKET", &path);
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = String::new();
+            BufReader::new(&stream).read_line(&mut request).unwrap();
+            // Every individual pause fits the 100ms SO_RCVTIMEO, but the
+            // complete valid reply exceeds the single request budget.
+            for byte in b"\"Pong\"\n" {
+                if stream.write_all(&[*byte]).is_err() {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(35));
+            }
+        });
+        let result = request_with_timeout(&Request::Ping, Duration::from_millis(100));
+        server.join().unwrap();
+        std::env::remove_var("IRLUME_SOCKET");
+        let _ = std::fs::remove_file(&path);
+        assert!(
+            matches!(result, Err(ref error) if error.kind() == io::ErrorKind::TimedOut),
+            "trickled reply must expire, got {result:?}"
+        );
     }
 
     #[test]
@@ -961,6 +1149,114 @@ mod tests {
             serde_json::from_slice::<Request>(&line[..line.len() - 1]).is_ok(),
             "the wiping buffer still carries parseable JSON"
         );
+    }
+
+    fn salt_helper_script() -> PathBuf {
+        use std::os::unix::fs::PermissionsExt as _;
+        let path =
+            std::env::temp_dir().join(format!("irlume-wallet-salt-helper-{}", std::process::id()));
+        std::fs::write(
+            &path,
+            r#"#!/bin/sh
+test "$1" = --read-salt && test "$#" -eq 2 || exit 9
+case "$2" in
+  present) printf '%056d' 0 ;;
+  absent) exit 3 ;;
+  denied) exit 1 ;;
+  partial) printf x; exit 1 ;;
+  oversized) printf '%057d' 0 ;;
+  envcheck) test -z "$IRLUME_WALLET_LEAK" && printf '%056d' 0 ;;
+  stalled) printf '%s\n' "$$" > "$0.pid"; exec /usr/bin/sleep 30 ;;
+  *) exit 9 ;;
+esac
+"#,
+        )
+        .unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o700)).unwrap();
+        path
+    }
+
+    #[test]
+    fn wallet_salt_helper_contract_is_bounded_and_unambiguous() {
+        let _guard = testenv::lock();
+        let helper = salt_helper_script();
+        std::env::set_var("IRLUME_KWALLET_INIT", &helper);
+
+        let salt = read_wallet_salt_with_timeout("present", Duration::from_secs(2))
+            .unwrap()
+            .expect("present salt");
+        assert_eq!(salt.expose(), &[b'0'; crate::kwallet_wire::SALT_LEN]);
+        std::env::set_var("IRLUME_WALLET_LEAK", "must-not-reach-helper");
+        assert!(
+            read_wallet_salt_with_timeout("envcheck", Duration::from_secs(2))
+                .unwrap()
+                .is_some()
+        );
+        std::env::remove_var("IRLUME_WALLET_LEAK");
+        assert!(
+            read_wallet_salt_with_timeout("absent", Duration::from_secs(2))
+                .unwrap()
+                .is_none()
+        );
+        for user in ["denied", "partial", "oversized"] {
+            let error = read_wallet_salt_with_timeout(user, Duration::from_secs(2))
+                .expect_err("only clean exit 3 with zero output means absent");
+            assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+            assert!(!error.to_string().contains(user));
+        }
+        let started = std::time::Instant::now();
+        let error = read_wallet_salt_with_timeout("stalled", Duration::from_millis(150))
+            .expect_err("stalled helper must be killed");
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+        assert!(started.elapsed() < Duration::from_secs(2));
+        let pid: u32 = std::fs::read_to_string(helper.with_extension("pid"))
+            .unwrap()
+            .trim()
+            .parse()
+            .unwrap();
+        assert!(
+            !std::path::Path::new(&format!("/proc/{pid}")).exists(),
+            "ordinary timeout child must be killed and reaped"
+        );
+
+        std::env::remove_var("IRLUME_KWALLET_INIT");
+        std::fs::remove_file(helper.with_extension("pid")).unwrap();
+        std::fs::remove_file(helper).unwrap();
+    }
+
+    #[test]
+    fn wallet_salt_result_is_not_accepted_after_the_deadline() {
+        let _guard = testenv::lock();
+        let helper = salt_helper_script();
+        std::env::set_var("IRLUME_KWALLET_INIT", &helper);
+        let expired = std::rc::Rc::new(std::cell::Cell::new(false));
+        let mark_expired = std::rc::Rc::clone(&expired);
+        let clock_expired = std::rc::Rc::clone(&expired);
+        let start = std::time::Instant::now();
+        let error = read_wallet_salt_with_timeout_and_clock(
+            "present",
+            Duration::from_millis(10),
+            |received_bytes| {
+                if received_bytes {
+                    mark_expired.set(true);
+                }
+            },
+            || {
+                if clock_expired.get() {
+                    start + Duration::from_millis(50)
+                } else {
+                    start
+                }
+            },
+        )
+        .expect_err("a complete helper result arriving after the budget must be refused");
+        assert!(
+            expired.get(),
+            "the seam must expire only after reading bytes"
+        );
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+        std::env::remove_var("IRLUME_KWALLET_INIT");
+        std::fs::remove_file(helper).unwrap();
     }
 }
 

--- a/crates/irlume-common/src/config.rs
+++ b/crates/irlume-common/src/config.rs
@@ -18,6 +18,81 @@ pub const CONFIG_ROOT: &str = "/etc/irlume";
 /// on which file holds the pin.
 pub const CAMERAS_CONF: &str = "cameras.conf";
 
+/// Machine-wide sensor selection, independent of two-camera scheduling.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum FaceSensorPolicy {
+    Dual,
+    IrOnlyExperimental,
+}
+
+/// One observed policy snapshot. Errors never imply permission to use RGB.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FaceSensorPolicyObservation {
+    DefaultDual,
+    Explicit(FaceSensorPolicy),
+    Invalid,
+    Unreadable,
+}
+
+impl FaceSensorPolicyObservation {
+    /// Resolve the single observation without defaulting on malformed policy.
+    ///
+    /// # Errors
+    /// Invalid or unreadable policy requires password fallback.
+    pub fn resolve(self) -> crate::Result<FaceSensorPolicy> {
+        match self {
+            Self::DefaultDual => Ok(FaceSensorPolicy::Dual),
+            Self::Explicit(policy) => Ok(policy),
+            Self::Invalid | Self::Unreadable => Err(crate::Error::Policy(
+                "face sensor policy is invalid or unreadable; use your password".into(),
+            )),
+        }
+    }
+}
+
+/// Read the sensor setting once without probing cameras or loading enrollment.
+/// Empty, duplicate and malformed settings are invalid, not the dual default.
+pub fn observe_face_sensor_policy() -> FaceSensorPolicyObservation {
+    use FaceSensorPolicyObservation::{DefaultDual, Explicit, Invalid, Unreadable};
+    let text = match std::fs::read_to_string(config_path("settings.conf")) {
+        Ok(text) => text,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return DefaultDual,
+        Err(_) => return Unreadable,
+    };
+    let mut selected = None;
+    for line in text.lines().map(str::trim) {
+        if line.starts_with('#') || line.is_empty() {
+            continue;
+        }
+        // Recognize malformed attempts to set this exact key too. Otherwise
+        // a missing '=' or a ':' separator silently restores the dual default.
+        // Distinct keys sharing the prefix remain unrelated settings.
+        let is_policy = line.strip_prefix("face_sensor_policy").is_some_and(|tail| {
+            tail.is_empty() || tail.starts_with(|c: char| c.is_whitespace() || c == '=' || c == ':')
+        });
+        if !is_policy {
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            return Invalid;
+        };
+        if key.trim() != "face_sensor_policy" {
+            return Invalid;
+        }
+        if selected.is_some() {
+            return Invalid;
+        }
+        selected = Some(match value.trim() {
+            "dual" => FaceSensorPolicy::Dual,
+            "ir-only-experimental" => FaceSensorPolicy::IrOnlyExperimental,
+            _ => return Invalid,
+        });
+    }
+    selected.map_or(DefaultDual, Explicit)
+}
+
 fn config_root() -> PathBuf {
     std::env::var_os("IRLUME_CONFIG_DIR")
         .map(PathBuf::from)
@@ -466,11 +541,13 @@ pub fn forbid_external_cameras_visible() -> Option<bool> {
 /// it again before honouring [`crate::IntentAttestation::PolicyWaived`], so a client
 /// cannot waive a confirmation the machine's own policy still requires.
 pub fn privileged_face_consent_visible() -> Option<bool> {
-    if let Ok(v) = std::env::var("IRLUME_PRIVILEGED_FACE_CONSENT") {
-        return Some(truthy(&v));
+    // Waiving confirmation requires an explicit opt-out. A typo, empty or
+    // non-Unicode environment value cannot silently remove the intent gate.
+    if let Some(v) = std::env::var_os("IRLUME_PRIVILEGED_FACE_CONSENT") {
+        return Some(!v.to_str().is_some_and(falsy));
     }
     match observe_kv("settings.conf", "privileged_face_consent") {
-        KvObservation::Value(v) => Some(truthy(&v)),
+        KvObservation::Value(v) => Some(!falsy(&v)),
         // Absent is unambiguous here too, but the default is ON.
         KvObservation::Absent => Some(true),
         KvObservation::Unknown(_) => None,
@@ -519,6 +596,58 @@ mod tests {
 
         std::env::remove_var("IRLUME_PRIVILEGED_FACE_CONSENT");
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn privileged_consent_requires_an_explicit_opt_out() {
+        let _g = testenv::lock();
+        let dir =
+            std::env::temp_dir().join(format!("irlume-consent-invalid-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::env::set_var("IRLUME_CONFIG_DIR", &dir);
+        std::env::remove_var("IRLUME_PRIVILEGED_FACE_CONSENT");
+        for (value, required) in [
+            ("0", false),
+            (" OFF ", false),
+            ("false", false),
+            ("no", false),
+            ("yes", true),
+            ("1", true),
+            ("on", true),
+            ("true", true),
+            ("typo", true),
+            ("2", true),
+            ("", true),
+        ] {
+            write_kv("settings.conf", "privileged_face_consent", value).unwrap();
+            assert_eq!(
+                privileged_face_consent_required(),
+                required,
+                "file value {value:?}"
+            );
+            std::env::set_var("IRLUME_PRIVILEGED_FACE_CONSENT", value);
+            assert_eq!(
+                privileged_face_consent_required(),
+                required,
+                "env value {value:?}"
+            );
+            std::env::remove_var("IRLUME_PRIVILEGED_FACE_CONSENT");
+        }
+        // A non-Unicode override must not fall through to a file waiver.
+        use std::os::unix::ffi::OsStringExt as _;
+        write_kv("settings.conf", "privileged_face_consent", "0").unwrap();
+        std::env::set_var(
+            "IRLUME_PRIVILEGED_FACE_CONSENT",
+            std::ffi::OsString::from_vec(vec![0xff]),
+        );
+        assert!(privileged_face_consent_required());
+        std::env::remove_var("IRLUME_PRIVILEGED_FACE_CONSENT");
+        std::fs::remove_file(dir.join("settings.conf")).unwrap();
+        std::fs::create_dir(dir.join("settings.conf")).unwrap();
+        assert_eq!(privileged_face_consent_visible(), None);
+        assert!(privileged_face_consent_required());
+        std::env::remove_var("IRLUME_CONFIG_DIR");
+        std::fs::remove_dir_all(dir).unwrap();
     }
 
     /// The external-camera prohibition reads env-over-settings with Absent

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -32,9 +32,18 @@ pub const SOCKET_PATH: &str = "/run/irlume.sock";
 /// `Debug` is redacted, so it never lingers on the daemon/PAM heap longer than
 /// needed nor leaks into a log line. `#[serde(transparent)]` so it ships as a
 /// plain byte array over the IPC channel.
-#[derive(Clone, Serialize, Default)]
+#[derive(Serialize, Default)]
 #[serde(transparent)]
 pub struct SecretBytes(Vec<u8>);
+
+// Manual so every copied allocation receives the same protection as a newly
+// constructed or deserialized secret. Deriving Clone copies the Vec directly
+// and bypasses new().
+impl Clone for SecretBytes {
+    fn clone(&self) -> Self {
+        Self::new(self.0.clone())
+    }
+}
 
 // Manual impl (not derived) so deserialization routes through `new()`: a
 // secret received over IPC gets the same memlock treatment as one built
@@ -82,6 +91,45 @@ impl std::fmt::Debug for SecretBytes {
     }
 }
 
+/// The fixed-size KDE wallet salt carried by authorized callers.
+///
+/// The wrapper makes the 56-byte wire invariant part of deserialization, so a
+/// malformed or mixed-version client is rejected before daemon dispatch. Its
+/// debug representation never includes salt bytes.
+#[derive(Clone, Serialize)]
+#[serde(transparent)]
+pub struct WalletSalt(SecretBytes);
+
+impl WalletSalt {
+    /// Construct a wallet salt only when it has KDE's exact wire length.
+    pub fn new(bytes: Vec<u8>) -> Option<Self> {
+        (bytes.len() == kwallet_wire::SALT_LEN).then(|| Self(SecretBytes::new(bytes)))
+    }
+
+    pub fn expose(&self) -> &[u8] {
+        self.0.expose()
+    }
+}
+
+impl<'de> Deserialize<'de> for WalletSalt {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> std::result::Result<Self, D::Error> {
+        let bytes = SecretBytes::deserialize(d)?;
+        if bytes.len() != kwallet_wire::SALT_LEN {
+            return Err(serde::de::Error::invalid_length(
+                bytes.len(),
+                &"exactly 56 wallet-salt bytes",
+            ));
+        }
+        Ok(Self(bytes))
+    }
+}
+
+impl std::fmt::Debug for WalletSalt {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "WalletSalt([{} bytes redacted])", self.0.len())
+    }
+}
+
 /// Where the irlume packages install onnxruntime: Fedora/Copr first, then the
 /// Debian/Ubuntu universal .deb and PPA layout (packaging/README.md records
 /// both). Their systemd drop-in hands `ORT_DYLIB_PATH` to the DAEMON only, so
@@ -98,6 +146,10 @@ pub const PACKAGED_ORT_PATHS: &[&str] = &[
 
 fn default_true() -> bool {
     true
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 /// Per-user enrolled templates + TPM-sealed release secrets.
@@ -611,6 +663,8 @@ pub enum Request {
     /// Resolve the daemon's active capture schedule from the exact camera pair
     /// it owns, including process-local safety degradation. CAMERA-CLASS.
     CaptureModeStatus,
+    /// Camera-free sensor policy; a user explicitly requests enrollment preflight.
+    FaceSensorStatus { user: Option<String> },
     /// Liveness/alignment self-test (no auth side effects). See PAD self-testing.
     SelfTest { kind: SelfTestKind },
     /// Enumerate the Hello camera pairs for the picker. CAMERA-CLASS: it
@@ -665,6 +719,16 @@ pub enum Request {
         /// wallet key without the client having to know to ask.
         #[serde(default)]
         kind: Option<KeyringSecretKind>,
+        /// Account-scoped KDE wallet salt read by the authorized caller. The
+        /// daemon never opens the user's wallet path. Absent for non-KDE
+        /// operations and older clients; redacted by the [`WalletSalt`] debug implementation.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        wallet_salt: Option<WalletSalt>,
+        /// True only when this caller ran the account-scoped helper. This
+        /// distinguishes a proven-absent salt from an older client that omitted
+        /// the field; the daemon fails the latter closed.
+        #[serde(default, skip_serializing_if = "is_false")]
+        wallet_salt_checked: bool,
     },
     /// Face-verify `user` and, on a live match, release the TPM-sealed password
     /// so the caller can set it as `PAM_AUTHTOK` (login keyring unlock).
@@ -731,7 +795,15 @@ pub enum Request {
     /// **session** phase, which runs only after authentication SUCCEEDED, so
     /// `password` is always one `pam_unix` accepted (never a typo). PRIVILEGED:
     /// root or `user`.
-    ResealPassword { user: String, password: SecretBytes },
+    ResealPassword {
+        user: String,
+        password: SecretBytes,
+        /// Account-scoped KDE wallet salt, when resealing a KDE envelope.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        wallet_salt: Option<WalletSalt>,
+        #[serde(default, skip_serializing_if = "is_false")]
+        wallet_salt_checked: bool,
+    },
 
     // --- template-key recovery passphrase -----------------------------------
     /// Wrap `user`'s template key under a recovery `passphrase` (the manual
@@ -754,6 +826,11 @@ pub enum Request {
     /// Erase `user`'s recovery envelope (keeps the template key). PRIVILEGED:
     /// root or `user`.
     RecoveryForget { user: String },
+    /// Inspect this account's face and password-reset retry state; root or self.
+    RetryStatus { user: String },
+    /// Reset retry state after independent password verification. Root is an
+    /// explicit administrator override and may supply an empty password.
+    RetryReset { user: String, password: SecretBytes },
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -871,6 +948,23 @@ pub struct PositionReport {
     pub guidance: String,
 }
 
+/// Camera-free prerequisites; never qualification or login permission.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IrOnlyReadiness {
+    /// The daemon cannot establish the prerequisites for an experimental attempt.
+    Unavailable,
+    ReadyForExperimentalAttempt,
+    InvalidPolicy,
+    TargetUnavailable,
+    BindingUnavailable,
+    BindingMismatch,
+    ModelsUnavailable,
+    PadUnavailable,
+    EnrollmentUnavailable,
+    IncompatibleEnrollment,
+}
+
 /// Runtime state of one shipped presentation-attack-detection model.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -881,9 +975,104 @@ pub enum PadModelStatus {
     LoadFailed,
 }
 
+/// Prospective cumulative face-request budget, independent of password recovery.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FaceRetryBudget {
+    /// Absent until the first reservation or verified reset creates an epoch.
+    pub unsuccessful_requests: Option<u32>,
+    pub limit: u32,
+    pub reset_required: bool,
+}
+
+#[cfg(test)]
+mod retry_status_wire_tests {
+    use super::*;
+
+    #[derive(Deserialize)]
+    enum LegacyResponse {
+        RetryStatus {
+            failures: u32,
+            cooldown_seconds: u64,
+            recovery_failures: u32,
+            recovery_cooldown_seconds: u64,
+            recovery_required: bool,
+            password_reset_available: bool,
+        },
+    }
+
+    #[test]
+    fn retry_status_old_and_new_clients_keep_distinct_budget_meanings() {
+        let old = serde_json::json!({"RetryStatus": {
+            "failures": 2, "cooldown_seconds": 0, "recovery_failures": 3,
+            "recovery_cooldown_seconds": 0, "recovery_required": false,
+            "password_reset_available": true
+        }});
+        let decoded: Response = serde_json::from_value(old.clone()).unwrap();
+        assert!(matches!(
+            decoded,
+            Response::RetryStatus {
+                face_budget: None,
+                ..
+            }
+        ));
+        let mut new = old;
+        new["RetryStatus"]["face_budget"] =
+            serde_json::json!({"unsuccessful_requests": 50, "limit": 50, "reset_required": true});
+        let LegacyResponse::RetryStatus {
+            failures,
+            cooldown_seconds,
+            recovery_failures,
+            recovery_cooldown_seconds,
+            recovery_required,
+            password_reset_available,
+        } = serde_json::from_value(new.clone()).unwrap();
+        assert_eq!(
+            (
+                failures,
+                cooldown_seconds,
+                recovery_failures,
+                recovery_cooldown_seconds,
+                recovery_required,
+                password_reset_available
+            ),
+            (2, 0, 3, 0, false, true)
+        );
+        let decoded: Response = serde_json::from_value(new).unwrap();
+        assert!(matches!(
+            decoded,
+            Response::RetryStatus {
+                recovery_required: false,
+                face_budget: Some(FaceRetryBudget {
+                    unsuccessful_requests: Some(50),
+                    reset_required: true,
+                    ..
+                }),
+                ..
+            }
+        ));
+    }
+}
+
 /// Daemon response.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Response {
+    /// Camera-free policy observation. Readiness is absent for ordinary status.
+    FaceSensorStatus {
+        policy: config::FaceSensorPolicyObservation,
+        ir_readiness: Option<IrOnlyReadiness>,
+    },
+    /// Retry recovery capability and current per-account state.
+    RetryStatus {
+        failures: u32,
+        cooldown_seconds: u64,
+        recovery_failures: u32,
+        recovery_cooldown_seconds: u64,
+        recovery_required: bool,
+        password_reset_available: bool,
+        /// Older daemons omit this field; absence never means a zero count.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        face_budget: Option<FaceRetryBudget>,
+    },
     /// Progress for an explicitly requested guided enrollment operation.
     EnrollmentSession(EnrollmentEvent),
     /// Authentication decision plus the evidence behind it.
@@ -1312,6 +1501,10 @@ pub enum Error {
     /// written, so the caller should say "retry", not "it broke".
     #[error("preempted: {0}")]
     Preempted(String),
+    /// The authentication budget ended; this is neither biometric evidence nor
+    /// a camera fault. Callers must fall back without retrying or recording a match.
+    #[error("authentication window expired; use your password")]
+    DeadlineExpired,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -1335,6 +1528,51 @@ pub(crate) mod testenv {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn wallet_salt_wire_is_optional_fixed_length_and_redacted() {
+        use super::{kwallet_wire::SALT_LEN, Request, WalletSalt};
+
+        let legacy = serde_json::json!({"SealPassword": {
+            "user": "alice", "password": [1, 2, 3], "kind": null
+        }});
+        let decoded: Request = serde_json::from_value(legacy.clone()).unwrap();
+        assert!(matches!(
+            decoded,
+            Request::SealPassword {
+                wallet_salt: None,
+                wallet_salt_checked: false,
+                ..
+            }
+        ));
+        assert_eq!(serde_json::to_value(&decoded).unwrap(), legacy);
+
+        let salt = WalletSalt::new(vec![0x5a; SALT_LEN]).unwrap();
+        assert_eq!(format!("{salt:?}"), "WalletSalt([56 bytes redacted])");
+        let request = Request::SealPassword {
+            user: "alice".into(),
+            password: super::SecretBytes::new(vec![1, 2, 3]),
+            kind: Some(super::KeyringSecretKind::KdeWalletKey),
+            wallet_salt: Some(salt),
+            wallet_salt_checked: true,
+        };
+        let encoded = serde_json::to_value(&request).unwrap();
+        assert_eq!(
+            encoded["SealPassword"]["wallet_salt"]
+                .as_array()
+                .unwrap()
+                .len(),
+            SALT_LEN
+        );
+        assert!(serde_json::from_value::<Request>(encoded).is_ok());
+
+        for len in [SALT_LEN - 1, SALT_LEN + 1] {
+            let malformed = serde_json::json!({"ResealPassword": {
+                "user": "alice", "password": [1], "wallet_salt": vec![0; len]
+            }});
+            assert!(serde_json::from_value::<Request>(malformed).is_err());
+        }
+    }
+
     #[test]
     fn auth_structured_errors_preserves_legacy_wire_and_unknown_codes() {
         use super::{OperationErrorCode, Request, Response};
@@ -1946,6 +2184,49 @@ mod tests {
         None
     }
 
+    #[repr(C)]
+    struct CapabilityHeader {
+        version: u32,
+        pid: i32,
+    }
+
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    struct CapabilityData {
+        effective: u32,
+        permitted: u32,
+        inheritable: u32,
+    }
+
+    fn drop_and_verify_ipc_lock_capability() {
+        const LINUX_CAPABILITY_VERSION_3: u32 = 0x2008_0522;
+        const CAP_IPC_LOCK_BIT: u32 = 1 << 14;
+        let mut header = CapabilityHeader {
+            version: LINUX_CAPABILITY_VERSION_3,
+            pid: 0,
+        };
+        let mut data = [CapabilityData {
+            effective: 0,
+            permitted: 0,
+            inheritable: 0,
+        }; 2];
+        // SAFETY: header/data use Linux's v3 capability ABI and point to
+        // initialized writable storage for the calling process (pid 0).
+        let rc = unsafe { libc::syscall(libc::SYS_capget, &mut header, data.as_mut_ptr()) };
+        assert_eq!(rc, 0, "capget failed: {}", std::io::Error::last_os_error());
+        data[0].effective &= !CAP_IPC_LOCK_BIT;
+        data[0].permitted &= !CAP_IPC_LOCK_BIT;
+        data[0].inheritable &= !CAP_IPC_LOCK_BIT;
+        // SAFETY: the same valid v3 buffers now request only removal of one
+        // capability from this process; dropping one's own capability is allowed.
+        let rc = unsafe { libc::syscall(libc::SYS_capset, &header, data.as_ptr()) };
+        assert_eq!(rc, 0, "capset failed: {}", std::io::Error::last_os_error());
+        // SAFETY: refresh the initialized data through the same v3 ABI.
+        let rc = unsafe { libc::syscall(libc::SYS_capget, &mut header, data.as_mut_ptr()) };
+        assert_eq!(rc, 0, "capget failed: {}", std::io::Error::last_os_error());
+        assert_eq!(data[0].effective & CAP_IPC_LOCK_BIT, 0);
+    }
+
     // Regression: e8e59c2. SecretBytes derived Deserialize, constructing the
     // inner Vec directly and skipping new()'s mlock: a secret received over
     // IPC was swappable/dumpable. Deserialization must route through new(),
@@ -1984,6 +2265,112 @@ mod tests {
             locked > 0,
             "a deserialized SecretBytes must be memlocked like a new()-built one"
         );
+    }
+
+    // Regression: deriving Clone copied the inner Vec directly, bypassing
+    // SecretBytes::new() and leaving the copied plaintext swappable/dumpable.
+    #[test]
+    fn cloned_secret_bytes_are_memlocked_like_new() {
+        if let Ok(case) = std::env::var("IRLUME_TEST_SECRET_CLONE_MEMLOCK") {
+            drop_and_verify_ipc_lock_capability();
+            let (limit, source_must_lock, clone_must_lock) = match case.as_str() {
+                "zero" => (0, false, false),
+                "constrained" => (384 * 1024, true, false),
+                "adequate" => (2 * 1024 * 1024, true, true),
+                other => panic!("unknown clone memlock test case: {other}"),
+            };
+            let rlimit = libc::rlimit {
+                rlim_cur: limit,
+                rlim_max: limit,
+            };
+            // SAFETY: `rlimit` is fully initialized and this fresh child only
+            // lowers its own RLIMIT_MEMLOCK before allocating either secret.
+            assert_eq!(unsafe { libc::setrlimit(libc::RLIMIT_MEMLOCK, &rlimit) }, 0);
+
+            // Large, distinct allocations make page ownership and aggregate
+            // accounting unambiguous at the three selected limits.
+            if case == "adequate" {
+                let first = SecretBytes::new(vec![0x61; 256 * 1024]);
+                let second = SecretBytes::new(vec![0x62; 256 * 1024]);
+                let first_locked =
+                    locked_kb_of(first.expose().as_ptr() as usize + 128 * 1024).unwrap_or(0) > 0;
+                let second_locked =
+                    locked_kb_of(second.expose().as_ptr() as usize + 128 * 1024).unwrap_or(0) > 0;
+                if !first_locked || !second_locked {
+                    eprintln!("unsupported: two live adequate-budget controls did not lock");
+                    println!("clone-memlock-case-{case}-unsupported");
+                    return;
+                }
+                drop((first, second));
+            }
+            let source = SecretBytes::new(vec![0x31; 256 * 1024]);
+            let clone = source.clone();
+            assert_eq!(clone.expose(), source.expose());
+            assert_ne!(clone.expose().as_ptr(), source.expose().as_ptr());
+            let source_locked =
+                locked_kb_of(source.expose().as_ptr() as usize + 128 * 1024).unwrap_or(0) > 0;
+            let clone_locked =
+                locked_kb_of(clone.expose().as_ptr() as usize + 128 * 1024).unwrap_or(0) > 0;
+            if case == "zero" && (source_locked || clone_locked) {
+                eprintln!("unsupported: zero-budget locks appear effective after capability drop");
+                println!("clone-memlock-case-{case}-unsupported");
+                return;
+            }
+            if case == "constrained" && !source_locked {
+                eprintln!("unsupported: constrained-budget source control did not lock");
+                println!("clone-memlock-case-{case}-unsupported");
+                return;
+            }
+            assert_eq!(source_locked, source_must_lock, "case {case}: source");
+            assert_eq!(clone_locked, clone_must_lock, "case {case}: clone");
+            println!("clone-memlock-case-{case}-passed");
+            return;
+        }
+
+        let mut inherited = libc::rlimit {
+            rlim_cur: 0,
+            rlim_max: 0,
+        };
+        // SAFETY: `inherited` is initialized storage for getrlimit's output.
+        let rc = unsafe { libc::getrlimit(libc::RLIMIT_MEMLOCK, &mut inherited) };
+        assert_eq!(rc, 0);
+        if inherited.rlim_max < 2 * 1024 * 1024 {
+            eprintln!(
+                "skipping clone memlock cases: inherited hard limit {} cannot establish the \
+                 required 2 MiB adequate-budget control",
+                inherited.rlim_max
+            );
+            return;
+        }
+
+        let exe = std::env::current_exe().unwrap();
+        for case in ["zero", "constrained", "adequate"] {
+            let out = std::process::Command::new(&exe)
+                .args([
+                    "tests::cloned_secret_bytes_are_memlocked_like_new",
+                    "--exact",
+                    "--nocapture",
+                    "--test-threads=1",
+                ])
+                .env("IRLUME_TEST_SECRET_CLONE_MEMLOCK", case)
+                .output()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "clone memlock case {case} failed; stdout: {}; stderr: {}",
+                String::from_utf8_lossy(&out.stdout),
+                String::from_utf8_lossy(&out.stderr)
+            );
+            assert!(
+                [
+                    format!("clone-memlock-case-{case}-passed"),
+                    format!("clone-memlock-case-{case}-unsupported"),
+                ]
+                .iter()
+                .any(|marker| String::from_utf8_lossy(&out.stdout).contains(marker)),
+                "clone memlock case {case} did not run"
+            );
+        }
     }
 
     #[test]
@@ -2275,6 +2662,10 @@ pub mod kwallet_wire {
 
     /// PBKDF2 iteration count. `KWALLET_PAM_ITERATIONS`.
     pub const ITERATIONS: u32 = 50_000;
+
+    /// Helper exit status meaning the salt path is absent. Every other
+    /// nonzero status is a read or policy failure.
+    pub const SALT_ABSENT_EXIT: i32 = 3;
 
     /// Basename of the handoff socket inside `XDG_RUNTIME_DIR`.
     ///

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -665,6 +665,8 @@ pub enum Request {
     CaptureModeStatus,
     /// Camera-free sensor policy; a user explicitly requests enrollment preflight.
     FaceSensorStatus { user: Option<String> },
+    /// Camera-free, non-secret machine preferences as observed by the daemon.
+    PreferencesStatus,
     /// Liveness/alignment self-test (no auth side effects). See PAD self-testing.
     SelfTest { kind: SelfTestKind },
     /// Enumerate the Hello camera pairs for the picker. CAMERA-CLASS: it
@@ -1053,9 +1055,36 @@ mod retry_status_wire_tests {
     }
 }
 
+/// Non-secret preference observations, including daemon environment overrides.
+/// These describe policy, not hardware readiness or a successful authentication.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PreferencesState {
+    pub face_sensor_policy: config::FaceSensorPolicyObservation,
+    pub privileged_face_consent: Option<bool>,
+    pub enforce_biopolicy: Option<bool>,
+    pub consent_overridden: bool,
+    pub biopolicy_overridden: bool,
+}
+
+impl PreferencesState {
+    /// Observe preferences in this process's configuration and environment.
+    #[must_use]
+    pub fn observe() -> Self {
+        Self {
+            face_sensor_policy: config::observe_face_sensor_policy(),
+            privileged_face_consent: config::privileged_face_consent_visible(),
+            enforce_biopolicy: config::enforce_biopolicy_visible(),
+            consent_overridden: std::env::var_os("IRLUME_PRIVILEGED_FACE_CONSENT").is_some(),
+            biopolicy_overridden: std::env::var_os("IRLUME_ENFORCE_BIOPOLICY").is_some(),
+        }
+    }
+}
+
 /// Daemon response.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Response {
+    /// Reply only to the explicit preferences request; older clients are unchanged.
+    PreferencesStatus(PreferencesState),
     /// Camera-free policy observation. Readiness is absent for ordinary status.
     FaceSensorStatus {
         policy: config::FaceSensorPolicyObservation,

--- a/crates/irlume-common/src/memlock.rs
+++ b/crates/irlume-common/src/memlock.rs
@@ -8,6 +8,13 @@
 //!
 //! Best-effort: `RLIMIT_MEMLOCK` may reject the lock for unprivileged callers,
 //! in which case we warn and carry on (auth must still work).
+//!
+//! There is deliberately no matching slice-level `munlock`: ordinary `Vec`
+//! allocations can share allocator pages with other live secrets, while the
+//! kernel locks and unlocks whole pages. Unlocking when one slice is dropped
+//! could therefore make a neighbouring live secret swappable. The process
+//! releases the locks when its mappings exit; each owner still zeroizes its
+//! own bytes on drop.
 
 /// Lock the pages backing `buf` against swap and core dumps. Idempotent-ish;
 /// safe to call on any slice. No-op for empty input.

--- a/crates/irlume-common/src/platform.rs
+++ b/crates/irlume-common/src/platform.rs
@@ -5,6 +5,77 @@
 //! the distro-family detection that the fingerprint (and, later, login) wiring
 //! needs to pick the right mechanism (authselect vs pam-auth-update vs direct).
 
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+/// System tools invoked from code that can run with elevated privilege.
+///
+/// Resolution deliberately ignores `PATH`: PAM and CLI apply/reconcile callers
+/// may be uid 0 while retaining an invoking process's environment. The fixed
+/// prefixes are an administrator-owned trust boundary, not inode attestation;
+/// symlinks remain valid for usr-merge and Nix system profiles.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SystemCommand {
+    Loginctl,
+    GnomeShell,
+    Semodule,
+    Systemctl,
+    Restorecon,
+}
+
+impl SystemCommand {
+    const ALL: [Self; 5] = [
+        Self::Loginctl,
+        Self::GnomeShell,
+        Self::Semodule,
+        Self::Systemctl,
+        Self::Restorecon,
+    ];
+
+    const fn basename(self) -> &'static str {
+        match self {
+            Self::Loginctl => "loginctl",
+            Self::GnomeShell => "gnome-shell",
+            Self::Semodule => "semodule",
+            Self::Systemctl => "systemctl",
+            Self::Restorecon => "restorecon",
+        }
+    }
+
+    /// Locate this tool under a fixed system prefix, never through `PATH`.
+    #[must_use]
+    pub fn path(self) -> Option<PathBuf> {
+        self.path_in(Path::new("/"))
+    }
+
+    fn path_in(self, root: &Path) -> Option<PathBuf> {
+        system_command_path_in(root, self.basename())
+    }
+}
+
+fn system_command_path_in(root: &Path, basename: &str) -> Option<PathBuf> {
+    if !SystemCommand::ALL
+        .iter()
+        .any(|command| command.basename() == basename)
+    {
+        return None;
+    }
+    const PREFIXES: [&str; 7] = [
+        "usr/bin",
+        "usr/sbin",
+        "bin",
+        "sbin",
+        "usr/local/bin",
+        "usr/local/sbin",
+        "run/current-system/sw/bin",
+    ];
+    PREFIXES.iter().find_map(|prefix| {
+        let path = root.join(prefix).join(basename);
+        let metadata = std::fs::metadata(&path).ok()?;
+        (metadata.is_file() && metadata.permissions().mode() & 0o111 != 0).then_some(path)
+    })
+}
+
 /// Distro family, for choosing the PAM-wiring mechanism.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DistroFamily {
@@ -112,7 +183,7 @@ pub fn user_has_live_session(user: &str) -> bool {
 /// session right now? `None` if `loginctl` is missing/unparsable (→ caller falls
 /// back to the runtime-dir heuristic).
 fn active_graphical_session(user: &str) -> Option<bool> {
-    let out = std::process::Command::new("loginctl")
+    let out = std::process::Command::new(SystemCommand::Loginctl.path()?)
         .args(["list-sessions", "--no-legend"])
         .output()
         .ok()?;
@@ -138,7 +209,10 @@ fn active_graphical_session(user: &str) -> Option<bool> {
 /// `Class=user`. A logout closes the user session (gone or `closing`), so only a
 /// live lock screen leaves an active/online user-class session.
 fn session_is_active_user(session: &str) -> bool {
-    let Ok(out) = std::process::Command::new("loginctl")
+    let Some(loginctl) = SystemCommand::Loginctl.path() else {
+        return false;
+    };
+    let Ok(out) = std::process::Command::new(loginctl)
         .args(["show-session", session, "-p", "Class", "-p", "State"])
         .output()
     else {
@@ -349,5 +423,58 @@ mod tests {
         // `loginctl show-session` on a bogus id prints nothing usable; the
         // parser must fail closed (false), never treat it as active.
         assert!(!session_is_active_user("irlume-test-no-such-session"));
+    }
+
+    #[test]
+    fn system_commands_resolve_only_from_fixed_executable_locations() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root =
+            std::env::temp_dir().join(format!("irlume-system-command-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        for command in SystemCommand::ALL {
+            let path = root.join("usr/bin").join(command.basename());
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(&path, b"fixture").unwrap();
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+            assert_eq!(command.path_in(&root), Some(path));
+        }
+
+        // A PATH-shaped writable directory is deliberately outside the fixed
+        // roots. Its executable must never participate in resolution.
+        let foreign = root.join("tmp/user-bin/loginctl");
+        std::fs::create_dir_all(foreign.parent().unwrap()).unwrap();
+        std::fs::write(&foreign, b"foreign").unwrap();
+        std::fs::set_permissions(&foreign, std::fs::Permissions::from_mode(0o777)).unwrap();
+        assert_ne!(SystemCommand::Loginctl.path_in(&root), Some(foreign));
+
+        for malformed in ["../loginctl", "/tmp/loginctl", "loginctl/other", ""] {
+            assert_eq!(system_command_path_in(&root, malformed), None);
+        }
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn system_command_skips_non_executable_and_supports_nix_profile_symlinks() {
+        use std::os::unix::fs::{symlink, PermissionsExt};
+
+        let root =
+            std::env::temp_dir().join(format!("irlume-system-command-nix-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let non_executable = root.join("usr/bin/systemctl");
+        std::fs::create_dir_all(non_executable.parent().unwrap()).unwrap();
+        std::fs::write(&non_executable, b"fixture").unwrap();
+        std::fs::set_permissions(&non_executable, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let store = root.join("nix/store/test-systemd/bin/systemctl");
+        std::fs::create_dir_all(store.parent().unwrap()).unwrap();
+        std::fs::write(&store, b"fixture").unwrap();
+        std::fs::set_permissions(&store, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let profile = root.join("run/current-system/sw/bin/systemctl");
+        std::fs::create_dir_all(profile.parent().unwrap()).unwrap();
+        symlink(&store, &profile).unwrap();
+
+        assert_eq!(SystemCommand::Systemctl.path_in(&root), Some(profile));
+        let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/crates/irlume-core/examples/derive_wallet_key.rs
+++ b/crates/irlume-core/examples/derive_wallet_key.rs
@@ -1,24 +1,35 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright the irlume contributors.
 
-//! Print the KDE wallet key irlume would derive for a home directory.
+//! Print the KDE wallet key irlume would derive for an account.
 //!
 //! Exists so the handoff can be exercised end to end against a real `ksecretd`
 //! using the SAME derivation the daemon seals, rather than a reimplementation
 //! in the test that could agree with itself while both are wrong.
 //!
-//!   derive_wallet_key <home> <password>   # raw key bytes on stdout
+//!   derive_wallet_key <user> <password>   # raw key bytes on stdout
 
 fn main() {
     let mut a = std::env::args().skip(1);
-    let (home, pw) = match (a.next(), a.next()) {
-        (Some(h), Some(p)) => (h, p),
+    let (user, pw) = match (a.next(), a.next()) {
+        (Some(user), Some(p)) => (user, p),
         _ => {
-            eprintln!("usage: derive_wallet_key <home> <password>");
+            eprintln!("usage: derive_wallet_key <user> <password>");
             std::process::exit(2);
         }
     };
-    match irlume_core::kwallet::derive_for_home(pw.as_bytes(), std::path::Path::new(&home)) {
+    let salt = match irlume_common::client::read_wallet_salt(&user) {
+        Ok(Some(salt)) => salt,
+        Ok(None) => {
+            eprintln!("derive: account has no KDE wallet salt");
+            std::process::exit(3);
+        }
+        Err(e) => {
+            eprintln!("derive: {e}");
+            std::process::exit(1);
+        }
+    };
+    match irlume_core::kwallet::derive_key(pw.as_bytes(), salt.expose()) {
         Ok(k) => {
             use std::io::Write;
             std::io::stdout().write_all(&k).expect("write key");

--- a/crates/irlume-core/src/biopolicy.rs
+++ b/crates/irlume-core/src/biopolicy.rs
@@ -129,6 +129,26 @@ pub fn decide(class: OperationClass, tier: Tier) -> Action {
 mod tests {
     use super::*;
 
+    /// The retired experimental desktop service and its lookalikes have no
+    /// supported policy. Existing on-demand `kde` remains a screen unlock.
+    #[test]
+    fn retired_experimental_face_service_is_unknown() {
+        for service in [
+            "kde-face",
+            "kde-face-other",
+            "kde-face-login",
+            "kde-face/other",
+        ] {
+            for session in [SessionState::Warm, SessionState::Cold] {
+                assert_eq!(classify(service, session), OperationClass::Unknown);
+                for tier in [Tier::Secure, Tier::Convenience] {
+                    assert_eq!(decide(classify(service, session), tier), Action::Deny);
+                    assert_eq!(decide(classify("kde", session), tier), Action::Verify);
+                }
+            }
+        }
+    }
+
     #[test]
     fn screen_unlock_never_unseals() {
         assert_eq!(

--- a/crates/irlume-core/src/envelope.rs
+++ b/crates/irlume-core/src/envelope.rs
@@ -156,10 +156,23 @@ pub struct SealedEnvelope {
 }
 
 impl SealedEnvelope {
+    pub(crate) fn validate_version(&self) -> Result<()> {
+        if self.version != CURRENT_VERSION {
+            return Err(Error::Protocol(format!(
+                "unsupported TPM envelope version: {}",
+                self.version
+            )));
+        }
+        Ok(())
+    }
+
     #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
     pub fn load(path: &Path) -> Result<Self> {
         let s = fs::read_to_string(path).map_err(|e| Error::Io(e.to_string()))?;
-        serde_json::from_str(&s).map_err(|e| Error::Protocol(e.to_string()))
+        let envelope: Self =
+            serde_json::from_str(&s).map_err(|e| Error::Protocol(e.to_string()))?;
+        envelope.validate_version()?;
+        Ok(envelope)
     }
 
     /// Write the envelope as a root-only (0600) file: it contains the wrapped
@@ -379,6 +392,28 @@ mod tests {
             SealedEnvelope::load(&bad),
             Err(Error::Protocol(_))
         ));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn load_rejects_unknown_versions() {
+        let dir = std::env::temp_dir().join(format!("irlume-env-version-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("sealed.json");
+
+        for version in [0, CURRENT_VERSION + 1] {
+            std::fs::write(
+                &path,
+                format!(r#"{{"version":{version},"pcrs":[7],"public":"AQID","private":"BAUG"}}"#),
+            )
+            .unwrap();
+            assert!(matches!(
+                SealedEnvelope::load(&path),
+                Err(Error::Protocol(message)) if message.contains("unsupported TPM envelope version")
+            ));
+        }
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/irlume-core/src/fusion.rs
+++ b/crates/irlume-core/src/fusion.rs
@@ -1,50 +1,40 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright the irlume contributors.
 
-//! Stage-2 lighting-adaptive RGB+IR score fusion.
+//! Stage-2 brightness-weighted RGB+IR score fusion.
 //!
-//! Each modality's cosine is mapped to a *calibrated* genuine-probability (Platt
-//! scaling), weighted by capture quality, then fused. This lets a marginal-RGB +
-//! marginal-IR capture JOINTLY grant in mixed light, while keeping the false-match
-//! rate bounded, because an impostor must fool BOTH modalities at once (the two
-//! score distributions are near-independent). Fusion only ADDS dim-light rescues on
-//! top of the existing single-modality thresholds; it never relaxes them.
+//! Fixed sigmoid mappings turn each modality's cosine into a score in `[0, 1]`.
+//! The caller weights these scores by capture brightness and takes an arithmetic
+//! mean. The legacy `prob` names do not establish calibrated genuine probabilities
+//! for the current pipeline, a joint posterior, or a false-match-rate bound.
 //!
-//! Constants fit offline, NOT by a script in this repo: `scripts/calibrate.py`
-//! was never committed, so do not go looking for it. RGB Platt on LFW
-//! genuine/impostor cosines; IR Platt on CBSR+Oulu NIR. Refitting means
-//! reproducing that offline fit; the caveat below says when that is needed.
+//! Historical comments attribute the RGB coefficients to LFW and the IR
+//! coefficients to CBSR+Oulu in the former v3 IR-adapter space. The fitting script
+//! and a reproducible fit report are not present in this repository. ADR-0004
+//! retired that shipped adapter; current raw/per-enrollment-calibrated IR scores
+//! have a different provenance. Retaining these constants does not validate them
+//! for that path or for a user-supplied adapter.
 //!
-//! CALIBRATION CAVEAT (ADR-0004): the IR Platt (`IR_PLATT_A/B`) was fit on IR
-//! cosines produced by the former v3 IR adapter, which no longer ships. The
-//! default IR path now scores raw-AuraFace (per-enrollment-calibrated) cosines,
-//! a different distribution, so these constants are retained as a CONSERVATIVE
-//! PRIOR pending a raw-space re-fit, not a validated fit. This is bounded, not
-//! dangerous: fusion only ADDS dim-light rescues on top of the single-modality
-//! thresholds (never relaxes them), the sigmoid midpoint (cos ≈ 0.405) still
-//! sits between raw genuine and impostor IR cosines, and a grant additionally
-//! requires the RGB side plus the conservative 0.50 fused bar. TODO: re-fit
-//! `IR_PLATT_A/B` against raw/calibrated-space IR captures and re-validate the
-//! dim-light rescue operating point.
+//! Fusion can accept scores below the standalone identity thresholds. It expands
+//! the acceptance rule even though those thresholds are unchanged. Assessing its
+//! false-match rate requires evaluating the full rule, including template/profile
+//! selection and other acceptance arms; neither modality independence nor an
+//! overall error bound follows from this arithmetic. The caller separately
+//! enforces liveness/PAD and disallows fusion grants for sequential pairs.
 
-/// RGB Platt: `p = sigmoid(a*cos + b)`. Fit on LFW (genuine cos μ0.565 / impostor μ0.062).
+/// Legacy RGB sigmoid coefficient, historically attributed to an offline LFW fit.
 pub const RGB_PLATT_A: f32 = 24.4708;
 pub const RGB_PLATT_B: f32 = -8.1873;
-/// IR Platt. Fit on CBSR+Oulu (former adapter space, genuine μ0.783 / impostor
-/// μ0.033); a conservative prior for the current raw path pending re-fit (see
-/// the module-level CALIBRATION CAVEAT).
+/// Legacy IR sigmoid coefficient from the retired adapter space.
+/// Its calibration for the current raw/per-enrollment path is unverified.
 pub const IR_PLATT_A: f32 = 40.0120;
 pub const IR_PLATT_B: f32 = -16.2221;
 
-/// Fused genuine-probability required to grant via fusion. CONSERVATIVE: the
-/// equal-weight independence model puts fused FAR≤1e-4 at ~0.31; 0.50 adds margin
-/// and is trivially cleared by a true user (deployment fused-prob ≈1.0). Raising
-/// this only tightens security.
+/// Minimum weighted score for the fusion arm, not a measured false-match bound.
 pub const FUSION_PROB_THRESHOLD: f32 = 0.50;
 
-/// Each modality must independently clear this genuine-probability for fusion to
-/// fire; blocks "one strong modality + pure noise" from granting (anti
-/// single-modality-spoof). Set just above chance.
+/// Per-modality sigmoid-score floor. This is not a standalone identity threshold
+/// or proof that both modalities independently verified the claimed identity.
 pub const FUSION_MIN_PER_MODALITY_PROB: f32 = 0.10;
 
 #[inline]
@@ -52,12 +42,11 @@ pub fn sigmoid(x: f32) -> f32 {
     1.0 / (1.0 + (-x).exp())
 }
 
-/// Calibrated genuine-probability for an RGB cosine.
+/// Legacy sigmoid score for an RGB cosine; current probability calibration is unverified.
 pub fn rgb_genuine_prob(cos: f32) -> f32 {
     sigmoid(RGB_PLATT_A * cos + RGB_PLATT_B)
 }
-/// Calibrated genuine-probability for an IR cosine (conservative prior; see the
-/// module-level CALIBRATION CAVEAT).
+/// Legacy sigmoid score for an IR cosine; see the module-level calibration limits.
 pub fn ir_genuine_prob(cos: f32) -> f32 {
     sigmoid(IR_PLATT_A * cos + IR_PLATT_B)
 }
@@ -98,17 +87,18 @@ pub fn ir_quality_weight(ir_present: bool, ir_brightness: f32) -> f32 {
 /// Outcome of a fusion attempt.
 #[derive(Debug, Clone, Copy)]
 pub struct Fusion {
-    /// Quality-weighted fused genuine-probability.
+    /// Brightness-weighted score; the legacy field name does not imply calibration.
     pub prob: f32,
     pub p_rgb: f32,
     pub p_ir: f32,
-    /// True iff the fused probability clears the bar AND each modality shows floor evidence.
+    /// True iff the weighted score and both floors pass with positive IR weight.
     pub grant: bool,
 }
 
-/// Quality-weighted fusion of the two calibrated genuine-probabilities. Grants only
-/// if the fused probability clears [`FUSION_PROB_THRESHOLD`], each modality clears
-/// [`FUSION_MIN_PER_MODALITY_PROB`], and a real IR capture was present (`w_ir > 0`).
+/// Brightness-weighted arithmetic mean of the supplied sigmoid scores. Grants only
+/// if the score clears [`FUSION_PROB_THRESHOLD`], each modality clears
+/// [`FUSION_MIN_PER_MODALITY_PROB`], and `w_ir > 0`. The caller is responsible for
+/// mapping absent IR to zero weight and enforcing capture/liveness policy.
 pub fn fuse(p_rgb: f32, w_rgb: f32, p_ir: f32, w_ir: f32) -> Fusion {
     let wsum = (w_rgb + w_ir).max(1e-6);
     let prob = (w_rgb * p_rgb + w_ir * p_ir) / wsum;
@@ -139,14 +129,14 @@ mod tests {
         ] {
             assert!((0.0..=1.0).contains(&p));
         }
-        // Deployment genuine cosines map to near-certain.
+        // Synthetic high-cosine examples approach the top of the sigmoid.
         assert!(rgb_genuine_prob(0.80) > 0.99);
         assert!(ir_genuine_prob(0.75) > 0.99);
     }
 
     #[test]
     fn genuine_both_modalities_grants() {
-        // True user, good light: both strong.
+        // Synthetic high-score pair with high brightness weights.
         let f = fuse(
             rgb_genuine_prob(0.78),
             rgb_quality_weight(120.0),
@@ -158,7 +148,7 @@ mod tests {
 
     #[test]
     fn genuine_dim_light_ir_rescues() {
-        // Dim RGB (marginal) + good IR -> fusion rescues.
+        // Synthetic low-brightness RGB and high-score IR exercise weighting.
         let f = fuse(
             rgb_genuine_prob(0.42),
             rgb_quality_weight(55.0),
@@ -170,7 +160,7 @@ mod tests {
 
     #[test]
     fn impostor_both_marginal_rejected() {
-        // Impostor near each modality's FAR-1e-3 cosine: must NOT grant.
+        // A synthetic low-score pair must not pass the configured fusion gate.
         let f = fuse(
             rgb_genuine_prob(0.29),
             rgb_quality_weight(120.0),
@@ -182,7 +172,7 @@ mod tests {
 
     #[test]
     fn one_strong_one_noise_rejected() {
-        // Strong RGB but IR is pure noise (cos ~0) -> per-modality floor blocks fusion.
+        // Synthetic high RGB and zero IR cosine: the IR score floor blocks fusion.
         let f = fuse(
             rgb_genuine_prob(0.85),
             rgb_quality_weight(120.0),

--- a/crates/irlume-core/src/keyring.rs
+++ b/crates/irlume-core/src/keyring.rs
@@ -173,8 +173,8 @@ pub fn rearm_gnome_token(user: &str, password: &[u8]) -> Result<Zeroizing<Vec<u8
 /// Derive the secret of `kind` that `user` should have sealed, from their
 /// VERIFIED login password.
 ///
-/// For [`SecretKind::KdeWalletKey`] this is PBKDF2 over the wallet salt in
-/// `home`, matching what `pam_kwallet5` computes. Note what that implies after
+/// For [`SecretKind::KdeWalletKey`] this is PBKDF2 over the caller-supplied
+/// wallet salt, matching what `pam_kwallet5` computes. Note what that implies after
 /// a password change: the wallet is still keyed to the OLD derived key until
 /// the user re-keys it in KWallet, so deriving from the new password yields a
 /// key that does not open it. That is not a regression we introduce; it is
@@ -184,17 +184,16 @@ pub fn rearm_gnome_token(user: &str, password: &[u8]) -> Result<Zeroizing<Vec<u8
 pub fn derive_secret(
     kind: SecretKind,
     password: &[u8],
-    home: Option<&std::path::Path>,
+    wallet_salt: Option<&[u8]>,
 ) -> Result<Zeroizing<Vec<u8>>> {
     match kind {
         // A login password needs no home, and demanding one would strand any
         // account NSS cannot resolve a home directory for.
         SecretKind::LoginPassword => Ok(Zeroizing::new(password.to_vec())),
-        SecretKind::KdeWalletKey => match home {
-            Some(h) => crate::kwallet::derive_for_home(password, h),
+        SecretKind::KdeWalletKey => match wallet_salt {
+            Some(salt) => crate::kwallet::derive_key(password, salt),
             None => Err(Error::Policy(
-                "a KDE wallet key needs the user's home directory, and none could be resolved"
-                    .into(),
+                "a KDE wallet key needs the account-scoped wallet salt".into(),
             )),
         },
         // Random by construction. Every caller that wants "the secret this
@@ -340,11 +339,7 @@ pub enum Reseal {
 /// envelope's PCR7 policy no longer satisfies, so we rebind to today's PCRs
 /// using the password the user just proved (via a successful login) they know.
 #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
-pub fn reseal_password(
-    user: &str,
-    password: &[u8],
-    home: Option<&std::path::Path>,
-) -> Result<Reseal> {
+pub fn reseal_password(user: &str, password: &[u8], wallet_salt: Option<&[u8]>) -> Result<Reseal> {
     if password.is_empty() {
         return Err(Error::Protocol(
             "refusing to reseal an empty password".into(),
@@ -364,7 +359,7 @@ pub fn reseal_password(
     if kind == SecretKind::GnomeKeyringToken {
         return reseal_token(user, password, env);
     }
-    let secret = match derive_secret(kind, password, home) {
+    let secret = match derive_secret(kind, password, wallet_salt) {
         Ok(s) => s,
         // A KDE wallet key cannot be derived without the salt. Leaving the
         // existing envelope alone is the safe outcome: it may still be valid,
@@ -656,18 +651,12 @@ mod tests {
         std::env::set_var("IRLUME_KEYRING_DIR", &dir);
         let _ = std::fs::remove_dir_all(dir);
 
-        // A home with a real salt, so the wallet key can actually be derived.
-        let home = std::path::PathBuf::from(crate::test_tmp_dir("kr-kind-home"));
-        let _ = std::fs::remove_dir_all(&home);
-        std::fs::create_dir_all(crate::kwallet::salt_path(&home).parent().unwrap()).unwrap();
-        std::fs::write(
-            crate::kwallet::salt_path(&home),
-            [0x33u8; crate::kwallet::SALT_LEN],
-        )
-        .unwrap();
+        // A fixed synthetic salt, supplied through the same pure derivation
+        // boundary as the daemon request.
+        let salt = [0x33u8; crate::kwallet::SALT_LEN];
 
         let pw = b"a-login-password";
-        let key = crate::kwallet::derive_for_home(pw, &home).expect("derive");
+        let key = crate::kwallet::derive_key(pw, &salt).expect("derive");
 
         // Seed at the WEAKEST tier on purpose. Sealing normally lands on this
         // machine's best tier, so the reseal returns Unchanged and the tier-climb
@@ -680,7 +669,7 @@ mod tests {
         assert_eq!(sealed_kind("kindtest"), Some(SecretKind::KdeWalletKey));
 
         // Same password, weaker tier on disk -> the tier-climb rewrite.
-        let first = reseal_password("kindtest", pw, Some(&home)).expect("reseal");
+        let first = reseal_password("kindtest", pw, Some(&salt)).expect("reseal");
         assert_eq!(
             first,
             Reseal::Upgraded,
@@ -696,7 +685,7 @@ mod tests {
         // A changed password takes the Resealed path, which rebuilds the
         // envelope from scratch.
         assert_eq!(
-            reseal_password("kindtest", b"a-different-password", Some(&home)).unwrap(),
+            reseal_password("kindtest", b"a-different-password", Some(&salt)).unwrap(),
             Reseal::Resealed
         );
         assert_eq!(
@@ -705,11 +694,10 @@ mod tests {
             "the Resealed path dropped the secret kind"
         );
         // And it holds the key derived from the NEW password, not the password.
-        let expect = crate::kwallet::derive_for_home(b"a-different-password", &home).unwrap();
+        let expect = crate::kwallet::derive_key(b"a-different-password", &salt).unwrap();
         assert_eq!(&*unseal_password("kindtest").unwrap(), &*expect);
 
         forget_password("kindtest").unwrap();
-        let _ = std::fs::remove_dir_all(&home);
         std::env::remove_var("IRLUME_KEYRING_DIR");
     }
 

--- a/crates/irlume-core/src/kwallet.rs
+++ b/crates/irlume-core/src/kwallet.rs
@@ -26,117 +26,13 @@
 //! cites its source.
 
 use irlume_common::{Error, Result};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use zeroize::Zeroizing;
 
 // The wire constants live in irlume-common so the handoff helper can use them
 // without this crate's TPM and inference dependencies, and so both sides of the
 // handoff read one definition.
 pub use irlume_common::kwallet_wire::{ITERATIONS, KEY_LEN, SALT_LEN};
-
-/// Path of the salt `pam_kwallet5` derives against, relative to `$HOME`.
-///
-/// Still `kwalletd` on disk even though the daemon that reads it is now
-/// `ksecretd`; KWallet became a compatibility shim over the Secret Service and
-/// the storage location did not move.
-const SALT_RELPATH: &str = ".local/share/kwalletd/kdewallet.salt";
-
-/// Absolute path of `home`'s wallet salt file.
-pub fn salt_path(home: &Path) -> PathBuf {
-    home.join(SALT_RELPATH)
-}
-
-/// The most this file can be and still be a wallet salt. A real one is
-/// [`SALT_LEN`] bytes; the headroom is for a future format, not for a payload.
-const MAX_SALT_BYTES: u64 = 4096;
-
-/// Read a REGULAR file of at most `max` bytes, without blocking and without
-/// following a symlink at the final component.
-///
-/// This path lives inside the user's own home, so its contents and its type are
-/// theirs to choose, and the daemon reads it as root on the worker thread. A
-/// plain `fs::read` here was a wedge: `mkfifo`ing the salt path blocks in
-/// `open(2)` until a writer appears, which stalls the camera worker forever
-/// while the connection threads keep answering Ping, so the daemon looks
-/// healthy while every capture and mutation is dead. The systemd watchdog then
-/// kills and restarts it, and the file is still a FIFO, so it happens again.
-/// Pointing it at /dev/zero gives unbounded allocation instead.
-///
-/// `O_NONBLOCK` makes opening a FIFO return instead of waiting, `O_NOFOLLOW`
-/// stops a symlink redirecting the final component elsewhere, and the fstat
-/// rejects anything that is not a regular file, which covers FIFOs, devices,
-/// and directories together. The size cap bounds the allocation.
-fn read_regular_file_capped(path: &Path, max: u64) -> std::io::Result<Vec<u8>> {
-    use std::io::Read as _;
-    use std::os::unix::fs::{FileTypeExt as _, OpenOptionsExt as _};
-
-    let file = std::fs::OpenOptions::new()
-        .read(true)
-        .custom_flags(libc::O_NONBLOCK | libc::O_NOFOLLOW)
-        .open(path)?;
-    let meta = file.metadata()?;
-    let ft = meta.file_type();
-    if !ft.is_file() {
-        let what = if ft.is_fifo() {
-            "a FIFO"
-        } else if ft.is_char_device() || ft.is_block_device() {
-            "a device"
-        } else if ft.is_dir() {
-            "a directory"
-        } else if ft.is_socket() {
-            "a socket"
-        } else {
-            "not a regular file"
-        };
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            format!("{} is {what}, not a regular file", path.display()),
-        ));
-    }
-    if meta.len() > max {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            format!(
-                "{} is {} bytes, over the {max}-byte limit",
-                path.display(),
-                meta.len()
-            ),
-        ));
-    }
-    let mut buf = Vec::with_capacity(meta.len() as usize);
-    // Cap the read as well as the stat: the file can grow between the two.
-    file.take(max).read_to_end(&mut buf)?;
-    Ok(buf)
-}
-
-/// Read `home`'s wallet salt.
-///
-/// Deliberately does NOT create a missing salt, unlike `pam_kwallet5`, which
-/// creates one on first login. Absent salt means this user has no KDE wallet
-/// yet, and inventing one here would derive a key that opens nothing while
-/// looking like a successful arm.
-#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
-pub fn read_salt(home: &Path) -> Result<Zeroizing<Vec<u8>>> {
-    let path = salt_path(home);
-    let raw = read_regular_file_capped(&path, MAX_SALT_BYTES).map_err(|e| {
-        Error::Policy(format!(
-            "no KDE wallet salt at {}: {e}. Log into a Plasma session once so \
-             the wallet exists, then arm again",
-            path.display()
-        ))
-    })?;
-    if raw.len() < SALT_LEN {
-        return Err(Error::Policy(format!(
-            "wallet salt at {} is {} bytes, expected at least {SALT_LEN}",
-            path.display(),
-            raw.len()
-        )));
-    }
-    // pam_kwallet5 reads SALT_LEN and derives over exactly that, so a longer
-    // file must be truncated rather than passed through, or we derive a
-    // different key from the same file it used.
-    Ok(Zeroizing::new(raw[..SALT_LEN].to_vec()))
-}
 
 /// Derive the wallet key `ksecretd` expects from `secret` and `salt`.
 ///
@@ -152,18 +48,15 @@ pub fn derive_key(secret: &[u8], salt: &[u8]) -> Result<Zeroizing<Vec<u8>>> {
         )));
     }
     let mut out = Zeroizing::new(vec![0u8; KEY_LEN]);
+    // Protect the allocation before PBKDF2 writes the derived secret into it;
+    // locking only after the KDF would leave the most sensitive window open.
+    irlume_common::memlock::lock_slice(&out);
     pbkdf2::pbkdf2_hmac::<sha2::Sha512>(secret, salt, ITERATIONS, &mut out);
     Ok(out)
 }
 
-/// Derive `home`'s wallet key from the login password.
-#[expect(clippy::missing_errors_doc, reason = "doc backlog")]
-pub fn derive_for_home(password: &[u8], home: &Path) -> Result<Zeroizing<Vec<u8>>> {
-    let salt = read_salt(home)?;
-    derive_key(password, &salt)
-}
-
-/// Which secret to seal for a user, judged by what they actually have.
+/// Which secret to seal for a user, combining the caller's account-scoped KDE
+/// salt result with the GNOME keyring visible below `home`.
 ///
 /// A KDE wallet key only makes sense where there is a KDE wallet. A GNOME
 /// keyring token only makes sense where there is a GNOME login keyring to
@@ -176,13 +69,12 @@ pub fn derive_for_home(password: &[u8], home: &Path) -> Result<Zeroizing<Vec<u8>
 /// resolves to it. A home with neither also lands there deliberately: a token
 /// arm on a fresh account would have no keyring to re-key, and the envelope it
 /// wrote would unlock nothing.
-pub fn detect_kind(home: &Path) -> crate::envelope::SecretKind {
+pub fn detect_kind(home: &Path, has_kde_salt: bool) -> crate::envelope::SecretKind {
     use crate::envelope::SecretKind;
-    let has_kde = salt_path(home).exists();
     // gnome-keyring's login keyring: what a token re-keys, and what a wallet
     // key arm would break.
     let has_gnome = home.join(".local/share/keyrings/login.keyring").exists();
-    match (has_kde, has_gnome) {
+    match (has_kde_salt, has_gnome) {
         (true, false) => SecretKind::KdeWalletKey,
         (false, true) => SecretKind::GnomeKeyringToken,
         _ => SecretKind::LoginPassword,
@@ -192,48 +84,28 @@ pub fn detect_kind(home: &Path) -> crate::envelope::SecretKind {
 #[cfg(test)]
 mod tests {
 
-    /// The salt path lives in the user's own home, so its TYPE is theirs to
-    /// choose. `fs::read` on a FIFO blocks in `open(2)` until a writer appears,
-    /// which stalls the daemon's camera worker forever while the connection
-    /// threads keep answering Ping: the daemon looks healthy while every capture
-    /// is dead, the watchdog kills it, and the FIFO is still there on restart.
-    #[test]
-    fn a_non_regular_salt_is_refused_instead_of_blocking() {
-        let dir = std::path::PathBuf::from(crate::test_tmp_dir("kwallet-fifo"))
-            .join(".local/share/kwalletd");
-        let _ = std::fs::remove_dir_all(dir.parent().unwrap().parent().unwrap());
-        std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("kdewallet.salt");
-        let c = std::ffi::CString::new(path.to_str().unwrap()).unwrap();
-        assert_eq!(
-            // SAFETY: `c` is a live CString that outlives this call, so the pointer is
-            // a valid NUL-terminated path for the duration of mkfifo.
-            unsafe { libc::mkfifo(c.as_ptr(), 0o600) },
-            0,
-            "mkfifo failed"
-        );
-
-        let home = dir.parent().unwrap().parent().unwrap().parent().unwrap();
-        // Must RETURN. Before the fix this call never came back.
-        let err = read_salt(home).expect_err("a FIFO must not be read as a salt");
-        let msg = format!("{err}");
-        assert!(
-            msg.contains("FIFO"),
-            "the refusal must name what it found: {msg}"
-        );
-
-        // A real salt still reads.
-        std::fs::remove_file(&path).unwrap();
-        std::fs::write(&path, vec![7u8; SALT_LEN]).unwrap();
-        assert_eq!(read_salt(home).unwrap().len(), SALT_LEN);
-
-        // And an implausibly large one is refused rather than allocated.
-        std::fs::write(&path, vec![0u8; (MAX_SALT_BYTES + 1) as usize]).unwrap();
-        assert!(
-            read_salt(home).is_err(),
-            "an oversized salt must be refused"
-        );
-        let _ = std::fs::remove_dir_all(home);
+    fn locked_kb_of(addr: usize) -> Option<u64> {
+        let smaps = std::fs::read_to_string("/proc/self/smaps").ok()?;
+        let mut in_range = false;
+        for line in smaps.lines() {
+            if let Some((range, _)) = line.split_once(' ') {
+                if let Some((start, end)) = range.split_once('-') {
+                    if let (Ok(start), Ok(end)) = (
+                        usize::from_str_radix(start, 16),
+                        usize::from_str_radix(end, 16),
+                    ) {
+                        in_range = start <= addr && addr < end;
+                        continue;
+                    }
+                }
+            }
+            if in_range {
+                if let Some(rest) = line.strip_prefix("Locked:") {
+                    return rest.trim().trim_end_matches("kB").trim().parse().ok();
+                }
+            }
+        }
+        None
     }
 
     use super::*;
@@ -247,6 +119,29 @@ mod tests {
             KEY_LEN,
             "ksecretd's waitForHash() reads exactly {KEY_LEN} bytes; a shorter \
              key leaves it blocking and a longer one silently truncates"
+        );
+    }
+
+    #[test]
+    fn derived_wallet_key_is_memlocked() {
+        let key = derive_key(b"synthetic password", &[0x5a; SALT_LEN]).expect("derive");
+        let key_locked = locked_kb_of(key.as_ptr() as usize).unwrap_or(0);
+
+        // Control: stand down when best-effort mlock is unavailable in this
+        // environment, rather than changing the authentication contract.
+        let control = irlume_common::SecretBytes::new(vec![0x71; 16 * 1024]);
+        let control_mid = control.expose().as_ptr() as usize + 8 * 1024;
+        match locked_kb_of(control_mid) {
+            Some(kb) if kb > 0 => {}
+            _ => {
+                eprintln!("skipping: environment cannot mlock (RLIMIT_MEMLOCK?)");
+                return;
+            }
+        }
+
+        assert!(
+            key_locked > 0,
+            "PBKDF2 output must be protected while and after it is derived"
         );
     }
 
@@ -310,12 +205,8 @@ mod tests {
         let base = std::env::temp_dir().join(format!("irlume-detect-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&base);
 
-        let mk = |name: &str, kde: bool, gnome: bool| {
+        let mk = |name: &str, gnome: bool| {
             let h = base.join(name);
-            if kde {
-                std::fs::create_dir_all(salt_path(&h).parent().unwrap()).unwrap();
-                std::fs::write(salt_path(&h), [0u8; SALT_LEN]).unwrap();
-            }
             if gnome {
                 let g = h.join(".local/share/keyrings");
                 std::fs::create_dir_all(&g).unwrap();
@@ -326,60 +217,21 @@ mod tests {
         };
 
         assert_eq!(
-            detect_kind(&mk("neither", false, false)),
+            detect_kind(&mk("neither", false), false),
             SecretKind::LoginPassword
         );
         assert_eq!(
-            detect_kind(&mk("gnome", false, true)),
+            detect_kind(&mk("gnome", true), false),
             SecretKind::GnomeKeyringToken
         );
         assert_eq!(
-            detect_kind(&mk("both", true, true)),
+            detect_kind(&mk("both", true), true),
             SecretKind::LoginPassword
         );
         assert_eq!(
-            detect_kind(&mk("kde", true, false)),
+            detect_kind(&mk("kde", false), true),
             SecretKind::KdeWalletKey
         );
         let _ = std::fs::remove_dir_all(&base);
-    }
-
-    #[test]
-    fn a_missing_salt_is_an_error_rather_than_a_freshly_invented_one() {
-        // pam_kwallet5 creates a missing salt; we must not. No salt means no
-        // wallet, and a key derived against an invented salt opens nothing
-        // while `keyring arm` reports success.
-        let dir = std::env::temp_dir().join(format!("irlume-kwallet-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).expect("mkdir");
-        let err = read_salt(&dir).expect_err("a missing salt must not be invented");
-        assert!(
-            !salt_path(&dir).exists(),
-            "read_salt created {} instead of failing",
-            salt_path(&dir).display()
-        );
-        assert!(
-            format!("{err}").contains("Plasma"),
-            "the error should tell the user how to get a wallet, got: {err}"
-        );
-        let _ = std::fs::remove_dir_all(&dir);
-    }
-
-    #[test]
-    fn a_salt_file_longer_than_the_derivation_uses_is_truncated_not_hashed_whole() {
-        // pam_kwallet5 reads SALT_LEN bytes and derives over exactly those. If we
-        // hashed a longer file whole we would get a different key from the same
-        // file it used, and the wallet would never open.
-        let dir = std::env::temp_dir().join(format!("irlume-kwallet-long-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(salt_path(&dir).parent().unwrap()).expect("mkdir");
-        let mut long = vec![0x7u8; SALT_LEN];
-        long.extend_from_slice(b"trailing bytes pam_kwallet5 never reads");
-        std::fs::write(salt_path(&dir), &long).expect("write salt");
-
-        let via_file = derive_for_home(b"pw", &dir).expect("derive");
-        let via_prefix = derive_key(b"pw", &long[..SALT_LEN]).expect("derive");
-        assert_eq!(via_file.to_vec(), via_prefix.to_vec());
-        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/irlume-core/src/recovery.rs
+++ b/crates/irlume-core/src/recovery.rs
@@ -40,6 +40,7 @@ const SALT_LEN: usize = 16;
 const M_COST: u32 = 19_456;
 const T_COST: u32 = 2;
 const P_COST: u32 = 1;
+const CURRENT_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RecoveryEnvelope {
@@ -80,7 +81,7 @@ pub fn wrap(passphrase: &[u8], template_key: &[u8]) -> Result<RecoveryEnvelope> 
     let dk = derive_key(passphrase, &salt, M_COST, T_COST, P_COST)?;
     let wrapped = crypto::encrypt(&dk, template_key)?;
     Ok(RecoveryEnvelope {
-        version: 1,
+        version: CURRENT_VERSION,
         kdf: "argon2id".into(),
         salt: STANDARD.encode(salt),
         m_cost: M_COST,
@@ -95,6 +96,12 @@ pub fn wrap(passphrase: &[u8], template_key: &[u8]) -> Result<RecoveryEnvelope> 
 /// from tampering, by design.
 #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn unwrap(passphrase: &[u8], env: &RecoveryEnvelope) -> Result<Zeroizing<Vec<u8>>> {
+    if env.version != CURRENT_VERSION {
+        return Err(Error::Protocol(format!(
+            "unsupported recovery envelope version: {}",
+            env.version
+        )));
+    }
     if env.kdf != "argon2id" {
         return Err(Error::Policy(format!(
             "unsupported recovery KDF: {}",
@@ -143,5 +150,24 @@ mod tests {
         let b = wrap(b"same-pass", &key).unwrap();
         assert_ne!(a.salt, b.salt, "each wrap must use a fresh salt");
         assert_ne!(a.wrapped, b.wrapped);
+    }
+
+    #[test]
+    fn unwrap_rejects_unknown_versions_before_payload_processing() {
+        for version in [0, 2] {
+            let env = RecoveryEnvelope {
+                version,
+                kdf: "argon2id".into(),
+                salt: "not base64".into(),
+                m_cost: M_COST,
+                t_cost: T_COST,
+                p_cost: P_COST,
+                wrapped: "not base64".into(),
+            };
+            assert!(matches!(
+                unwrap(b"passphrase", &env),
+                Err(Error::Protocol(message)) if message.contains("unsupported recovery envelope version")
+            ));
+        }
     }
 }

--- a/crates/irlume-core/src/storage.rs
+++ b/crates/irlume-core/src/storage.rs
@@ -526,8 +526,9 @@ pub fn profile_path(user: &str) -> PathBuf {
     state_dir().join(format!("{user}.json"))
 }
 
-/// On-disk wrapper for an encrypted enrollment (version 2). The plaintext under
-/// `enc` is the same JSON an unencrypted `Enrollment` serializes to.
+/// On-disk wrapper for an encrypted enrollment (historical version 2 or current
+/// version 3). The plaintext under `enc` is the same JSON an unencrypted
+/// `Enrollment` serializes to.
 #[derive(Serialize, Deserialize)]
 struct EncEnvelope {
     version: u32,
@@ -540,10 +541,24 @@ struct EncEnvelope {
     enc: String,
 }
 
-/// Version written into new [`EncEnvelope`]s. Informational only: the load
-/// path detects the encrypted format by the `enc` field and never checks this
-/// number.
+/// Version written into new [`EncEnvelope`]s.
 const ENC_ENVELOPE_VERSION: u32 = 3;
+const LEGACY_ENC_ENVELOPE_VERSION: u32 = 2;
+
+fn is_encrypted_enrollment(v: &serde_json::Value) -> irlume_common::Result<bool> {
+    if v.get("enc").is_none() {
+        return Ok(false);
+    }
+    let version = v.get("version").and_then(serde_json::Value::as_u64);
+    if matches!(version, Some(version) if version == u64::from(LEGACY_ENC_ENVELOPE_VERSION) || version == u64::from(ENC_ENVELOPE_VERSION))
+    {
+        return Ok(true);
+    }
+    let version = version.map_or_else(|| "missing or invalid".to_string(), |v| v.to_string());
+    Err(irlume_common::Error::Protocol(format!(
+        "unsupported encrypted enrollment version: {version}"
+    )))
+}
 
 /// Serialize an enrollment, encrypting under `key` when one is supplied (TPM
 /// host) or emitting pretty plaintext when not (dev / no-TPM). Pure; tested
@@ -572,12 +587,12 @@ fn serialize_enrollment(e: &Enrollment, key: Option<&[u8]>) -> irlume_common::Re
 }
 
 /// Parse on-disk bytes into an `Enrollment`, handling all three formats:
-/// encrypted (v2, needs `key`), plaintext multi-profile, and the legacy
+/// encrypted (v2/v3, needs `key`), plaintext multi-profile, and the legacy
 /// single-profile layout (migrated). Pure; tested without a TPM.
 fn deserialize_enrollment(data: &[u8], key: Option<&[u8]>) -> irlume_common::Result<Enrollment> {
     let v: serde_json::Value =
         serde_json::from_slice(data).map_err(|e| irlume_common::Error::Protocol(e.to_string()))?;
-    if v.get("enc").is_some() {
+    if is_encrypted_enrollment(&v)? {
         let env: EncEnvelope =
             serde_json::from_value(v).map_err(|e| irlume_common::Error::Protocol(e.to_string()))?;
         let key = key.ok_or_else(|| {
@@ -659,7 +674,10 @@ fn replacement_key(
     load_existing: impl FnOnce(&str) -> irlume_common::Result<Zeroizing<Vec<u8>>>,
     first_save: impl FnOnce(&str) -> irlume_common::Result<Option<Zeroizing<Vec<u8>>>>,
 ) -> irlume_common::Result<Option<Zeroizing<Vec<u8>>>> {
-    if template_key::has_key(user) || store_is_encrypted(user)? == Some(true) {
+    // Probe first even when a key exists: the probe admits the stored format,
+    // and short-circuiting it would let replacement overwrite a future schema.
+    let encrypted_store = store_is_encrypted(user)? == Some(true);
+    if template_key::has_key(user) || encrypted_store {
         // Never mint a replacement key or fall back to plaintext on unseal
         // failure. The user can restore recovery or explicitly delete state.
         load_existing(user).map(Some)
@@ -681,27 +699,52 @@ fn save_with_key(
     persist_enrollment(&path, &bytes)
 }
 
-/// Load an enrollment, transparently decrypting (v2) and migrating the legacy
+/// Load an enrollment, transparently decrypting v2/v3 and migrating the legacy
 /// single-profile format. A plaintext file loads without touching the TPM; an
 /// encrypted file unseals the template key (and fails cleanly, with face auth
 /// falling back to the password, if the seal can no longer be satisfied).
 #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn load(user: &str) -> irlume_common::Result<Option<Enrollment>> {
-    let _state = template_key::UserStateLock::acquire(user)?;
+    load_with(
+        user,
+        template_key::UserStateLock::acquire,
+        template_key::load_key_unlocked,
+    )
+}
+
+/// Load an enrollment without writing enrollment, key, recovery, or lock files
+/// or initializing a persistent TPM storage root key. Legacy migration happens
+/// only in memory; encrypted stores still require successful TPM unsealing.
+///
+/// # Errors
+/// Returns an error if the existing user lock is absent, or on a read, unseal,
+/// or decryption failure. This diagnostic path does not initialize state.
+pub fn load_read_only(user: &str) -> irlume_common::Result<Option<Enrollment>> {
+    load_with(
+        user,
+        template_key::UserStateLock::acquire_read_only,
+        template_key::load_key_read_only_unlocked,
+    )
+}
+
+fn load_with(
+    user: &str,
+    acquire_lock: impl FnOnce(&str) -> irlume_common::Result<template_key::UserStateLock>,
+    load_key: impl FnOnce(&str) -> irlume_common::Result<Zeroizing<Vec<u8>>>,
+) -> irlume_common::Result<Option<Enrollment>> {
+    let _state = acquire_lock(user)?;
     let path = profile_path(user);
     if !path.exists() {
         return Ok(None);
     }
     let data = fs::read(&path).map_err(|e| irlume_common::Error::Io(e.to_string()))?;
-    // Only unseal the key when the file is actually encrypted.
-    let is_enc = serde_json::from_slice::<serde_json::Value>(&data)
-        .map(|v| v.get("enc").is_some())
-        .unwrap_or(false);
-    let key = if is_enc {
-        Some(template_key::load_key_unlocked(user)?)
-    } else {
-        None
+    // Validate the encrypted format before resolving a key: on TPM hosts,
+    // key resolution can open a TPM context and attempt an unseal.
+    let is_enc = match serde_json::from_slice::<serde_json::Value>(&data) {
+        Ok(value) => is_encrypted_enrollment(&value)?,
+        Err(_) => false,
     };
+    let key = if is_enc { Some(load_key(user)?) } else { None };
     deserialize_enrollment(&data, key.as_ref().map(|k| k.as_slice())).map(Some)
 }
 
@@ -725,11 +768,10 @@ pub fn load(user: &str) -> irlume_common::Result<Option<Enrollment>> {
 pub fn store_is_encrypted(user: &str) -> irlume_common::Result<Option<bool>> {
     let path = profile_path(user);
     match fs::read(&path) {
-        Ok(data) => Ok(Some(
-            serde_json::from_slice::<serde_json::Value>(&data)
-                .map(|v| v.get("enc").is_some())
-                .unwrap_or(false),
-        )),
+        Ok(data) => match serde_json::from_slice::<serde_json::Value>(&data) {
+            Ok(value) => is_encrypted_enrollment(&value).map(Some),
+            Err(_) => Ok(Some(false)),
+        },
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
         Err(e) => Err(irlume_common::Error::Io(e.to_string())),
     }
@@ -806,6 +848,68 @@ pub fn list_users() -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn read_only_plaintext_load_preserves_enrollment_and_missing_state() {
+        let _env = crate::testenv::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let dir = PathBuf::from(crate::test_tmp_dir("readonly-store"));
+        let _ = fs::remove_dir_all(&dir);
+        std::env::set_var("IRLUME_STATE_DIR", &dir);
+        assert!(load_read_only("u").is_err());
+        assert!(!dir.exists());
+        drop(template_key::UserStateLock::acquire("u").unwrap());
+        assert!(load_read_only("u").unwrap().is_none());
+        let path = profile_path("u");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let bytes = serialize_enrollment(&sample(), None).unwrap();
+        fs::write(&path, &bytes).unwrap();
+        assert_eq!(load_read_only("u").unwrap().unwrap().user, "u");
+        assert_eq!(fs::read(&path).unwrap(), bytes);
+        std::env::remove_var("IRLUME_STATE_DIR");
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn protected_load_decrypts_without_rewriting_enrollment() {
+        let _env = crate::testenv::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let dir = PathBuf::from(crate::test_tmp_dir("readonly-encrypted-store"));
+        let _ = fs::remove_dir_all(&dir);
+        std::env::set_var("IRLUME_STATE_DIR", &dir);
+        drop(template_key::UserStateLock::acquire("u").unwrap());
+        let path = profile_path("u");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let bytes = serialize_enrollment(&sample(), Some(&[42; 32])).unwrap();
+        fs::write(&path, &bytes).unwrap();
+        let loaded = load_with(
+            "u",
+            template_key::UserStateLock::acquire_read_only,
+            |user| {
+                assert_eq!(user, "u");
+                Ok(Zeroizing::new(vec![42; 32]))
+            },
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            loaded.profiles[0].scans[0].ir.as_deref(),
+            Some(&[0.5, 0.6][..])
+        );
+        assert_eq!(fs::read(&path).unwrap(), bytes);
+        assert!(
+            load_with("u", template_key::UserStateLock::acquire_read_only, |_| {
+                Err(irlume_common::Error::Policy(
+                    "synthetic unseal refusal".into(),
+                ))
+            })
+            .is_err()
+        );
+        assert_eq!(fs::read(&path).unwrap(), bytes);
+        std::env::remove_var("IRLUME_STATE_DIR");
+        fs::remove_dir_all(dir).unwrap();
+    }
 
     #[test]
     fn unknown_ir_retag_preserves_all_scan_data_in_every_live_space() {
@@ -1208,6 +1312,61 @@ mod tests {
     }
 
     #[test]
+    fn encrypted_enrollment_accepts_historical_and_current_versions() {
+        let key = crypto::generate_key();
+        let plain = serde_json::to_vec(&sample()).unwrap();
+        for version in [2, ENC_ENVELOPE_VERSION] {
+            let envelope = EncEnvelope {
+                version,
+                key_id: (version == ENC_ENVELOPE_VERSION).then(|| irlume_common::sha256_hex(&key)),
+                enc: STANDARD.encode(crypto::encrypt(&key, &plain).unwrap()),
+            };
+            let bytes = serde_json::to_vec(&envelope).unwrap();
+            let loaded = deserialize_enrollment(&bytes, Some(&key)).unwrap();
+            assert_eq!(loaded.user, "u");
+            assert_eq!(loaded.total_scans(), 1);
+        }
+    }
+
+    #[test]
+    fn encrypted_enrollment_rejects_unknown_versions_before_payload_processing() {
+        for version in [0, 1, ENC_ENVELOPE_VERSION + 1] {
+            let bytes = format!(r#"{{"version":{version},"enc":"not base64"}}"#);
+            assert!(matches!(
+                deserialize_enrollment(bytes.as_bytes(), Some(&[42; 32])),
+                Err(irlume_common::Error::Protocol(message))
+                    if message.contains("unsupported encrypted enrollment version")
+            ));
+        }
+    }
+
+    #[test]
+    fn load_rejects_unknown_encrypted_version_before_loading_key_and_preserves_file() {
+        let _env = crate::testenv::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let dir = PathBuf::from(crate::test_tmp_dir("unknown-encrypted-version"));
+        let _ = fs::remove_dir_all(&dir);
+        std::env::set_var("IRLUME_STATE_DIR", &dir);
+        drop(template_key::UserStateLock::acquire("u").unwrap());
+        let path = profile_path("u");
+        let bytes = br#"{"version":4,"enc":"not base64"}"#;
+        fs::write(&path, bytes).unwrap();
+
+        assert!(matches!(
+            load_with("u", template_key::UserStateLock::acquire_read_only, |_| {
+                panic!("unknown versions must be rejected before key loading")
+            }),
+            Err(irlume_common::Error::Protocol(message))
+                if message.contains("unsupported encrypted enrollment version")
+        ));
+        assert_eq!(fs::read(&path).unwrap(), bytes);
+
+        std::env::remove_var("IRLUME_STATE_DIR");
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
     fn plaintext_round_trip_without_key() {
         let e = sample();
         let bytes = serialize_enrollment(&e, None).unwrap();
@@ -1549,6 +1708,49 @@ mod tests {
         fs::remove_dir_all(dir).unwrap();
     }
 
+    #[test]
+    fn replacement_rejects_unknown_version_before_key_selection_and_preserves_state() {
+        let _g = crate::testenv::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let dir =
+            std::env::temp_dir().join(format!("irlume-replacement-version-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        std::env::set_var("IRLUME_STATE_DIR", &dir);
+        let before = br#"{"version":4,"enc":"future ciphertext"}"#;
+
+        for (user, has_key) in [("with-key", true), ("without-key", false)] {
+            let path = profile_path(user);
+            fs::write(&path, before).unwrap();
+            if has_key {
+                let key_path = template_key::key_path(user);
+                fs::create_dir_all(key_path.parent().unwrap()).unwrap();
+                fs::write(key_path, b"synthetic sealed key").unwrap();
+            }
+            let mut replacement = sample();
+            replacement.user = user.into();
+
+            let error = save_with_key(&replacement, |user| {
+                replacement_key(
+                    user,
+                    |_| panic!("unknown versions must be rejected before loading a key"),
+                    |_| panic!("unknown versions must be rejected before creating a key"),
+                )
+            })
+            .unwrap_err();
+            assert!(matches!(
+                error,
+                irlume_common::Error::Protocol(message)
+                    if message.contains("unsupported encrypted enrollment version")
+            ));
+            assert_eq!(fs::read(&path).unwrap(), before);
+        }
+
+        std::env::remove_var("IRLUME_STATE_DIR");
+        fs::remove_dir_all(dir).unwrap();
+    }
+
     // Regression: 0be786b. save() used fs::write straight onto the profile
     // path: a crash mid-write left a truncated profile and the umask window
     // made it briefly world-readable. The fix writes a 0600 temp file and
@@ -1679,6 +1881,19 @@ mod tests {
         // Encrypted envelope: Ok(Some(true)) — detection is the `enc` field.
         fs::write(dir.join("sealed.json"), br#"{"version":3,"enc":"AAAA"}"#).unwrap();
         assert_eq!(store_is_encrypted("sealed").unwrap(), Some(true));
+
+        for (user, version) in [("zero", 0), ("future", ENC_ENVELOPE_VERSION + 1)] {
+            fs::write(
+                dir.join(format!("{user}.json")),
+                format!(r#"{{"version":{version},"enc":"AAAA"}}"#),
+            )
+            .unwrap();
+            assert!(matches!(
+                store_is_encrypted(user),
+                Err(irlume_common::Error::Protocol(message))
+                    if message.contains("unsupported encrypted enrollment version")
+            ));
+        }
 
         // Unparseable bytes read as plaintext so the FULL load reports the
         // real parse error instead of this probe.

--- a/crates/irlume-core/src/template_key.rs
+++ b/crates/irlume-core/src/template_key.rs
@@ -55,16 +55,26 @@ fn recovery_dir() -> PathBuf {
 pub(crate) struct UserStateLock(std::fs::File);
 
 impl UserStateLock {
+    pub(crate) fn acquire_read_only(user: &str) -> Result<Self> {
+        Self::acquire_with_creation(user, false)
+    }
+
     pub(crate) fn acquire(user: &str) -> Result<Self> {
+        Self::acquire_with_creation(user, true)
+    }
+
+    fn acquire_with_creation(user: &str, create: bool) -> Result<Self> {
         let dir = key_dir().join(".locks");
-        let dir_existed = dir.try_exists().unwrap_or(false);
-        std::fs::create_dir_all(&dir).map_err(|error| Error::Io(error.to_string()))?;
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            if !dir_existed {
-                std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700))
-                    .map_err(|error| Error::Io(error.to_string()))?;
+        if create {
+            let dir_existed = dir.try_exists().unwrap_or(false);
+            std::fs::create_dir_all(&dir).map_err(|error| Error::Io(error.to_string()))?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                if !dir_existed {
+                    std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700))
+                        .map_err(|error| Error::Io(error.to_string()))?;
+                }
             }
         }
         let path = dir.join(format!(
@@ -72,7 +82,11 @@ impl UserStateLock {
             irlume_common::sha256_hex(user.as_bytes())
         ));
         let mut options = std::fs::OpenOptions::new();
-        options.read(true).write(true).create(true).truncate(false);
+        options
+            .read(true)
+            .write(create)
+            .create(create)
+            .truncate(false);
         #[cfg(unix)]
         options
             .mode(0o600)
@@ -170,7 +184,41 @@ pub fn load_key(user: &str) -> Result<Zeroizing<Vec<u8>>> {
     load_key_unlocked(user)
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum KeyLoadPolicy {
+    Upgrade,
+    ReadOnly,
+}
+
 pub(crate) fn load_key_unlocked(user: &str) -> Result<Zeroizing<Vec<u8>>> {
+    load_key_with(
+        user,
+        KeyLoadPolicy::Upgrade,
+        tpm::unseal,
+        tpm::stronger_tier_available_than,
+        tpm::seal,
+    )
+}
+
+/// Caller holds the existing user state lock. Never upgrades the envelope or
+/// initializes a persistent TPM storage root key.
+pub(crate) fn load_key_read_only_unlocked(user: &str) -> Result<Zeroizing<Vec<u8>>> {
+    load_key_with(
+        user,
+        KeyLoadPolicy::ReadOnly,
+        tpm::unseal_read_only,
+        tpm::stronger_tier_available_than,
+        tpm::seal,
+    )
+}
+
+fn load_key_with(
+    user: &str,
+    policy: KeyLoadPolicy,
+    unseal: impl FnOnce(&SealedEnvelope) -> Result<Zeroizing<Vec<u8>>>,
+    stronger_tier_available: impl FnOnce(&crate::envelope::PolicyKind) -> bool,
+    seal: impl FnOnce(&[u8]) -> Result<SealedEnvelope>,
+) -> Result<Zeroizing<Vec<u8>>> {
     let path = key_path(user);
     if !path.exists() {
         return Err(Error::Policy(format!(
@@ -178,7 +226,7 @@ pub(crate) fn load_key_unlocked(user: &str) -> Result<Zeroizing<Vec<u8>>> {
         )));
     }
     let env = SealedEnvelope::load(&path)?;
-    let key = tpm::unseal(&env)?;
+    let key = unseal(&env)?;
     // Best-effort tier auto-upgrade (mirrors keyring::reseal_password): if a
     // strictly stronger sealing tier became available since this key was sealed
     // (e.g. signed-PCR started working), re-seal the key to it so an existing
@@ -186,8 +234,8 @@ pub(crate) fn load_key_unlocked(user: &str) -> Result<Zeroizing<Vec<u8>>> {
     // no-op once the envelope is already at the best tier, so there is no steady
     // per-match cost. Never fail the load on it: the key unsealed fine and the
     // weaker envelope stays usable.
-    if tpm::stronger_tier_available_than(&env.policy) {
-        if let Ok(candidate) = tpm::seal(&key) {
+    if policy == KeyLoadPolicy::Upgrade && stronger_tier_available(&env.policy) {
+        if let Ok(candidate) = seal(&key) {
             if candidate.policy.strength_rank() > env.policy.strength_rank()
                 && candidate.save(&path).is_ok()
             {
@@ -365,6 +413,72 @@ mod tests {
     }
 
     use super::*;
+
+    #[test]
+    fn read_only_key_load_preserves_envelope_while_normal_load_upgrades() {
+        let _env = crate::testenv::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let dir = PathBuf::from(crate::test_tmp_dir("readonly-key"));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::env::set_var("IRLUME_TEMPLATE_KEY_DIR", &dir);
+        let weak: SealedEnvelope =
+            serde_json::from_str(r#"{"version":1,"pcrs":[7],"public":"","private":""}"#).unwrap();
+        weak.save(&key_path("alice")).unwrap();
+        let before = std::fs::read(key_path("alice")).unwrap();
+        let unseal = |_: &SealedEnvelope| Ok(Zeroizing::new(vec![42; 32]));
+        let key = load_key_with(
+            "alice",
+            KeyLoadPolicy::ReadOnly,
+            unseal,
+            |_| panic!("read-only load must not probe upgrades"),
+            |_| panic!("read-only load must not seal"),
+        )
+        .unwrap();
+        assert_eq!(key.as_slice(), &[42; 32]);
+        assert_eq!(std::fs::read(key_path("alice")).unwrap(), before);
+        let key = load_key_with(
+            "alice",
+            KeyLoadPolicy::Upgrade,
+            unseal,
+            |_| true,
+            |key| {
+                assert_eq!(key, &[42; 32]);
+                let mut stronger: SealedEnvelope = serde_json::from_slice(&before).unwrap();
+                stronger.policy = crate::envelope::PolicyKind::PcrlockNv { nv_index: 1 };
+                Ok(stronger)
+            },
+        )
+        .unwrap();
+        assert_eq!(key.as_slice(), &[42; 32]);
+        assert_eq!(
+            SealedEnvelope::load(&key_path("alice"))
+                .unwrap()
+                .policy
+                .strength_rank(),
+            2
+        );
+        assert_ne!(std::fs::read(key_path("alice")).unwrap(), before);
+        std::env::remove_var("IRLUME_TEMPLATE_KEY_DIR");
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn read_only_lock_requires_existing_lock_without_creating_state() {
+        let _env = crate::testenv::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let dir = PathBuf::from(crate::test_tmp_dir("readonly-lock"));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::env::set_var("IRLUME_TEMPLATE_KEY_DIR", &dir);
+        assert!(UserStateLock::acquire_read_only("alice").is_err());
+        assert!(!dir.exists());
+        drop(UserStateLock::acquire("alice").unwrap());
+        drop(UserStateLock::acquire_read_only("alice").unwrap());
+        std::env::remove_var("IRLUME_TEMPLATE_KEY_DIR");
+        std::fs::remove_dir_all(dir).unwrap();
+    }
 
     #[test]
     fn independent_user_state_locks_serialize_threads() {

--- a/crates/irlume-core/src/tpm.rs
+++ b/crates/irlume-core/src/tpm.rs
@@ -319,7 +319,7 @@ fn is_irlume_srk(public: &Public) -> Result<bool> {
 ///
 /// Returns the handle and whether it is persistent (a persistent handle must NOT
 /// be flushed by the caller).
-fn load_or_create_srk(ctx: &mut Context) -> Result<(KeyHandle, bool)> {
+fn load_or_create_srk(ctx: &mut Context, mode: SrkMode) -> Result<(KeyHandle, bool)> {
     let persistent = persistent_srk_handle()?;
     let wanted = TpmHandle::Persistent(persistent);
 
@@ -344,32 +344,34 @@ fn load_or_create_srk(ctx: &mut Context) -> Result<(KeyHandle, bool)> {
             }
             // Persistent handle occupied by a foreign key: leave it untouched and
             // use a transient SRK this run (correct, just slower).
-            let transient = create_srk(ctx)?;
+            let transient = mode.initialize(|| create_srk(ctx))?;
             return Ok((transient, false));
         }
     }
 
-    // First run: derive the primary (one-time slow step) and persist it.
-    // Said in our words, because the library's logging for the expected
-    // handle miss this path replaces is three ERROR lines (#601).
-    irlume_common::dlog!(
-        "irlume: first TPM use on this machine: deriving and persisting the \
+    mode.initialize(|| {
+        // First run: derive the primary (one-time slow step) and persist it.
+        // Said in our words, because the library's logging for the expected
+        // handle miss this path replaces is three ERROR lines (#601).
+        irlume_common::dlog!(
+            "irlume: first TPM use on this machine: deriving and persisting the \
          storage root key (a few seconds on slow TPMs)"
-    );
-    let transient = create_srk(ctx)?;
-    let persisted = ctx
-        .execute_with_nullauth_session(|ctx| {
-            ctx.evict_control(
-                Provision::Owner,
-                transient.into(),
-                Persistent::Persistent(persistent),
-            )
-        })
-        .map_err(tpm_err)?;
-    let _ = ctx.flush_context(transient.into());
-    ctx.tr_set_auth(persisted, Auth::default())
-        .map_err(tpm_err)?;
-    Ok((KeyHandle::from(ESYS_TR::from(persisted)), true))
+        );
+        let transient = create_srk(ctx)?;
+        let persisted = ctx
+            .execute_with_nullauth_session(|ctx| {
+                ctx.evict_control(
+                    Provision::Owner,
+                    transient.into(),
+                    Persistent::Persistent(persistent),
+                )
+            })
+            .map_err(tpm_err)?;
+        let _ = ctx.flush_context(transient.into());
+        ctx.tr_set_auth(persisted, Auth::default())
+            .map_err(tpm_err)?;
+        Ok((KeyHandle::from(ESYS_TR::from(persisted)), true))
+    })
 }
 
 /// Run `body` with irlume's persistent SRK as parent. Never flushes the SRK when
@@ -379,7 +381,32 @@ fn with_srk<T>(
     ctx: &mut Context,
     body: impl FnOnce(&mut Context, &KeyHandle) -> Result<T>,
 ) -> Result<T> {
-    let (srk, persistent) = load_or_create_srk(ctx)?;
+    with_srk_mode(ctx, SrkMode::Initialize, body)
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum SrkMode {
+    Initialize,
+    ReadOnly,
+}
+
+impl SrkMode {
+    fn initialize<T>(self, initialize: impl FnOnce() -> Result<T>) -> Result<T> {
+        if self == Self::ReadOnly {
+            return Err(Error::Policy(
+                "read-only unseal requires the existing irlume storage root key".into(),
+            ));
+        }
+        initialize()
+    }
+}
+
+fn with_srk_mode<T>(
+    ctx: &mut Context,
+    mode: SrkMode,
+    body: impl FnOnce(&mut Context, &KeyHandle) -> Result<T>,
+) -> Result<T> {
+    let (srk, persistent) = load_or_create_srk(ctx, mode)?;
     let result = body(ctx, &srk);
     if !persistent {
         let _ = ctx.flush_context(srk.into());
@@ -580,22 +607,81 @@ pub fn is_pcr_changed_race(e: &Error) -> bool {
 /// leg did not.
 #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn unseal(env: &SealedEnvelope) -> Result<Zeroizing<Vec<u8>>> {
+    unseal_with_mode(env, SrkMode::Initialize)
+}
+
+/// Unseal without creating or persisting a storage root key.
+///
+/// # Errors
+/// Returns an error if the existing SRK is unavailable, or policy unsealing fails.
+pub(crate) fn unseal_read_only(env: &SealedEnvelope) -> Result<Zeroizing<Vec<u8>>> {
+    unseal_with_mode(env, SrkMode::ReadOnly)
+}
+
+fn unseal_with_mode(env: &SealedEnvelope, mode: SrkMode) -> Result<Zeroizing<Vec<u8>>> {
+    env.validate_version()?;
     let out = retry_on_pcr_race(
         PCR_CHANGED_RETRIES,
         PCR_CHANGED_RETRY_BUDGET,
         || match &env.policy {
-            PolicyKind::PcrLiteral => unseal_literal(env),
+            PolicyKind::PcrLiteral => unseal_literal(env, mode),
             PolicyKind::Authorized {
                 pubkey_pem,
                 policy_ref,
-            } => unseal_authorized(env, pubkey_pem, policy_ref),
-            PolicyKind::PcrlockNv { nv_index } => unseal_pcrlock(env, *nv_index),
+            } => unseal_authorized(env, pubkey_pem, policy_ref, mode),
+            PolicyKind::PcrlockNv { nv_index } => unseal_pcrlock(env, *nv_index, mode),
         },
     )?;
     // Lock the unsealed secret (login password / template key) against swap and
     // core dumps for as long as it lives.
     irlume_common::memlock::lock_slice(&out);
     Ok(out)
+}
+
+#[cfg(test)]
+mod envelope_version_tests {
+    use super::*;
+
+    fn unknown_envelope(version: u32, pcr_values: Vec<PcrValue>) -> SealedEnvelope {
+        SealedEnvelope {
+            version,
+            policy: PolicyKind::PcrLiteral,
+            secret: crate::envelope::SecretKind::LoginPassword,
+            pcrs: vec![7],
+            public: Vec::new(),
+            private: Vec::new(),
+            pcr_values,
+            password_wrap: None,
+        }
+    }
+
+    #[test]
+    fn unseal_rejects_unknown_envelope_version_before_opening_tpm() {
+        for version in [0, crate::envelope::CURRENT_VERSION + 1] {
+            let envelope = unknown_envelope(version, Vec::new());
+            assert!(matches!(
+                unseal(&envelope),
+                Err(Error::Protocol(message)) if message.contains("unsupported TPM envelope version")
+            ));
+        }
+    }
+
+    #[test]
+    fn diagnose_rejects_unknown_envelope_version_before_empty_return_or_tpm() {
+        for pcr_values in [
+            Vec::new(),
+            vec![PcrValue {
+                pcr: 7,
+                value: vec![0; 32],
+            }],
+        ] {
+            let envelope = unknown_envelope(crate::envelope::CURRENT_VERSION + 1, pcr_values);
+            assert!(matches!(
+                diagnose_pcrs(&envelope),
+                Err(Error::Protocol(message)) if message.contains("unsupported TPM envelope version")
+            ));
+        }
+    }
 }
 
 /// Run `attempt` until it stops losing to the PCR-counter race, at most
@@ -638,10 +724,10 @@ where
 /// Unseal a literal-`PolicyPCR` envelope: replay the bound PCRs into a policy
 /// session and unseal.
 #[allow(clippy::redundant_closure_call)]
-fn unseal_literal(env: &SealedEnvelope) -> Result<Zeroizing<Vec<u8>>> {
+fn unseal_literal(env: &SealedEnvelope, mode: SrkMode) -> Result<Zeroizing<Vec<u8>>> {
     let mut ctx = open_context()?;
 
-    with_srk(&mut ctx, |ctx, srk| {
+    with_srk_mode(&mut ctx, mode, |ctx, srk| {
         let public = Public::unmarshall(&env.public).map_err(tpm_err)?;
         let private = Private::try_from(env.private.clone()).map_err(tpm_err)?;
 
@@ -734,10 +820,11 @@ fn unseal_authorized(
     env: &SealedEnvelope,
     pubkey_pem: &str,
     policy_ref: &[u8],
+    mode: SrkMode,
 ) -> Result<Zeroizing<Vec<u8>>> {
     let mut ctx = open_context()?;
 
-    with_srk(&mut ctx, |ctx, srk| {
+    with_srk_mode(&mut ctx, mode, |ctx, srk| {
         let public = Public::unmarshall(&env.public).map_err(tpm_err)?;
         let private = Private::try_from(env.private.clone()).map_err(tpm_err)?;
         let sealed_handle = ctx
@@ -1315,13 +1402,17 @@ fn seal_pcrlock(secret: &[u8], nv_index: u32) -> Result<SealedEnvelope> {
 /// Unseal a `PolicyAuthorizeNV`-bound object against `nv_index`: replay the live
 /// super-PCR policy, run PolicyAuthorizeNV, and unseal.
 #[allow(clippy::redundant_closure_call)]
-fn unseal_pcrlock(env: &SealedEnvelope, nv_index: u32) -> Result<Zeroizing<Vec<u8>>> {
+fn unseal_pcrlock(
+    env: &SealedEnvelope,
+    nv_index: u32,
+    mode: SrkMode,
+) -> Result<Zeroizing<Vec<u8>>> {
     let plock = read_pcrlock_json()?;
     let mut ctx = open_context()?;
     let nv = nv_index_handle(&mut ctx, nv_index)?;
     let super_pcr = build_super_pcr(&plock)?;
 
-    with_srk(&mut ctx, |ctx, srk| {
+    with_srk_mode(&mut ctx, mode, |ctx, srk| {
         let public = Public::unmarshall(&env.public).map_err(tpm_err)?;
         let private = Private::try_from(env.private.clone()).map_err(tpm_err)?;
         let sealed_handle = ctx
@@ -1421,6 +1512,7 @@ pub fn is_pcr_mismatch(e: &Error) -> bool {
 /// PCRs whose SHA-256 differs (empty ⇒ no drift, or no values captured at seal).
 #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
 pub fn diagnose_pcrs(env: &SealedEnvelope) -> Result<Vec<u32>> {
+    env.validate_version()?;
     if env.pcr_values.is_empty() {
         return Ok(Vec::new());
     }
@@ -1437,6 +1529,17 @@ pub fn diagnose_pcrs(env: &SealedEnvelope) -> Result<Vec<u32>> {
 
 #[cfg(test)]
 pub(crate) mod tests {
+    #[test]
+    fn read_only_srk_refuses_initialization() {
+        let result = super::SrkMode::ReadOnly.initialize(|| -> irlume_common::Result<()> {
+            panic!("read-only unseal must not create or persist an SRK")
+        });
+        assert!(matches!(result, Err(irlume_common::Error::Policy(_))));
+        assert_eq!(
+            super::SrkMode::Initialize.initialize(|| Ok(17)).unwrap(),
+            17
+        );
+    }
     use super::*;
 
     #[test]

--- a/crates/irlume-daemon/src/arbiter.rs
+++ b/crates/irlume-daemon/src/arbiter.rs
@@ -91,8 +91,11 @@ pub fn classify(req: &Request) -> Class {
         // serves from the worker with the other TPM users.
         Ping
         | Health
+        | FaceSensorStatus { user: None }
         | HasSealedPassword { .. }
         | RecoveryStatus { .. }
+        | RetryStatus { .. }
+        | RetryReset { .. } // connection-only operation; never a camera job
         | ListProfiles { .. }
         | SupportSnapshot { .. }
         // Served directly by its connection thread before this classification
@@ -143,7 +146,8 @@ pub fn classify(req: &Request) -> Class {
         // `Class::Status` gives: the TPM executes one command at a time, so
         // anything that issues one serves from the worker with the other TPM
         // users instead of racing them from a connection thread.
-        SealPassword { .. }
+        FaceSensorStatus { user: Some(_) }
+        | SealPassword { .. }
         | KeyringInfo { .. }
         | ForgetPassword { .. }
         | ReleaseTokenForDisarm { .. }
@@ -203,11 +207,18 @@ impl Refusal {
 ///
 /// Enrolment captures many scans and may retry each one. The boundary between
 /// two whole captures is where stopping is safe, and it is the only place this
-/// is read. The token says "an authentication is waiting"; what it never does is
-/// interrupt a capture already inside V4L2 or an inference session, or fire
-/// while a profile is half-written.
+/// is honored. A scheduling yield is separate from the current client leaving:
+/// queued authentication must not interrupt running authentication, while a
+/// departed client's own request must stop. Neither interrupts a capture inside
+/// V4L2 or an inference session, or fires while a profile is half-written.
 #[derive(Clone, Default)]
-pub struct CancelToken(Arc<AtomicBool>);
+pub struct CancelToken(Arc<StopRequests>);
+
+#[derive(Default)]
+struct StopRequests {
+    yield_requested: AtomicBool,
+    cancel_requested: AtomicBool,
+}
 
 impl CancelToken {
     pub fn new() -> Self {
@@ -216,18 +227,29 @@ impl CancelToken {
 
     /// Ask the running long operation to stop at its next safe boundary.
     pub fn request_stop(&self) {
-        self.0.store(true, Ordering::SeqCst);
+        self.0.yield_requested.store(true, Ordering::SeqCst);
+    }
+
+    /// The current client has left. Unlike scheduling preemption, this also
+    /// stops authentication. The caller must hold that job's ownership guard.
+    pub fn request_cancel(&self) {
+        self.0.cancel_requested.store(true, Ordering::SeqCst);
+    }
+
+    pub fn cancel_requested(&self) -> bool {
+        self.0.cancel_requested.load(Ordering::SeqCst)
     }
 
     /// True once a stop has been asked for.
     pub fn stop_requested(&self) -> bool {
-        self.0.load(Ordering::SeqCst)
+        self.0.yield_requested.load(Ordering::SeqCst) || self.cancel_requested()
     }
 
     /// Clear the signal before the worker starts its next operation, so the one
     /// that yielded does not hand its cancellation to the one that follows.
     pub fn reset(&self) {
-        self.0.store(false, Ordering::SeqCst);
+        self.0.yield_requested.store(false, Ordering::SeqCst);
+        self.0.cancel_requested.store(false, Ordering::SeqCst);
     }
 }
 
@@ -482,6 +504,10 @@ mod tests {
             token.stop_requested(),
             "the enrolment must learn an authentication is waiting"
         );
+        assert!(
+            !token.cancel_requested(),
+            "queued auth is not client cancellation"
+        );
         a.finish(job.class, job.uid);
         let next = a.take().unwrap();
         assert_eq!(next.payload, "login");
@@ -597,6 +623,8 @@ mod tests {
                 kind: None,
                 user: "u".into(),
                 password: SecretBytes::new(vec![1u8]),
+                wallet_salt: None,
+                wallet_salt_checked: true,
             }),
             Class::Plain
         );
@@ -627,6 +655,8 @@ mod tests {
             classify(&Request::ResealPassword {
                 user: "u".into(),
                 password: irlume_common::SecretBytes::new(vec![1u8]),
+                wallet_salt: None,
+                wallet_salt_checked: true,
             }),
             Class::Plain
         );

--- a/crates/irlume-daemon/src/arbiter.rs
+++ b/crates/irlume-daemon/src/arbiter.rs
@@ -91,6 +91,7 @@ pub fn classify(req: &Request) -> Class {
         // serves from the worker with the other TPM users.
         Ping
         | Health
+        | PreferencesStatus
         | FaceSensorStatus { user: None }
         | HasSealedPassword { .. }
         | RecoveryStatus { .. }

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -2738,6 +2738,9 @@ fn dispatch_before_engine(req: Request, peer: &Peer) -> Response {
             have_password,
         } => unseal_keyring(&user, service.as_deref(), have_password, peer),
         Request::Ping => Response::Ok("starting".into()),
+        Request::PreferencesStatus => {
+            Response::PreferencesStatus(irlume_common::PreferencesState::observe())
+        }
         Request::FaceSensorStatus { user } => Response::FaceSensorStatus {
             policy: irlume_common::config::observe_face_sensor_policy(),
             ir_readiness: user.map(|_| irlume_common::IrOnlyReadiness::Unavailable),
@@ -2793,7 +2796,9 @@ fn serve_peer(
             // startup instead of replacing them with a generic starting reply.
             if matches!(
                 req,
-                Request::SupportSnapshot { .. } | Request::FaceSensorStatus { .. }
+                Request::SupportSnapshot { .. }
+                    | Request::FaceSensorStatus { .. }
+                    | Request::PreferencesStatus
             ) {
                 if let Some(resp) = pregate(&req, &peer) {
                     return respond(stream, &resp);
@@ -3314,6 +3319,7 @@ fn posture(req: &Request) -> RequestPosture<'_> {
             enrollment: Reads,
         },
         Ping
+        | PreferencesStatus
         | Health
         | Identify
         | ListCameras
@@ -3770,6 +3776,9 @@ fn dispatch_status_with_diagnostics(
         .unwrap_or_else(|e| e.into_inner())
         .clone();
     Some(match req {
+        Request::PreferencesStatus => {
+            Response::PreferencesStatus(irlume_common::PreferencesState::observe())
+        }
         Request::FaceSensorStatus { user: Some(_) } => return None,
         Request::FaceSensorStatus { user: None } => Response::FaceSensorStatus {
             policy: irlume_common::config::observe_face_sensor_policy(),
@@ -4336,6 +4345,7 @@ fn diagnostic_operation_class(req: &Request) -> irlume_common::diagnostics::Oper
         | CameraDiagnostics => OperationClass::CameraDiagnostics,
         SetCameras { .. }
         | FaceSensorStatus { .. }
+        | PreferencesStatus
         | ListProfiles { .. }
         | DeleteProfile { .. }
         | DeleteScan { .. }
@@ -4555,6 +4565,7 @@ fn dispatch_scoped_session_inner(
         Request::Ping
         | Request::Health
         | Request::FaceSensorStatus { user: None }
+        | Request::PreferencesStatus
         | Request::HasSealedPassword { .. }
         | Request::RecoveryStatus { .. }
         | Request::SupportSnapshot { .. }
@@ -7540,6 +7551,7 @@ mod tests {
         TuneCaptureMode => Request::TuneCaptureMode { rounds: None },
         CaptureModeStatus => Request::CaptureModeStatus,
         FaceSensorStatus => Request::FaceSensorStatus { user: Some(u()) },
+        PreferencesStatus => Request::PreferencesStatus,
         SelfTest => Request::SelfTest {
             kind: irlume_common::SelfTestKind::Liveness,
         },
@@ -9140,6 +9152,42 @@ mod tests {
         assert!(
             cached_enrollment_summary(SAMPLE_USER).is_none(),
             "an authorized mutation must drop the summary before it runs"
+        );
+    }
+
+    #[test]
+    fn preferences_status_is_non_secret_camera_free_and_available_during_startup() {
+        let _guard = env_lock();
+        let sb = sandbox("preferences-status");
+        let _ = sb;
+        let expected = irlume_common::PreferencesState::observe();
+        assert!(matches!(
+            arbiter::classify(&Request::PreferencesStatus),
+            arbiter::Class::Status
+        ));
+        let response = dispatch_status(&Request::PreferencesStatus, &peer(65534)).unwrap();
+        assert!(matches!(response, Response::PreferencesStatus(state) if state == expected));
+        let arbiter = std::sync::Arc::new(arbiter::Arbiter::<Queued>::new());
+        let ready = std::sync::atomic::AtomicBool::new(false);
+        let response = with_serve(&arbiter, &ready, |ours| {
+            writeln!(
+                &*ours,
+                "{}",
+                serde_json::to_string(&Request::PreferencesStatus).unwrap()
+            )
+            .unwrap();
+            let mut line = String::new();
+            BufReader::new(ours).read_line(&mut line).unwrap();
+            serde_json::from_str::<Response>(&line).unwrap()
+        });
+        assert!(matches!(response, Response::PreferencesStatus(state) if state == expected));
+        arbiter.close();
+        let value = serde_json::to_value(response).unwrap();
+        let object = value["PreferencesStatus"].as_object().unwrap();
+        assert_eq!(
+            object.len(),
+            5,
+            "only policy enums, optional bools and override flags"
         );
     }
 

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -62,6 +62,7 @@ mod diagnostics;
 mod enrollment_session;
 mod operation_authorization;
 mod position_session;
+mod retry_recovery;
 mod retry_throttle;
 mod users;
 
@@ -158,11 +159,10 @@ fn verify_models(paths: &[&str], keep: Option<&str>) -> Option<irlume_common::Ha
                 "irlumed: WARNING: {path} does not match any release model checksum (sha256 {digest})"
             );
             if strict {
-                // Strict verification runs once in the startup thread. Only the
-                // recognizer's verified bytes are carried into the initial load;
-                // the detector, adapter, mesh and Blaze models are reopened by
-                // path, and a post-panic rebuild reopens every model path without
-                // repeating this manifest check (#346).
+                // Startup and post-panic rebuilds both run this verification.
+                // Only the recognizer's verified bytes are carried into its
+                // loader; the detector, adapter, mesh and Blaze still reopen
+                // paths after checking. Root controls those paths (#346).
                 //
                 // A changed recognizer fails closed for identity matching: its
                 // full digest changes the `embed:<sha256>` space tag, so
@@ -170,9 +170,8 @@ fn verify_models(paths: &[&str], keep: Option<&str>) -> Option<irlume_common::Ha
                 // old space. That argument does not cover the other artifacts.
                 eprintln!(
                     "irlumed: IRLUME_MODELS_STRICT=1: refusing to start with unverified models \
-                     (verification is a one-time startup path check; only the recognizer bytes \
-                     are carried from this check into the initial load, and a rebuild after a \
-                     worker panic reloads model paths without re-checking)"
+                     (verification runs before startup and post-panic rebuilds; only the recognizer \
+                     bytes are carried from this check into the loader)"
                 );
                 std::process::exit(1);
             }
@@ -198,10 +197,11 @@ fn verify_models(paths: &[&str], keep: Option<&str>) -> Option<irlume_common::Ha
 /// tighter guarantee: [`irlume_auth::Engine::load`] re-opens the path, so a file
 /// swapped between the check and the load would reach the session unverified.
 ///
-/// `None` is the camera worker's post-panic rebuild, which pays the read as it
-/// always has. Keeping the 260MB buffer alive for the daemon's whole life to
-/// save that one re-read would cost more resident memory than the entire rest
-/// of the process, so startup drops it as soon as the session owns its copy.
+/// `None` is the fallback when verification could not retain readable bytes.
+/// Post-panic rebuilds repeat verification in [`rebuild_engine_from_config`]
+/// and pass retained bytes here when available. Each build drops that buffer
+/// as soon as the session owns its copy rather than retaining it for the
+/// daemon's lifetime.
 fn load_shipped_recognizer(
     det_path: &str,
     model_path: &str,
@@ -366,10 +366,81 @@ fn load_pad_models(
     (engine, rgb_status, ir_status)
 }
 
+#[derive(Debug, PartialEq, Eq, Default)]
+struct EngineDevices {
+    rgb: String,
+    ir: String,
+    rgb_available: bool,
+    ir_available: bool,
+}
+
+fn select_engine_devices_with(
+    policy: irlume_common::config::FaceSensorPolicyObservation,
+    discover: impl FnOnce() -> EngineDevices,
+    configured: impl FnOnce() -> EngineDevices,
+) -> EngineDevices {
+    match policy.resolve() {
+        Ok(irlume_common::config::FaceSensorPolicy::Dual) => discover(),
+        Ok(irlume_common::config::FaceSensorPolicy::IrOnlyExperimental) => configured(),
+        Err(_) => EngineDevices::default(),
+    }
+}
+
+fn select_engine_devices(
+    policy: irlume_common::config::FaceSensorPolicyObservation,
+) -> EngineDevices {
+    select_engine_devices_with(
+        policy,
+        || {
+            let caps = irlume_auth::capabilities();
+            let (rgb, ir) = irlume_auth::select_pair()
+                .unwrap_or_else(|| (irlume_auth::select_rgb().unwrap_or_default(), String::new()));
+            EngineDevices {
+                rgb_available: caps.rgb && std::path::Path::new(&rgb).exists(),
+                ir_available: caps.ir_pair && std::path::Path::new(&ir).exists(),
+                rgb,
+                ir,
+            }
+        },
+        || {
+            let (rgb, ir) = irlume_auth::configured_pair_no_probe().unwrap_or_default();
+            EngineDevices {
+                rgb_available: false,
+                ir_available: irlume_auth::configured_ir_target().is_ok(),
+                rgb,
+                ir,
+            }
+        },
+    )
+}
+
+fn permits_background_requalification(
+    policy: irlume_common::config::FaceSensorPolicyObservation,
+) -> bool {
+    matches!(
+        policy.resolve(),
+        Ok(irlume_common::config::FaceSensorPolicy::Dual)
+    )
+}
+
+fn sensor_preflight_with(
+    policy: irlume_common::config::FaceSensorPolicyObservation,
+    preflight: impl FnOnce() -> irlume_common::IrOnlyReadiness,
+) -> irlume_common::IrOnlyReadiness {
+    match policy.resolve() {
+        Ok(irlume_common::config::FaceSensorPolicy::IrOnlyExperimental) => preflight(),
+        Ok(irlume_common::config::FaceSensorPolicy::Dual) => {
+            irlume_common::IrOnlyReadiness::Unavailable
+        }
+        Err(_) => irlume_common::IrOnlyReadiness::InvalidPolicy,
+    }
+}
+
 struct EngineBuildConfig {
     det: String,
     model: String,
     adapter: String,
+    adapter_required: bool,
     mesh: String,
     blaze: String,
     vit_pad: String,
@@ -389,6 +460,7 @@ fn build_engine_from_config(
     load_shipped_recognizer(&config.det, &config.model, recognizer)
         .map(|engine| engine.with_devices(&config.rgb_dev, &config.ir_dev))
         .and_then(|engine| engine.with_ir_adapter(&config.adapter))
+        .map(|engine| engine.with_ir_adapter_required(config.adapter_required))
         // FaceMesh load failure disables rescue alignment but not head
         // consent, which uses detector landmarks. Outside strict mode the
         // daemon therefore stays available; strict mode retains the explicit
@@ -416,6 +488,25 @@ fn build_engine_from_config(
         .map(|engine| load_pad_models(engine, &config.vit_pad, &config.pad_ir))
 }
 
+fn rebuild_engine_from_config(
+    config: &EngineBuildConfig,
+) -> irlume_common::Result<(
+    irlume_auth::Engine,
+    irlume_common::PadModelStatus,
+    irlume_common::PadModelStatus,
+)> {
+    // Re-establish the same manifest policy as startup before rebuilding ONNX
+    // sessions. Carry the recognizer bytes we actually hashed into its loader.
+    let recognizer = verify_models(
+        &models_to_verify(
+            [&config.det, &config.model, &config.mesh, &config.blaze],
+            &config.adapter,
+        ),
+        Some(&config.model),
+    );
+    build_engine_from_config(config, recognizer.as_ref())
+}
+
 fn main() {
     // FIRST, before models load. The watchdog deadline starts ticking the moment
     // systemd execs us, and loading the ONNX sessions takes tens of seconds on a
@@ -428,6 +519,7 @@ fn main() {
     let det = env_or("IRLUME_DET_MODEL", "/etc/irlume/det.onnx");
     let model = env_or("IRLUME_MODEL", "/etc/irlume/face.onnx");
     let adapter = env_or("IRLUME_IR_ADAPTER", "/etc/irlume/ir_adapter.onnx");
+    let adapter_required = std::env::var_os("IRLUME_IR_ADAPTER").is_some();
     let mesh = env_or(
         "IRLUME_MESH_MODEL",
         "/etc/irlume/face_landmarks_detector.tflite",
@@ -518,13 +610,14 @@ fn main() {
             // discovered Hello camera (built-in or external Brio/NexiGo). No node-number
             // fallback: a camera-less or RGB-only machine has no pair, and the
             // convenience tier falls back to the first discoverable RGB node.
-            let caps = irlume_auth::capabilities();
-            let (rgb_dev, ir_dev) = irlume_auth::select_pair().unwrap_or_else(|| {
-                (irlume_auth::select_rgb().unwrap_or_default(), String::new())
-            });
-            if !ir_dev.is_empty() {
+            let startup_policy = irlume_common::config::observe_face_sensor_policy();
+            let devices = select_engine_devices(startup_policy);
+            let (rgb_dev, ir_dev) = (devices.rgb, devices.ir);
+            if !permits_background_requalification(startup_policy) {
+                eprintln!("irlumed: camera discovery disabled by sensor policy; IR readiness is checked on request");
+            } else if !ir_dev.is_empty() {
                 eprintln!("irlumed: cameras rgb={rgb_dev} ir={ir_dev} (secure tier)");
-            } else if caps.rgb {
+            } else if devices.rgb_available {
                 eprintln!(
                     "irlumed: RGB-only camera, no IR pair (convenience tier: screen unlock only)"
                 );
@@ -563,13 +656,16 @@ fn main() {
             // the same measurement camera-tune runs, stored atomically,
             // and yields to any auth request via the camera lease. Cloned
             // because `build_engine` below moves the originals.
-            if !ir_dev.is_empty() {
+            if !ir_dev.is_empty() && permits_background_requalification(startup_policy) {
                 let rgb_for_requalify = rgb_dev.clone();
                 let ir_for_requalify = ir_dev.clone();
                 std::thread::Builder::new()
                     .name("irlume-requalify".into())
                     .spawn(move || {
                         std::thread::sleep(std::time::Duration::from_secs(60));
+                        if !permits_background_requalification(irlume_common::config::observe_face_sensor_policy()) {
+                            return;
+                        }
                         match irlume_auth::stored_capture_qualification(
                             &rgb_for_requalify,
                             &ir_for_requalify,
@@ -630,13 +726,14 @@ fn main() {
             // worker thread, and it is Fn, so startup calls it before that move.
             //
             // `recognizer` is what startup already read, hashed and verified
-            // (#346); the worker's post-panic rebuild passes None and re-reads
-            // the path, which is why the closure takes it as an argument instead
-            // of capturing it and holding 260MB for the daemon's life.
+            // (#346); None requests a fresh manifest check for a post-panic
+            // rebuild. Verified bytes are released after each build instead of
+            // holding 260MB for the daemon's life.
             let engine_config = EngineBuildConfig {
                 det,
                 model,
                 adapter,
+                adapter_required,
                 mesh,
                 blaze,
                 vit_pad: vit_pad_path,
@@ -645,7 +742,10 @@ fn main() {
                 ir_dev,
             };
             let build_engine = move |recognizer: Option<&irlume_common::HashedModel>| {
-                build_engine_from_config(&engine_config, recognizer)
+                match recognizer {
+                    Some(recognizer) => build_engine_from_config(&engine_config, Some(recognizer)),
+                    None => rebuild_engine_from_config(&engine_config),
+                }
             };
             // Bits are published before the socket binds (bind happens after the
             // models load), so no connection can observe the default EngineBits.
@@ -880,7 +980,8 @@ fn main() {
                                     // No bytes in hand here: the startup buffer
                                     // was released once the first session owned
                                     // its copy, so this rebuild re-reads the
-                                    // recognizer from disk (#346).
+                                    // recognizer from disk and repeats startup's
+                                    // manifest verification before loading (#346).
                                     //
                                     // Heartbeat around the rebuild: it re-reads
                                     // the 260MB recognizer and rebuilds five
@@ -909,10 +1010,10 @@ fn main() {
                                              with the existing engine"
                                         ),
                                     }
-                                    Response::Error("request failed".into())
+                                    Response::Error("request failed".into()).into()
                                 }
                             };
-                            scope.finish(categorical_outcome(&resp));
+                            scope.finish(categorical_outcome(&resp.response));
                             // The client may already be gone; its thread owns that.
                             let _ = reply.send(resp);
                             // Back to waiting for work: idle is healthy, and leaving the
@@ -1078,6 +1179,42 @@ fn recorded_face_response(
 ) -> Response {
     match record() {
         Ok(()) => complete(),
+        Err(reason) => refuse(reason),
+    }
+}
+
+/// Admit a prepared face response within its original request window.
+fn bounded_face_response(
+    granted: bool,
+    active: impl Fn() -> irlume_common::Result<()>,
+    prepare: impl FnOnce() -> Response,
+    record: impl FnOnce() -> Result<(), &'static str>,
+    refuse: fn(&str) -> Response,
+) -> Response {
+    if !granted {
+        return recorded_face_response(record, refuse, prepare);
+    }
+    if let Err(error) = active() {
+        return Response::Error(error.to_string());
+    }
+    let response = prepare();
+    if let Err(error) = active() {
+        return Response::Error(error.to_string());
+    }
+    // A failed TPM operation never publishes a credential or clears history.
+    // Prepared secret responses remain zeroizing owners on every refusal path.
+    if !matches!(
+        response,
+        Response::AuthResult { granted: true, .. } | Response::PasswordUnsealed { .. }
+    ) {
+        return response;
+    }
+    let recorded = record();
+    if let Err(error) = active() {
+        return Response::Error(error.to_string());
+    }
+    match recorded {
+        Ok(()) => response,
         Err(reason) => refuse(reason),
     }
 }
@@ -1335,13 +1472,82 @@ const MAX_REQUEST_BYTES: u64 = 64 * 1024;
 /// answer. The reply travels back over a channel rather than being written by
 /// the worker, so a client that stops reading stalls its own connection thread
 /// instead of the one thread every login needs.
+struct FaceCompletion {
+    attempt: retry_throttle::FaceAttempt,
+    window: irlume_auth::AuthenticationWindow,
+}
+
+struct WorkerReply {
+    response: Response,
+    completion: Option<FaceCompletion>,
+}
+
+impl std::fmt::Debug for WorkerReply {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("WorkerReply")
+    }
+}
+
+impl From<Response> for WorkerReply {
+    fn from(response: Response) -> Self {
+        Self {
+            response,
+            completion: None,
+        }
+    }
+}
+
+fn is_face_grant(response: &Response) -> bool {
+    matches!(
+        response,
+        Response::AuthResult { granted: true, .. } | Response::PasswordUnsealed { .. }
+    )
+}
+
+impl WorkerReply {
+    fn respond(self, stream: UnixStream) -> std::io::Result<()> {
+        let Some(completion) = self.completion.filter(|_| is_face_grant(&self.response)) else {
+            return respond(stream, &self.response);
+        };
+        let result = respond_admitted(stream, &self.response, |stream| {
+            let timeout = completion
+                .window
+                .remaining()
+                .unwrap_or(std::time::Duration::from_secs(15))
+                .min(std::time::Duration::from_secs(15));
+            if timeout.is_zero() {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "authentication window expired",
+                ));
+            }
+            stream.set_write_timeout(Some(timeout))?;
+            if peer_gone(stream) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::ConnectionAborted,
+                    "authentication client disconnected",
+                ));
+            }
+            // Last admission check, after serialization and before the first
+            // byte. A partial write cannot be retracted if expiry arrives later.
+            completion.window.check().map_err(std::io::Error::other)
+        });
+        if result.is_ok() && completion.attempt.delivered().is_err() {
+            // The admitted response cannot be retracted. Disk stays authoritative;
+            // retain conservative accounting and never send a second response.
+            eprintln!("irlumed: delivered face response; retry reset was not confirmed");
+        }
+        result
+    }
+}
+
 struct Queued {
     authorization: Option<operation_authorization::Grant>,
     session: Option<enrollment_session::Worker>,
     position: Option<position_session::Worker>,
     req: Request,
     peer: Peer,
-    reply: std::sync::mpsc::Sender<Response>,
+    reply: std::sync::mpsc::Sender<WorkerReply>,
     /// Lets the worker learn that this request's client has gone away.
     link: std::sync::Arc<ClientLink>,
     scope: diagnostics::OperationScope,
@@ -1359,46 +1565,55 @@ struct Queued {
 /// else's authentication.
 #[derive(Default)]
 struct ClientLink {
-    /// Set by the worker when this job starts and owns the camera.
-    running: std::sync::atomic::AtomicBool,
-    /// Set by the connection thread when its peer disconnects.
-    abandoned: std::sync::atomic::AtomicBool,
+    state: std::sync::Mutex<ClientState>,
+}
+
+#[derive(Default)]
+enum ClientState {
+    #[default]
+    Queued,
+    Running,
+    Abandoned,
+    Released,
 }
 
 impl ClientLink {
-    /// Worker side: take ownership of this job. `false` means the client already
-    /// left while the job sat in the queue, so the camera must never open for it.
+    fn lock(&self) -> std::sync::MutexGuard<'_, ClientState> {
+        self.state.lock().unwrap_or_else(|error| error.into_inner())
+    }
+
+    /// Worker side: take ownership only while the client is still waiting.
+    /// Claim and abandonment share one lock, so a disconnect cannot fall between
+    /// checking the client and marking the job as running.
     fn claim(&self) -> bool {
-        use std::sync::atomic::Ordering::{Acquire, Release};
-        if self.abandoned.load(Acquire) {
+        let mut state = self.lock();
+        if !matches!(*state, ClientState::Queued) {
             return false;
         }
-        self.running.store(true, Release);
+        *state = ClientState::Running;
         true
     }
 
-    /// Worker side: this job is done and no longer owns the camera. Keeps a late
-    /// disconnect on a finished job from cancelling whatever runs next.
+    /// Worker side: release this link before finishing the arbiter slot and
+    /// taking another job. No cancellation from this client can follow us past
+    /// this boundary into the next job's freshly reset shared token.
     fn released(&self) {
-        self.running
-            .store(false, std::sync::atomic::Ordering::Release);
+        *self.lock() = ClientState::Released;
     }
 
-    /// Connection side: the peer is gone. `true` means this job is RUNNING and the
-    /// capture should be cancelled; `false` means it is still queued and `claim`
-    /// will drop it, so nothing needs cancelling.
-    ///
-    /// Ordered abandoned-then-running against `claim`'s running-after-abandoned, so
-    /// the two cannot both decide to skip: whichever runs first, the job either
-    /// gets dropped by `claim` or cancelled here. The one interleaving that falls
-    /// through both (claim reads `abandoned` false, then this reads `running`
-    /// false, then claim stores `running`) lets the capture finish uncancelled,
-    /// which wastes the remaining budget but can never cancel a different job or
-    /// grant anything. Fail-safe by construction.
-    fn abandon(&self) -> bool {
-        use std::sync::atomic::Ordering::{Acquire, Release};
-        self.abandoned.store(true, Release);
-        self.running.load(Acquire)
+    /// Connection side: abandon this request and stop it if it owns the camera.
+    /// The stop signal MUST be written while holding the ownership lock. Returning
+    /// a decision for the caller to act on later lets the worker release this job
+    /// and start another before that caller writes the shared cancellation token.
+    /// The boolean is only for logging; cancellation is complete before return.
+    fn abandon(&self, stop: &arbiter::CancelToken) -> bool {
+        let mut state = self.lock();
+        let running = matches!(*state, ClientState::Running);
+        *state = ClientState::Abandoned;
+        if running {
+            stop.request_cancel();
+        }
+        running
     }
 }
 
@@ -1518,11 +1733,16 @@ mod worker_engine {
     /// attaching actually attaches.
     pub(super) trait StopSignalSink {
         fn accept_stop_signal(&mut self, signal: std::sync::Arc<dyn Fn() -> bool + Send + Sync>);
+        fn accept_cancel_signal(&mut self, signal: std::sync::Arc<dyn Fn() -> bool + Send + Sync>);
     }
 
     impl StopSignalSink for irlume_auth::Engine {
         fn accept_stop_signal(&mut self, signal: std::sync::Arc<dyn Fn() -> bool + Send + Sync>) {
             self.set_stop_signal(signal);
+        }
+
+        fn accept_cancel_signal(&mut self, signal: std::sync::Arc<dyn Fn() -> bool + Send + Sync>) {
+            self.set_request_cancel_signal(signal);
         }
     }
 
@@ -1564,6 +1784,8 @@ mod worker_engine {
         /// observes the same signal the arbiter is already setting.
         pub(super) fn attach(mut engine: E, arbiter: &arbiter::Arbiter<Queued>) -> Self {
             engine.accept_stop_signal(stop_signal(arbiter.cancel_token()));
+            let cancel = arbiter.cancel_token();
+            engine.accept_cancel_signal(std::sync::Arc::new(move || cancel.cancel_requested()));
             Self(engine)
         }
     }
@@ -2068,7 +2290,10 @@ mod worker_engine {
         /// Stands in for an `Engine`, which a test cannot build without the
         /// model files.
         #[derive(Default)]
-        struct Sink(Option<std::sync::Arc<dyn Fn() -> bool + Send + Sync>>);
+        struct Sink(
+            Option<std::sync::Arc<dyn Fn() -> bool + Send + Sync>>,
+            Option<std::sync::Arc<dyn Fn() -> bool + Send + Sync>>,
+        );
 
         impl StopSignalSink for Sink {
             fn accept_stop_signal(
@@ -2076,6 +2301,13 @@ mod worker_engine {
                 signal: std::sync::Arc<dyn Fn() -> bool + Send + Sync>,
             ) {
                 self.0 = Some(signal);
+            }
+
+            fn accept_cancel_signal(
+                &mut self,
+                signal: std::sync::Arc<dyn Fn() -> bool + Send + Sync>,
+            ) {
+                self.1 = Some(signal);
             }
         }
 
@@ -2113,6 +2345,22 @@ mod worker_engine {
             assert!(
                 signal(),
                 "a requested stop must be visible through the signal"
+            );
+            let cancelled = engine.0 .1.as_ref().expect("request cancellation signal");
+            assert!(
+                !cancelled(),
+                "queued authentication must not cancel running auth"
+            );
+            arb.cancel_token().reset();
+            arb.cancel_token().request_cancel();
+            assert!(
+                signal() && cancelled(),
+                "disconnect must stop both work classes"
+            );
+            arb.cancel_token().reset();
+            assert!(
+                !signal() && !cancelled(),
+                "the next job starts with neither signal"
             );
             super::super::note_worker_idle();
         }
@@ -2490,6 +2738,10 @@ fn dispatch_before_engine(req: Request, peer: &Peer) -> Response {
             have_password,
         } => unseal_keyring(&user, service.as_deref(), have_password, peer),
         Request::Ping => Response::Ok("starting".into()),
+        Request::FaceSensorStatus { user } => Response::FaceSensorStatus {
+            policy: irlume_common::config::observe_face_sensor_policy(),
+            ir_readiness: user.map(|_| irlume_common::IrOnlyReadiness::Unavailable),
+        },
         _ => Response::Error(
             "irlumed is still starting (loading models); retry, or use your password".into(),
         ),
@@ -2536,11 +2788,13 @@ fn serve_peer(
                 }
                 return serve_trace(stream, diagnostic_state, peer.uid, *duration_ms);
             }
-            // The recent-event ring exists before model/camera startup and is
-            // intentionally independent of engine readiness. Keep this one
-            // status request useful during startup instead of replacing its
-            // evidence with the generic "still starting" response.
-            if matches!(req, Request::SupportSnapshot { .. }) {
+            // The recent-event ring and saved sensor policy exist independently
+            // of model/camera readiness. Keep those observations available during
+            // startup instead of replacing them with a generic starting reply.
+            if matches!(
+                req,
+                Request::SupportSnapshot { .. } | Request::FaceSensorStatus { .. }
+            ) {
                 if let Some(resp) = pregate(&req, &peer) {
                     return respond(stream, &resp);
                 }
@@ -2549,6 +2803,16 @@ fn serve_peer(
                 {
                     return respond(stream, &resp);
                 }
+            }
+            if matches!(
+                req,
+                Request::RetryStatus { .. } | Request::RetryReset { .. }
+            ) {
+                if let Some(response) = pregate(&req, &peer) {
+                    return respond(stream, &response);
+                }
+                let response = retry_recovery::dispatch(&req, &peer, &stream);
+                return respond(stream, &response);
             }
             // No engine yet means no worker to queue for.
             if !engine_ready.load(std::sync::atomic::Ordering::Acquire) {
@@ -2629,17 +2893,13 @@ fn serve_peer(
             let resp = loop {
                 if let Some(connection) = &mut session_connection {
                     if let Err(error) = connection.pump(&stream) {
-                        if link.abandon() {
-                            arbiter.cancel_token().request_stop();
-                        }
+                        link.abandon(&arbiter.cancel_token());
                         return Err(error);
                     }
                 }
                 if let Some(connection) = &mut position_connection {
                     if let Err(error) = connection.pump(&stream) {
-                        if link.abandon() {
-                            arbiter.cancel_token().request_stop();
-                        }
+                        link.abandon(&arbiter.cancel_token());
                         return Err(error);
                     }
                 }
@@ -2655,20 +2915,17 @@ fn serve_peer(
                     }
                     Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
                         if std::time::Instant::now() >= deadline {
-                            if (session_connection.is_some() || position_connection.is_some())
-                                && link.abandon()
-                            {
-                                arbiter.cancel_token().request_stop();
+                            if session_connection.is_some() || position_connection.is_some() {
+                                link.abandon(&arbiter.cancel_token());
                             }
-                            break Response::Error("request did not complete".into());
+                            break Response::Error("request did not complete".into()).into();
                         }
                         if peer_gone(&stream) {
                             // Cancel ONLY if this connection's own job holds the
                             // camera; a job still queued is dropped by `claim`
                             // instead, so another user's authentication is never
                             // cancelled by someone else hanging up.
-                            if link.abandon() {
-                                arbiter.cancel_token().request_stop();
+                            if link.abandon(&arbiter.cancel_token()) {
                                 irlume_common::dlog!(
                                     "client disconnected mid-request; asked the capture to stop"
                                 );
@@ -2681,11 +2938,11 @@ fn serve_peer(
                     // came). This request has no answer, and a client that gets an
                     // error falls back to the password.
                     Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-                        break Response::Error("request did not complete".into())
+                        break Response::Error("request did not complete".into()).into()
                     }
                 }
             };
-            respond(stream, &resp)
+            resp.respond(stream)
         }
     }
 }
@@ -2922,6 +3179,13 @@ fn posture(req: &Request) -> RequestPosture<'_> {
             user: Some(user.as_str()),
             enrollment: Reads,
         },
+        RetryReset { user, .. } | RetryStatus { user } => RequestPosture {
+            user: Some(user),
+            privilege: RootOrTarget {
+                verb: "manage retry state for",
+            },
+            enrollment: Reads,
+        },
         HasSealedPassword { user } | KeyringInfo { user } | RecoveryStatus { user } => {
             RequestPosture {
                 privilege: RootOrTarget { verb: "query" },
@@ -3040,6 +3304,15 @@ fn posture(req: &Request) -> RequestPosture<'_> {
             user: user.as_deref(),
             enrollment: Reads,
         },
+        FaceSensorStatus { user } => RequestPosture {
+            privilege: if user.is_some() {
+                RootOrTarget { verb: "query" }
+            } else {
+                AnyPeer
+            },
+            user: user.as_deref(),
+            enrollment: Reads,
+        },
         Ping
         | Health
         | Identify
@@ -3089,16 +3362,11 @@ fn publish_engine_bits(
     rgb_pad: irlume_common::PadModelStatus,
     ir_pad: irlume_common::PadModelStatus,
 ) {
-    // One probe, at load, on the thread that owns the engine. Every later
-    // Health answer reads this copy.
-    let caps = irlume_auth::capabilities();
-    // The Hello pair when one was selected. On a camera-less or RGB-only
-    // machine there is no pair, so the convenience tier falls back to the
-    // first discoverable RGB node (never a guessed `/dev/videoN`).
-    let (rgb, ir) = irlume_auth::select_pair()
-        .unwrap_or_else(|| (irlume_auth::select_rgb().unwrap_or_default(), String::new()));
-    let rgb_dev = (caps.rgb && std::path::Path::new(&rgb).exists()).then_some(rgb);
-    let ir_dev = (caps.ir_pair && std::path::Path::new(&ir).exists()).then_some(ir);
+    // Dual retains its discovery path. Experimental IR uses configured sysfs
+    // evidence only; status publication must not cause an RGB camera open.
+    let devices = select_engine_devices(irlume_common::config::observe_face_sensor_policy());
+    let rgb_dev = devices.rgb_available.then_some(devices.rgb);
+    let ir_dev = devices.ir_available.then_some(devices.ir);
     let tier = if ir_dev.is_some() {
         "secure"
     } else if rgb_dev.is_some() {
@@ -3502,6 +3770,11 @@ fn dispatch_status_with_diagnostics(
         .unwrap_or_else(|e| e.into_inner())
         .clone();
     Some(match req {
+        Request::FaceSensorStatus { user: Some(_) } => return None,
+        Request::FaceSensorStatus { user: None } => Response::FaceSensorStatus {
+            policy: irlume_common::config::observe_face_sensor_policy(),
+            ir_readiness: None,
+        },
         Request::Ping => Response::Pong,
         Request::Health => {
             // MEMORY ONLY. The camera facts were probed once when the engine
@@ -4062,6 +4335,7 @@ fn diagnostic_operation_class(req: &Request) -> irlume_common::diagnostics::Oper
         | ListCameras
         | CameraDiagnostics => OperationClass::CameraDiagnostics,
         SetCameras { .. }
+        | FaceSensorStatus { .. }
         | ListProfiles { .. }
         | DeleteProfile { .. }
         | DeleteScan { .. }
@@ -4084,7 +4358,9 @@ fn diagnostic_operation_class(req: &Request) -> irlume_common::diagnostics::Oper
         | RecoverySetup { .. }
         | RecoveryRestore { .. }
         | RecoveryStatus { .. }
-        | RecoveryForget { .. } => OperationClass::Status,
+        | RecoveryForget { .. }
+        | RetryStatus { .. }
+        | RetryReset { .. } => OperationClass::Status,
     }
 }
 
@@ -4111,6 +4387,17 @@ fn categorical_outcome(response: &Response) -> irlume_common::diagnostics::Categ
     }
 }
 
+// Camera paths are persisted in a line-based configuration. Validate syntax
+// before changing the live engine so malformed input cannot inject another
+// setting or select a different path after restart. Empty selections retain
+// their existing meaning; device eligibility belongs to the capture layer.
+fn camera_path_is_serializable(path: &str) -> bool {
+    path.is_empty()
+        || (std::path::Path::new(path).is_absolute()
+            && path.trim() == path
+            && !path.chars().any(char::is_control))
+}
+
 #[cfg(test)]
 fn dispatch(req: Request, peer: &Peer, engine: &mut irlume_auth::Engine) -> Response {
     let state = diagnostics::DiagnosticState::default();
@@ -4128,7 +4415,9 @@ fn dispatch_scoped(
     scope: &diagnostics::OperationScope,
     authorization: Option<operation_authorization::Grant>,
 ) -> Response {
-    dispatch_scoped_session(req, peer, engine, scope, authorization, None, None)
+    // Returning a value is not delivery. An unacknowledged token is dropped
+    // conservatively; reset tests exercise the production socket responder.
+    dispatch_scoped_session(req, peer, engine, scope, authorization, None, None).response
 }
 
 fn dispatch_scoped_session(
@@ -4139,6 +4428,37 @@ fn dispatch_scoped_session(
     authorization: Option<operation_authorization::Grant>,
     session: Option<&enrollment_session::Worker>,
     position: Option<&position_session::Worker>,
+) -> WorkerReply {
+    let mut completion = None;
+    let response = dispatch_scoped_session_inner(
+        req,
+        peer,
+        engine,
+        scope,
+        authorization,
+        session,
+        position,
+        &mut completion,
+    );
+    if !is_face_grant(&response) {
+        completion = None;
+    }
+    WorkerReply {
+        response,
+        completion,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn dispatch_scoped_session_inner(
+    req: Request,
+    peer: &Peer,
+    engine: &mut irlume_auth::Engine,
+    scope: &diagnostics::OperationScope,
+    authorization: Option<operation_authorization::Grant>,
+    session: Option<&enrollment_session::Worker>,
+    position: Option<&position_session::Worker>,
+    completion: &mut Option<FaceCompletion>,
 ) -> Response {
     // Status requests are normally answered on the connection thread and
     // never reach here; delegating keeps this dispatch total (and identical
@@ -4223,6 +4543,9 @@ fn dispatch_scoped_session(
         invalidate_enrollment_summary(user);
     }
     match req {
+        Request::RetryStatus { .. } | Request::RetryReset { .. } => {
+            Response::Error("retry recovery requires its live connection".into())
+        }
         Request::EnrollmentSession { .. } => {
             Response::Error("guided enrollment requires its live connection".into())
         }
@@ -4231,6 +4554,7 @@ fn dispatch_scoped_session(
         // second implementation to drift.
         Request::Ping
         | Request::Health
+        | Request::FaceSensorStatus { user: None }
         | Request::HasSealedPassword { .. }
         | Request::RecoveryStatus { .. }
         | Request::SupportSnapshot { .. }
@@ -4247,6 +4571,14 @@ fn dispatch_scoped_session(
                 retryable: false,
             },
         },
+        Request::FaceSensorStatus { user: Some(user) } => {
+            let policy = irlume_common::config::observe_face_sensor_policy();
+            let readiness = sensor_preflight_with(policy, || engine.ir_only_preflight(&user));
+            Response::FaceSensorStatus {
+                policy,
+                ir_readiness: Some(readiness),
+            }
+        }
         Request::KeyringInfo { user } => {
             let armed = irlume_core::keyring::has_sealed_password(&user);
             let path = irlume_core::keyring::envelope_path(&user);
@@ -4361,11 +4693,17 @@ fn dispatch_scoped_session(
                     situation: String::new(),
                 };
             }
+            let sensor_policy = match irlume_common::config::observe_face_sensor_policy().resolve()
+            {
+                Ok(policy) => policy,
+                Err(error) => return retry_verify_refusal(&error.to_string()),
+            };
+            let tier = face_tier(sensor_policy, engine.tier());
             // Smart-Auto tier gate: on a CONVENIENCE (RGB-only) device, a face
             // match may ONLY satisfy a screen unlock; never login, elevation, or
             // a remote/unknown service (those keep the password). Always-on for
             // RGB-only hardware (independent of the opt-in biopolicy for IR boxes).
-            if engine.tier() == irlume_core::biopolicy::Tier::Convenience {
+            if tier == irlume_core::biopolicy::Tier::Convenience {
                 use irlume_core::biopolicy::{classify, OperationClass, SessionState};
                 // Warm = the user already has a running session (their systemd
                 // runtime dir exists); then an ambiguous greeter service (GDM
@@ -4410,7 +4748,7 @@ fn dispatch_scoped_session(
             // hardware (mirrors the credential-release gate); else a face grant
             // for a Remote/Unknown service would bypass the "face never satisfies
             // remote" invariant. Off by default (behaviour unchanged).
-            if biopolicy_enforced() && engine.tier() != irlume_core::biopolicy::Tier::Convenience {
+            if biopolicy_enforced() && tier != irlume_core::biopolicy::Tier::Convenience {
                 use irlume_core::biopolicy::{classify, decide, Action, SessionState, Tier};
                 let svc = service.as_deref().unwrap_or("");
                 if decide(classify(svc, SessionState::Cold), Tier::Secure) == Action::Deny {
@@ -4429,16 +4767,24 @@ fn dispatch_scoped_session(
                     };
                 }
             }
-            // Too many recent failures: don't fire the camera, fall to password.
-            if let Err(reason) = retry_throttle::check(&user) {
-                return retry_verify_refusal(reason);
-            }
-            let convenience = engine.tier() == irlume_core::biopolicy::Tier::Convenience;
+            let window = irlume_auth::AuthenticationWindow::for_service(service.as_deref());
+            let retry_attempt = match retry_throttle::FaceAttempt::for_user(&user) {
+                Ok(attempt) => attempt,
+                Err(reason) => return retry_verify_refusal(reason),
+            };
+            let convenience = tier == irlume_core::biopolicy::Tier::Convenience;
             let t = std::time::Instant::now();
-            match engine.authenticate_with_diagnostics(&user, service.as_deref(), scope) {
-                Ok(o) => recorded_face_response(
-                    || retry_throttle::record(&user, &o),
-                    retry_verify_refusal,
+            match engine.authenticate_for_in_window_with_policy(
+                &user,
+                service.as_deref(),
+                irlume_auth::AuthenticationPurpose::for_service(service.as_deref()),
+                window,
+                sensor_policy,
+                scope,
+            ) {
+                Ok(o) => bounded_face_response(
+                    o.granted,
+                    || engine.check_authentication_completion(window),
                     || {
                         if convenience || irlume_common::dbglog::on() {
                             // Denied score + reason measurements quantized/redacted
@@ -4478,6 +4824,18 @@ fn dispatch_scoped_session(
                             reason: o.reason.clone(),
                         }
                     },
+                    || {
+                        if o.granted {
+                            *completion = Some(FaceCompletion {
+                                attempt: retry_attempt,
+                                window,
+                            });
+                            Ok(())
+                        } else {
+                            retry_attempt.denied(&o)
+                        }
+                    },
+                    retry_verify_refusal,
                 ),
                 Err(e) => authentication_error(e, structured_errors),
             }
@@ -4518,6 +4876,12 @@ fn dispatch_scoped_session(
             // camera the daemon trusts, and an attacker who could set it to a
             // v4l2loopback node feeds recorded video into the match path
             // (spoof) or bricks face auth (DoS).
+            if !camera_path_is_serializable(&rgb) || !camera_path_is_serializable(&ir) {
+                return Response::Error(
+                    "camera paths must be empty or absolute, without control characters or surrounding whitespace"
+                        .into(),
+                );
+            }
             engine.set_devices(&rgb, &ir);
             let mut msg = format!("cameras set to rgb={rgb} ir={ir}");
             // Record each node's stable device identity (vid:pid:serial) next to
@@ -4713,6 +5077,8 @@ fn dispatch_scoped_session(
             user,
             password,
             kind,
+            wallet_salt,
+            wallet_salt_checked,
         } => {
             // Arming the keyring: root or the user themselves (posture table).
             // `password` zeroizes on drop, covering every return path.
@@ -4720,6 +5086,22 @@ fn dispatch_scoped_session(
             // Refuse to seal a password that is not the user's LOGIN password:
             // it would seal cleanly but fail later at wallet key-derive ("-9").
             // Only a POSITIVE mismatch blocks; an unverifiable hash proceeds.
+            if !wallet_salt_checked {
+                return Response::Error(
+                    "the client did not perform the required account-scoped wallet lookup; upgrade the irlume client and retry"
+                        .into(),
+                );
+            }
+            if let Some(forced) = kind {
+                if (forced == irlume_common::KeyringSecretKind::KdeWalletKey)
+                    != wallet_salt.is_some()
+                {
+                    return Response::Error(
+                        "a forced KDE wallet-key arm requires an account-scoped wallet salt, and other forced kinds forbid one"
+                            .into(),
+                    );
+                }
+            }
             if password_matches_login(&user, password.expose()) == Some(false) {
                 return Response::Error(format!(
                     "that is not '{user}'s current login password; the keyring is unlocked with \
@@ -4735,10 +5117,14 @@ fn dispatch_scoped_session(
             // did not force one, so a KDE-only machine gets the wallet key
             // without the client needing to know to ask.
             let home = crate::users::home_for_name(&user);
-            let core_kind = match kind {
+            let forced_kind = kind;
+            let core_kind = match forced_kind {
                 Some(k) => crate::users::wire_to_core_kind(k),
                 None => match home.as_deref() {
-                    Some(h) => irlume_core::kwallet::detect_kind(h),
+                    Some(h) => irlume_core::kwallet::detect_kind(h, wallet_salt.is_some()),
+                    None if wallet_salt.is_some() => {
+                        irlume_core::envelope::SecretKind::KdeWalletKey
+                    }
                     None => irlume_core::envelope::SecretKind::LoginPassword,
                 },
             };
@@ -4805,7 +5191,7 @@ fn dispatch_scoped_session(
                     irlume_core::keyring::derive_secret(
                         core_kind,
                         password.expose(),
-                        home.as_deref(),
+                        wallet_salt.as_ref().map(irlume_common::WalletSalt::expose),
                     )
                 }
             };
@@ -4837,6 +5223,12 @@ fn dispatch_scoped_session(
                     "face auth disabled: the configured method is fingerprint".into(),
                 );
             }
+            let sensor_policy = match irlume_common::config::observe_face_sensor_policy().resolve()
+            {
+                Ok(policy) => policy,
+                Err(error) => return Response::Error(error.to_string()),
+            };
+            let tier = face_tier(sensor_policy, engine.tier());
             // ALWAYS-ON: a polkit prompt never releases the sealed credential,
             // independent of the tier and the opt-in biopolicy below. The
             // A polkit agent can start PAM before conventional confirmation, so
@@ -4858,7 +5250,7 @@ fn dispatch_scoped_session(
             }
             // Smart-Auto: an RGB-only (convenience) device NEVER releases the
             // sealed credential: no cold-login / keyring unlock by RGB-only face.
-            if engine.tier() == irlume_core::biopolicy::Tier::Convenience {
+            if tier == irlume_core::biopolicy::Tier::Convenience {
                 eprintln!("irlumed: convenience(RGB-only) refuses credential release for '{user}' -> password");
                 return Response::UnsealUnavailable {
                     reason: "RGB-only convenience: face cannot release the login credential".into(),
@@ -4891,7 +5283,14 @@ fn dispatch_scoped_session(
                     ));
                 }
             }
-            do_unseal_password_scoped(&user, service.as_deref(), engine, scope)
+            do_unseal_password_scoped(
+                &user,
+                service.as_deref(),
+                engine,
+                scope,
+                completion,
+                sensor_policy,
+            )
         }
         Request::UnsealKeyring {
             user,
@@ -4921,18 +5320,32 @@ fn dispatch_scoped_session(
                 Err(e) => Response::Error(e.to_string()),
             }
         }
-        Request::ResealPassword { user, password } => {
+        Request::ResealPassword {
+            user,
+            password,
+            wallet_salt,
+            wallet_salt_checked,
+        } => {
             // Self-heal hook from the login SESSION phase (runs only after auth
             // succeeded, so `password` is verified-correct). Same authz as arming
             // (root or the user), but it can only ever *re-seal an already armed*
             // password against today's PCRs; it never arms a fresh user, so a
             // self-peer cannot use it to plant a sealed password they didn't set.
             //
-            // The home directory is where the KDE wallet salt lives; a
-            // login-password envelope ignores it, so an unresolvable home is
-            // only fatal for the wallet kind and reseal decides that itself.
-            let home = crate::users::home_for_name(&user);
-            match irlume_core::keyring::reseal_password(&user, password.expose(), home.as_deref()) {
+            // A KDE envelope can be re-derived only from the account-scoped
+            // salt supplied by this authenticated caller. Other envelope kinds
+            // ignore it; the daemon never opens the wallet path.
+            if !wallet_salt_checked {
+                return Response::Error(
+                    "the PAM client did not perform the required account-scoped wallet lookup; upgrade irlume before resealing"
+                        .into(),
+                );
+            }
+            match irlume_core::keyring::reseal_password(
+                &user,
+                password.expose(),
+                wallet_salt.as_ref().map(irlume_common::WalletSalt::expose),
+            ) {
                 Ok(outcome) => {
                     use irlume_core::keyring::Reseal;
                     if outcome == Reseal::Resealed {
@@ -5405,6 +5818,20 @@ fn deny_reason(r: &str) -> String {
     out
 }
 
+fn face_tier(
+    policy: irlume_common::config::FaceSensorPolicy,
+    detected: irlume_core::biopolicy::Tier,
+) -> irlume_core::biopolicy::Tier {
+    match policy {
+        irlume_common::config::FaceSensorPolicy::Dual => detected,
+        // Missing prerequisites still refuse in the IR pipeline. Selection
+        // must never route to convenience RGB when an IR target is absent.
+        irlume_common::config::FaceSensorPolicy::IrOnlyExperimental => {
+            irlume_core::biopolicy::Tier::Secure
+        }
+    }
+}
+
 /// Keep credential release distinct from session verification.
 fn credential_release_purpose() -> irlume_auth::AuthenticationPurpose {
     irlume_auth::AuthenticationPurpose::CredentialRelease
@@ -5424,7 +5851,11 @@ fn do_unseal_password(
 ) -> Response {
     let state = diagnostics::DiagnosticState::default();
     let scope = state.begin(irlume_common::diagnostics::OperationClass::Authentication);
-    do_unseal_password_scoped(user, service, engine, &scope)
+    let policy = match irlume_common::config::observe_face_sensor_policy().resolve() {
+        Ok(policy) => policy,
+        Err(error) => return Response::Error(error.to_string()),
+    };
+    do_unseal_password_scoped(user, service, engine, &scope, &mut None, policy)
 }
 
 fn do_unseal_password_scoped(
@@ -5432,6 +5863,8 @@ fn do_unseal_password_scoped(
     service: Option<&str>,
     engine: &mut irlume_auth::Engine,
     diagnostics: &dyn irlume_common::diagnostics::DiagnosticSink,
+    completion: &mut Option<FaceCompletion>,
+    sensor_policy: irlume_common::config::FaceSensorPolicy,
 ) -> Response {
     eprintln!("irlumed: UnsealPassword: attempt for '{user}'");
     let t = std::time::Instant::now();
@@ -5440,15 +5873,17 @@ fn do_unseal_password_scoped(
             reason: format!("no sealed password for '{user}': run `irlume keyring arm`"),
         };
     }
-    // Same failure throttle as the login/sudo path: after a run of failures,
-    // skip the camera and let PAM fall to the password.
-    if let Err(reason) = retry_throttle::check(user) {
-        return retry_unseal_refusal(reason);
-    }
-    let outcome = match engine.authenticate_for_with_diagnostics(
+    let window = irlume_auth::AuthenticationWindow::for_service(service);
+    let retry_attempt = match retry_throttle::FaceAttempt::for_user(user) {
+        Ok(attempt) => attempt,
+        Err(reason) => return retry_unseal_refusal(reason),
+    };
+    let outcome = match engine.authenticate_for_in_window_with_policy(
         user,
         service,
         credential_release_purpose(),
+        window,
+        sensor_policy,
         diagnostics,
     ) {
         Ok(o) => o,
@@ -5467,10 +5902,22 @@ fn do_unseal_password_scoped(
             return Response::Error(e.to_string());
         }
     };
-    recorded_face_response(
-        || retry_throttle::record(user, &outcome),
-        retry_unseal_refusal,
+    bounded_face_response(
+        outcome.granted,
+        || engine.check_authentication_completion(window),
         || finish_unseal_password(user, &outcome, t),
+        || {
+            if outcome.granted {
+                *completion = Some(FaceCompletion {
+                    attempt: retry_attempt,
+                    window,
+                });
+                Ok(())
+            } else {
+                retry_attempt.denied(&outcome)
+            }
+        },
+        retry_unseal_refusal,
     )
 }
 
@@ -5538,15 +5985,20 @@ fn is_pcr_drift(e: &irlume_common::Error) -> bool {
     irlume_core::tpm::is_pcr_mismatch(e)
 }
 
-fn respond(mut stream: UnixStream, resp: &Response) -> std::io::Result<()> {
-    let mut json = serde_json::to_vec(resp)?;
+fn respond(stream: UnixStream, resp: &Response) -> std::io::Result<()> {
+    respond_admitted(stream, resp, |_| Ok(()))
+}
+
+fn respond_admitted(
+    mut stream: UnixStream,
+    resp: &Response,
+    admit: impl FnOnce(&UnixStream) -> std::io::Result<()>,
+) -> std::io::Result<()> {
+    let mut json = zeroize::Zeroizing::new(serde_json::to_vec(resp)?);
     json.push(b'\n');
+    admit(&stream)?;
     stream.write_all(&json)?;
-    let r = stream.flush();
-    // The response may carry an unsealed secret (PasswordUnsealed); wipe the
-    // serialized line, same hygiene as the request path and the client side.
-    json.zeroize();
-    r
+    stream.flush()
 }
 
 /// Mode for the control socket. Every local uid may connect; `SO_PEERCRED`
@@ -5587,6 +6039,51 @@ fn journal_safe(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn authentication_budget_finalization_refuses_late_engine_tpm_and_persistence() {
+        use std::cell::Cell;
+        for stop_at in [0, 1, 2, 3] {
+            let stage = Cell::new(0);
+            let records = Cell::new(0);
+            let preparations = Cell::new(0);
+            let response = bounded_face_response(
+                true,
+                || {
+                    if stage.get() == stop_at {
+                        Err(irlume_common::Error::DeadlineExpired)
+                    } else {
+                        Ok(())
+                    }
+                },
+                || {
+                    preparations.set(preparations.get() + 1);
+                    stage.set(1);
+                    Response::PasswordUnsealed {
+                        kind: irlume_common::KeyringSecretKind::LoginPassword,
+                        secret: irlume_common::SecretBytes::new(b"synthetic-secret".to_vec()),
+                    }
+                },
+                || {
+                    records.set(records.get() + 1);
+                    stage.set(2);
+                    Ok(())
+                },
+                retry_unseal_refusal,
+            );
+            assert_eq!(
+                matches!(response, Response::PasswordUnsealed { .. }),
+                stop_at == 3,
+                "late success at stage {stop_at} must not escape"
+            );
+            assert_eq!(preparations.get(), usize::from(stop_at != 0));
+            assert_eq!(
+                records.get(),
+                usize::from(stop_at >= 2),
+                "late engine/TPM results must not clear history"
+            );
+        }
+    }
 
     /// The #340 trigger rule: enrollment probes exactly the unmeasured pair.
     /// A stored verdict of either value suppresses the probe entirely, which
@@ -5982,6 +6479,52 @@ mod tests {
     }
 
     #[test]
+    fn panic_rebuild_rechecks_missing_and_tampered_models_before_loading() {
+        const CHILD: &str = "IRLUME_TEST_REBUILD_MODEL_CHILD";
+        if let Ok(path) = std::env::var(CHILD) {
+            let config = EngineBuildConfig {
+                det: path.clone(),
+                model: path.clone(),
+                adapter: format!("{path}.absent-adapter"),
+                adapter_required: false,
+                mesh: path.clone(),
+                blaze: path.clone(),
+                vit_pad: path.clone(),
+                pad_ir: path,
+                rgb_dev: "/dev/irlume-test-none-rgb".into(),
+                ir_dev: "/dev/irlume-test-none-ir".into(),
+            };
+            let _ = rebuild_engine_from_config(&config);
+            panic!("strict rebuild must reject before the model loader returns");
+        }
+        let dir = std::env::temp_dir().join(format!("irlume-rebuild-model-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let tampered = dir.join("tampered.onnx");
+        std::fs::write(&tampered, b"unmanifested model bytes").unwrap();
+        for (path, expected) in [
+            (dir.join("missing.onnx"), "cannot read model"),
+            (tampered, "refusing to start with unverified models"),
+        ] {
+            let output = std::process::Command::new(std::env::current_exe().unwrap())
+                .args([
+                    "tests::panic_rebuild_rechecks_missing_and_tampered_models_before_loading",
+                    "--exact",
+                    "--nocapture",
+                    "--test-threads=1",
+                ])
+                .env(CHILD, path)
+                .env("IRLUME_MODELS_STRICT", "1")
+                .output()
+                .unwrap();
+            assert_eq!(output.status.code(), Some(1));
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            assert!(stderr.contains(expected), "unexpected refusal: {stderr}");
+            assert!(!stderr.contains("strict rebuild must reject"));
+        }
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
     fn strict_verification_rejects_damaged_pad_without_exiting() {
         let dir =
             std::env::temp_dir().join(format!("irlume-daemon-bad-pad-{}", std::process::id()));
@@ -6017,6 +6560,7 @@ mod tests {
                 .join("absent-adapter.onnx")
                 .to_string_lossy()
                 .into_owned(),
+            adapter_required: false,
             mesh: dir.join("absent-mesh.onnx").to_string_lossy().into_owned(),
             blaze: dir.join("absent-blaze.onnx").to_string_lossy().into_owned(),
             vit_pad: damaged_pad.to_string_lossy().into_owned(),
@@ -6534,7 +7078,7 @@ mod tests {
         //
         // `include_str!` and not a runtime read: a renamed or deleted module
         // is then a compile error rather than a silently smaller scan.
-        let sources: [(&str, &str); 8] = [
+        let sources: [(&str, &str); 10] = [
             ("main.rs", include_str!("main.rs")),
             ("users.rs", include_str!("users.rs")),
             (
@@ -6543,6 +7087,22 @@ mod tests {
                     include_str!("retry_throttle.rs"),
                     "\n",
                     include_str!("retry_throttle/tests.rs")
+                ),
+            ),
+            (
+                "recovery.rs",
+                concat!(
+                    include_str!("retry_throttle/recovery.rs"),
+                    "\n",
+                    include_str!("retry_throttle/recovery/tests.rs")
+                ),
+            ),
+            (
+                "retry_recovery.rs",
+                concat!(
+                    include_str!("retry_recovery.rs"),
+                    "\n",
+                    include_str!("retry_recovery/tests.rs")
                 ),
             ),
             ("arbiter.rs", include_str!("arbiter.rs")),
@@ -6565,8 +7125,11 @@ mod tests {
             "pregate(",
             "authorized_for(",
             "uid_of(",
-            "retry_throttle::check(",
+            "FaceAttempt::for_user(",
+            "Recovery::for_user(",
+            "dispatch_using(",
             "retry_throttle::record(",
+            "retry_throttle::record_if(",
             "account(",
             "uid_for_name(",
             "name_for_uid(",
@@ -6976,6 +7539,7 @@ mod tests {
         SetupIrEmitter => Request::SetupIrEmitter { dry_run: false },
         TuneCaptureMode => Request::TuneCaptureMode { rounds: None },
         CaptureModeStatus => Request::CaptureModeStatus,
+        FaceSensorStatus => Request::FaceSensorStatus { user: Some(u()) },
         SelfTest => Request::SelfTest {
             kind: irlume_common::SelfTestKind::Liveness,
         },
@@ -6993,6 +7557,8 @@ mod tests {
             user: u(),
             password: secret(),
             kind: None,
+            wallet_salt: None,
+            wallet_salt_checked: false,
         },
         UnsealPassword => Request::UnsealPassword {
             user: u(),
@@ -7013,6 +7579,8 @@ mod tests {
         ResealPassword => Request::ResealPassword {
             user: u(),
             password: secret(),
+            wallet_salt: None,
+            wallet_salt_checked: false,
         },
         RecoverySetup => Request::RecoverySetup {
             user: u(),
@@ -7024,6 +7592,8 @@ mod tests {
         },
         RecoveryStatus => Request::RecoveryStatus { user: u() },
         RecoveryForget => Request::RecoveryForget { user: u() },
+        RetryStatus => Request::RetryStatus { user: u() },
+        RetryReset => Request::RetryReset { user: u(), password: secret() },
     }
 
     /// Second shapes of variants the catalog already covers, where the posture
@@ -7035,6 +7605,7 @@ mod tests {
         vec![
             // No user to screen, and no band to tune to an account.
             Request::PositionSample { user: None },
+            Request::FaceSensorStatus { user: None },
             // The reading form, which any peer may send.
             Request::SetupIrEmitter { dry_run: true },
         ]
@@ -7506,7 +8077,7 @@ mod tests {
                         },
                         _ => Response::Pong,
                     };
-                    let _ = reply.send(resp);
+                    let _ = reply.send(resp.into());
                 }
             })
         };
@@ -7561,7 +8132,7 @@ mod tests {
             let arbiter = std::sync::Arc::clone(&arbiter);
             std::thread::spawn(move || {
                 while let Some(job) = arbiter.take() {
-                    let _ = job.payload.reply.send(Response::Ok("queued".into()));
+                    let _ = job.payload.reply.send(Response::Ok("queued".into()).into());
                     arbiter.finish(job.class, job.uid);
                 }
             })
@@ -7653,7 +8224,7 @@ mod tests {
                 while let Some(job) = arbiter.take() {
                     let Queued { reply, .. } = job.payload;
                     arbiter.finish(job.class, job.uid);
-                    let _ = reply.send(Response::Pong);
+                    let _ = reply.send(Response::Pong.into());
                 }
             })
         };
@@ -7899,7 +8470,7 @@ mod tests {
                 scope.finish(categorical_outcome(&response));
                 link.released();
                 authorized.finish(job.class, job.uid);
-                reply.send(response).unwrap();
+                reply.send(response.into()).unwrap();
             })
         };
         let request = Request::Authenticate {
@@ -8029,7 +8600,7 @@ mod tests {
                     scope.finish(categorical_outcome(&response));
                     link.released();
                     authorized.finish(job.class, job.uid);
-                    reply.send(response).unwrap();
+                    reply.send(response.into()).unwrap();
                 }
             })
         };
@@ -8099,6 +8670,7 @@ mod tests {
 
     #[test]
     fn a_departing_client_cancels_only_its_own_running_job() {
+        let stop = arbiter::CancelToken::new();
         // The cancellation token is shared by every job, so "the client left" may
         // only stop the capture when THIS connection's job is the one holding the
         // camera. Both orderings are pinned because the wrong one cancels a
@@ -8107,7 +8679,7 @@ mod tests {
         // Queued, then abandoned: nothing to cancel, and the worker must drop it.
         let queued = ClientLink::default();
         assert!(
-            !queued.abandon(),
+            !queued.abandon(&stop),
             "a job that never started must not cancel the running capture"
         );
         assert!(
@@ -8115,13 +8687,19 @@ mod tests {
             "the worker must skip a job whose client already left"
         );
 
+        assert!(!stop.stop_requested());
+
         // Running, then abandoned: this IS the camera holder, so cancel it.
         let running = ClientLink::default();
         assert!(running.claim(), "a fresh job is claimable");
         assert!(
-            running.abandon(),
+            running.abandon(&stop),
             "a running job's client leaving must cancel the capture"
         );
+
+        assert!(stop.stop_requested());
+        running.released();
+        stop.reset();
 
         // Finished, then a late disconnect: the job no longer owns the camera, so it
         // must not cancel whatever the worker started next.
@@ -8129,9 +8707,143 @@ mod tests {
         assert!(finished.claim());
         finished.released();
         assert!(
-            !finished.abandon(),
+            !finished.abandon(&stop),
             "a finished job must not cancel the job that followed it"
         );
+        assert!(!stop.stop_requested());
+    }
+
+    #[test]
+    fn cancellation_is_complete_before_the_connection_releases_ownership() {
+        let arbiter = arbiter::Arbiter::<()>::new();
+        let stop = arbiter.cancel_token();
+        let link = ClientLink::default();
+        arbiter.submit(arbiter::Class::Auth, 0, ()).unwrap();
+        let first = arbiter.take().unwrap();
+        assert!(link.claim());
+        assert!(link.abandon(&stop));
+        assert!(
+            stop.cancel_requested(),
+            "disconnect must signal under the same ownership guard, not later in its caller"
+        );
+        link.released();
+        arbiter.finish(first.class, first.uid);
+        arbiter.submit(arbiter::Class::Auth, 0, ()).unwrap();
+        let second = arbiter.take().unwrap();
+        assert!(!stop.stop_requested());
+        assert!(!link.abandon(&stop));
+        assert!(
+            !stop.stop_requested(),
+            "late disconnect cancelled the next job"
+        );
+        arbiter.finish(second.class, second.uid);
+    }
+
+    #[test]
+    fn racing_claim_and_disconnect_always_drop_or_stop_the_request() {
+        for _ in 0..256 {
+            let link = ClientLink::default();
+            let stop = arbiter::CancelToken::new();
+            let start = std::sync::Barrier::new(2);
+            let claimed = std::thread::scope(|threads| {
+                let worker = threads.spawn(|| {
+                    start.wait();
+                    link.claim()
+                });
+                start.wait();
+                link.abandon(&stop);
+                worker.join().unwrap()
+            });
+            assert_eq!(
+                claimed,
+                stop.stop_requested(),
+                "a disconnected request must either never start or receive a stop signal"
+            );
+            assert!(!link.claim(), "an abandoned request cannot restart");
+        }
+    }
+
+    #[test]
+    fn racing_disconnect_and_release_cannot_cancel_the_next_request() {
+        for _ in 0..256 {
+            let link = ClientLink::default();
+            let next = ClientLink::default();
+            let stop = arbiter::CancelToken::new();
+            let start = std::sync::Barrier::new(2);
+            assert!(link.claim());
+            std::thread::scope(|threads| {
+                let connection = threads.spawn(|| {
+                    start.wait();
+                    link.abandon(&stop);
+                });
+                start.wait();
+                // The single camera worker releases the old link before the
+                // arbiter resets the shared signal and starts the next job.
+                link.released();
+                stop.reset();
+                assert!(next.claim());
+                connection.join().unwrap();
+                assert!(!stop.stop_requested(), "cancel leaked into the next job");
+            });
+            next.released();
+            assert!(!next.claim(), "a completed request cannot restart");
+        }
+    }
+
+    #[test]
+    fn socket_disconnect_drops_queued_auth_and_stops_running_auth() {
+        // The real connection parser, peer gate, queue and disconnect poll run;
+        // a synthetic worker owns the job without opening a camera or TPM.
+        let _passwd = passwd_lock();
+        for running in [false, true] {
+            let arbiter = arbiter::Arbiter::<Queued>::new();
+            let ready = std::sync::atomic::AtomicBool::new(true);
+            let diagnostics = diagnostics::DiagnosticState::default();
+            let stop = arbiter.cancel_token();
+            let (mut client, server) = UnixStream::pair().unwrap();
+            let peer = peer_cred(&client).unwrap();
+            let user = users::name_for_uid(peer.uid).expect("test user exists");
+            let request = Request::Authenticate {
+                user,
+                service: Some("kde".into()),
+                intent_confirmation: None,
+                structured_errors: false,
+            };
+            let wire = serde_json::to_string(&request).unwrap() + "\n";
+            client.write_all(wire.as_bytes()).unwrap();
+            std::thread::scope(|threads| {
+                let arbiter = &arbiter;
+                let ready = &ready;
+                let diagnostics = &diagnostics;
+                let (completed, completion) = std::sync::mpsc::channel();
+                threads.spawn(move || {
+                    let result = serve(server, arbiter, ready, diagnostics);
+                    completed.send(result).unwrap();
+                });
+                let (taken, work) = std::sync::mpsc::channel();
+                threads.spawn(move || {
+                    let _ = taken.send(arbiter.take());
+                });
+                let job = work.recv_timeout(std::time::Duration::from_secs(5));
+                // Also wake the taker on a failing request, so a test failure
+                // cannot leave its scoped worker blocked in take().
+                arbiter.close();
+                let job = job.expect("request must queue").expect("queued job");
+                if running {
+                    assert!(job.payload.link.claim());
+                }
+                drop(client);
+                completion
+                    .recv_timeout(std::time::Duration::from_secs(5))
+                    .expect("disconnect must end the connection wait")
+                    .expect("closed clients need no reply");
+                assert_eq!(stop.stop_requested(), running);
+                assert_eq!(stop.cancel_requested(), running);
+                assert!(!job.payload.link.claim(), "departed client must not start");
+                job.payload.link.released();
+                arbiter.finish(job.class, job.uid);
+            });
+        }
     }
 
     #[test]
@@ -8429,6 +9141,230 @@ mod tests {
             cached_enrollment_summary(SAMPLE_USER).is_none(),
             "an authorized mutation must drop the summary before it runs"
         );
+    }
+
+    #[test]
+    fn sensor_policy_status_is_camera_free_and_preflight_cannot_claim_ready() {
+        let _guard = env_lock();
+        let sandbox = sandbox("sensor-status");
+        let _ = sandbox;
+        let arbiter = std::sync::Arc::new(arbiter::Arbiter::<Queued>::new());
+        let ready = std::sync::atomic::AtomicBool::new(false);
+        let early = with_serve(&arbiter, &ready, |ours| {
+            let bytes = serde_json::to_vec(&Request::FaceSensorStatus { user: None }).unwrap();
+            (&*ours).write_all(&bytes).unwrap();
+            (&*ours).write_all(b"\n").unwrap();
+            let mut line = String::new();
+            BufReader::new(ours).read_line(&mut line).unwrap();
+            serde_json::from_str::<Response>(&line).unwrap()
+        });
+        assert!(matches!(
+            early,
+            Response::FaceSensorStatus {
+                ir_readiness: None,
+                ..
+            }
+        ));
+        arbiter.close();
+        let response =
+            dispatch_status(&Request::FaceSensorStatus { user: None }, &peer(65534)).unwrap();
+        assert!(matches!(
+            response,
+            Response::FaceSensorStatus {
+                ir_readiness: None,
+                ..
+            }
+        ));
+        let response = dispatch_status(
+            &Request::FaceSensorStatus {
+                user: Some("root".into()),
+            },
+            &peer(65534),
+        )
+        .unwrap();
+        assert!(matches!(response, Response::Error(_)));
+        let response = dispatch_status(
+            &Request::FaceSensorStatus {
+                user: Some("root".into()),
+            },
+            &peer(0),
+        );
+        assert!(response.is_none());
+    }
+
+    #[test]
+    fn sensor_preflight_queues_for_real_worker_and_refuses_missing_target() {
+        let _guard = env_lock();
+        let sb = sandbox("sensor-worker-preflight");
+        std::fs::write(
+            sb.dir.join("config/settings.conf"),
+            "face_sensor_policy=ir-only-experimental\n",
+        )
+        .unwrap();
+        let request = Request::FaceSensorStatus {
+            user: Some(users::name_for_uid(0).unwrap()),
+        };
+        assert!(
+            dispatch_status(&request, &peer(0)).is_none(),
+            "explicit preflight must reach the worker"
+        );
+        let mut engine = engine();
+        let old_rgb = std::env::var_os("IRLUME_RGB_DEVICE");
+        let old_ir = std::env::var_os("IRLUME_IR_DEVICE");
+        std::env::set_var("IRLUME_RGB_DEVICE", NO_RGB);
+        std::env::set_var("IRLUME_IR_DEVICE", NO_IR);
+        let response = dispatch(request, &peer(0), &mut engine);
+        for (key, old) in [("IRLUME_RGB_DEVICE", old_rgb), ("IRLUME_IR_DEVICE", old_ir)] {
+            match old {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
+        }
+        assert!(matches!(
+            response,
+            Response::FaceSensorStatus {
+                ir_readiness: Some(irlume_common::IrOnlyReadiness::TargetUnavailable),
+                ..
+            }
+        ));
+        let wire = serde_json::to_value(response).unwrap();
+        let body = wire.get("FaceSensorStatus").unwrap().as_object().unwrap();
+        assert_eq!(body.len(), 2);
+        assert!(body.contains_key("policy") && body.contains_key("ir_readiness"));
+    }
+
+    #[test]
+    fn sensor_policy_controls_startup_publication_and_background_discovery() {
+        use irlume_common::config::{
+            FaceSensorPolicy as Policy, FaceSensorPolicyObservation as Seen,
+        };
+        let calls = std::cell::RefCell::new(Vec::new());
+        for policy in [
+            Seen::DefaultDual,
+            Seen::Explicit(Policy::Dual),
+            Seen::Explicit(Policy::IrOnlyExperimental),
+            Seen::Invalid,
+            Seen::Unreadable,
+        ] {
+            calls.borrow_mut().clear();
+            let devices = select_engine_devices_with(
+                policy,
+                || {
+                    calls.borrow_mut().push("discovery");
+                    EngineDevices {
+                        rgb: "dual-rgb".into(),
+                        ..EngineDevices::default()
+                    }
+                },
+                || {
+                    calls.borrow_mut().push("configured");
+                    EngineDevices {
+                        ir: "configured-ir".into(),
+                        ..EngineDevices::default()
+                    }
+                },
+            );
+            match policy.resolve() {
+                Ok(Policy::Dual) => {
+                    assert_eq!(*calls.borrow(), ["discovery"]);
+                    assert_eq!(devices.rgb, "dual-rgb");
+                }
+                Ok(Policy::IrOnlyExperimental) => {
+                    assert_eq!(*calls.borrow(), ["configured"]);
+                    assert_eq!(devices.ir, "configured-ir");
+                }
+                Err(_) => {
+                    assert!(calls.borrow().is_empty());
+                    assert_eq!(devices, EngineDevices::default());
+                }
+            }
+            assert_eq!(
+                permits_background_requalification(policy),
+                matches!(policy.resolve(), Ok(Policy::Dual))
+            );
+        }
+    }
+
+    #[test]
+    fn sensor_preflight_requires_selected_ir_policy_before_user_access() {
+        use irlume_common::config::{
+            FaceSensorPolicy as Policy, FaceSensorPolicyObservation as Seen,
+        };
+        use irlume_common::IrOnlyReadiness as Ready;
+        for policy in [
+            Seen::DefaultDual,
+            Seen::Explicit(Policy::Dual),
+            Seen::Explicit(Policy::IrOnlyExperimental),
+            Seen::Invalid,
+            Seen::Unreadable,
+        ] {
+            let calls = std::cell::Cell::new(0);
+            let readiness = sensor_preflight_with(policy, || {
+                calls.set(calls.get() + 1);
+                Ready::ReadyForExperimentalAttempt
+            });
+            let selected = policy == Seen::Explicit(Policy::IrOnlyExperimental);
+            assert_eq!(calls.get(), usize::from(selected));
+            assert_eq!(
+                readiness,
+                if selected {
+                    Ready::ReadyForExperimentalAttempt
+                } else if policy.resolve().is_err() {
+                    Ready::InvalidPolicy
+                } else {
+                    Ready::Unavailable
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn experimental_ir_refusals_charge_both_granting_routes_and_never_release_credentials() {
+        let _guard = env_lock();
+        let sb = sandbox("ir-granting-refusals");
+        let mut engine = engine();
+        let user = users::name_for_uid(0).unwrap();
+        plant_fake_envelope(&user);
+        let old_config = std::env::var_os("IRLUME_CONFIG_DIR");
+        let old_rgb = std::env::var_os("IRLUME_RGB_DEVICE");
+        let old_ir = std::env::var_os("IRLUME_IR_DEVICE");
+        std::env::set_var("IRLUME_CONFIG_DIR", &sb.dir);
+        std::env::set_var("IRLUME_RGB_DEVICE", "/dev/irlume-test-none-rgb");
+        std::env::set_var("IRLUME_IR_DEVICE", "/dev/irlume-test-none-ir");
+        std::fs::write(
+            sb.dir.join("settings.conf"),
+            "face_sensor_policy=ir-only-experimental\n",
+        )
+        .unwrap();
+        let verify = dispatch(
+            Request::Authenticate {
+                user: user.clone(),
+                service: Some("kde".into()),
+                intent_confirmation: None,
+                structured_errors: false,
+            },
+            &peer(0),
+            &mut engine,
+        );
+        let unseal = do_unseal_password(&user, None, &mut engine);
+        let record = std::fs::read(sb.dir.join("retry/0.json")).unwrap();
+        for (key, old) in [
+            ("IRLUME_CONFIG_DIR", old_config),
+            ("IRLUME_RGB_DEVICE", old_rgb),
+            ("IRLUME_IR_DEVICE", old_ir),
+        ] {
+            match old {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
+        }
+        assert!(
+            matches!(verify, Response::AuthResult { granted: false, reason, .. } if reason.contains("configured IR target"))
+        );
+        assert!(
+            matches!(unseal, Response::Error(reason) if reason.contains("configured IR target"))
+        );
+        assert_short_history_and_charge(&None, &record, 2, false);
     }
 
     #[test]
@@ -9084,7 +10020,7 @@ mod tests {
         );
         assert!(
             err.contains(
-                "verification is a one-time startup path check; only the recognizer bytes"
+                "verification runs before startup and post-panic rebuilds; only the recognizer"
             ),
             "the refusal must not claim every checked path stays verified through load: {err}"
         );
@@ -9260,6 +10196,18 @@ mod tests {
             .is_none(),
             "a real confirmation still passes"
         );
+
+        for invalid in ["", "typo", "2"] {
+            std::env::set_var("IRLUME_PRIVILEGED_FACE_CONSENT", invalid);
+            assert!(
+                intent_confirmation_gate(
+                    &sudo_with(Some(IntentAttestation::PolicyWaived)),
+                    &peer(0)
+                )
+                .is_some(),
+                "invalid policy {invalid:?} must not authorize a waiver"
+            );
+        }
 
         std::env::set_var("IRLUME_PRIVILEGED_FACE_CONSENT", "0");
         assert!(
@@ -9699,6 +10647,130 @@ mod tests {
     }
 
     #[test]
+    fn request_cancellation_charges_verify_and_unseal_before_engine_work() {
+        let _guard = env_lock();
+        let user = users::name_for_uid(0).expect("root NSS account");
+        let mut engine = engine();
+        for prior_rejection in [false, true] {
+            for unseal in [false, true] {
+                let sandbox = sandbox("cancelled-auth-retry");
+                plant_fake_envelope(&user);
+                if prior_rejection {
+                    retry_throttle::record(
+                        &user,
+                        &irlume_auth::Outcome {
+                            granted: false,
+                            live: true,
+                            score: 0.1,
+                            reason: "synthetic rejected match".into(),
+                            kind: irlume_auth::OutcomeKind::BelowThreshold,
+                        },
+                    )
+                    .unwrap();
+                }
+                let record = sandbox.dir.join("retry/0.json");
+                let read_history = || match std::fs::read(&record) {
+                    Ok(bytes) => Some(bytes),
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+                    Err(error) => panic!("retry history read failed: {error}"),
+                };
+                for n in 1..=6 {
+                    engine.set_request_cancel_signal(std::sync::Arc::new(|| true));
+                    let response = if unseal {
+                        do_unseal_password(&user, None, &mut engine)
+                    } else {
+                        dispatch(
+                            Request::Authenticate {
+                                structured_errors: false,
+                                user: user.clone(),
+                                service: Some("kde".into()),
+                                intent_confirmation: None,
+                            },
+                            &peer(0),
+                            &mut engine,
+                        )
+                    };
+                    engine.set_request_cancel_signal(std::sync::Arc::new(|| false));
+                    let allowance = 5 - u32::from(prior_rejection);
+                    if n <= allowance {
+                        assert!(
+                            matches!(&response, Response::Error(reason) if reason.contains("authentication cancelled")),
+                            "{response:?}"
+                        );
+                    } else {
+                        assert!(
+                            matches!(&response, Response::Error(reason) if reason == retry_throttle::LIMITED)
+                                || matches!(&response, Response::AuthResult {granted: false, refused_by_policy: true, reason, ..} if reason == retry_throttle::LIMITED),
+                            "{response:?}"
+                        );
+                    }
+                    let state: serde_json::Value =
+                        serde_json::from_slice(&read_history().unwrap()).unwrap();
+                    assert_eq!(state["budget"]["unsuccessful_requests"], n.min(allowance));
+                    assert_eq!(state["budget"]["pending"], n <= allowance);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn exhausted_face_budget_blocks_verify_and_unseal_before_engine_entry() {
+        let _guard = env_lock();
+        let user = users::name_for_uid(0).expect("root NSS account");
+        let mut engine = engine();
+        for unseal in [false, true] {
+            let sandbox = sandbox("exhausted-face-budget");
+            plant_fake_envelope(&user);
+            retry_throttle::record(
+                &user,
+                &irlume_auth::Outcome {
+                    granted: false,
+                    live: true,
+                    score: 0.1,
+                    reason: "synthetic rejection".into(),
+                    kind: irlume_auth::OutcomeKind::BelowThreshold,
+                },
+            )
+            .unwrap();
+            let path = sandbox.dir.join("retry/0.json");
+            let mut record: serde_json::Value =
+                serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+            record["version"] = 2.into();
+            record["strikes"] = 0.into();
+            record["budget"] = serde_json::json!({
+                "unsuccessful_requests": 50,
+                "pending": false
+            });
+            let before = serde_json::to_vec(&record).unwrap();
+            std::fs::write(&path, &before).unwrap();
+            // Engine entry would report cancellation. The durable ceiling must
+            // refuse first, without reaching that check or any engine setup.
+            engine.set_request_cancel_signal(std::sync::Arc::new(|| true));
+            let response = if unseal {
+                do_unseal_password(&user, None, &mut engine)
+            } else {
+                dispatch(
+                    Request::Authenticate {
+                        structured_errors: false,
+                        user: user.clone(),
+                        service: Some("kde".into()),
+                        intent_confirmation: None,
+                    },
+                    &peer(0),
+                    &mut engine,
+                )
+            };
+            engine.set_request_cancel_signal(std::sync::Arc::new(|| false));
+            assert!(
+                matches!(&response, Response::Error(reason) if reason == retry_throttle::LIMITED)
+                    || matches!(&response, Response::AuthResult {granted: false, refused_by_policy: true, reason, ..} if reason == retry_throttle::LIMITED),
+                "{response:?}"
+            );
+            assert_eq!(std::fs::read(path).unwrap(), before);
+        }
+    }
+
+    #[test]
     fn setup_refusals_preserve_verify_retry_history() {
         let _g = env_lock();
         setup_refusals_preserve_retry_history(false, false);
@@ -9759,7 +10831,7 @@ mod tests {
                 Err(error) => panic!("retry history read failed: {error}"),
             };
             let before = read_history();
-            for _ in 0..6 {
+            for count in 1..=6 {
                 let response = if unseal {
                     do_unseal_password(&user, None, &mut e)
                 } else {
@@ -9790,11 +10862,7 @@ mod tests {
                     }
                     other => panic!("setup must remain a terminal refusal: {other:?}"),
                 }
-                assert_eq!(
-                    read_history(),
-                    before,
-                    "setup refusal must neither create nor change retry history"
-                );
+                assert_short_history_and_charge(&before, &read_history().unwrap(), count, false);
             }
             // Repairing enrollment reaches the missing-camera boundary. It
             // must not replenish the account's prior face retry budget.
@@ -9816,8 +10884,31 @@ mod tests {
             assert!(
                 matches!(response, Response::Error(ref reason) if reason.contains("no camera found"))
             );
-            assert_eq!(read_history(), before);
+            assert_short_history_and_charge(&before, &read_history().unwrap(), 7, true);
         }
+    }
+
+    fn assert_short_history_and_charge(
+        before: &Option<Vec<u8>>,
+        after: &[u8],
+        count: u32,
+        pending: bool,
+    ) {
+        let before: serde_json::Value = before
+            .as_ref()
+            .map(|bytes| serde_json::from_slice(bytes).unwrap())
+            .unwrap_or_else(|| serde_json::json!({"strikes": 0, "cooldown": null}));
+        let after: serde_json::Value = serde_json::from_slice(after).unwrap();
+        assert_eq!(
+            after["strikes"], before["strikes"],
+            "neutral refusal preserves short strikes"
+        );
+        assert_eq!(
+            after["cooldown"], before["cooldown"],
+            "neutral refusal preserves short cooldown"
+        );
+        assert_eq!(after["budget"]["unsuccessful_requests"], count);
+        assert_eq!(after["budget"]["pending"], pending);
     }
 
     #[test]
@@ -10860,12 +11951,59 @@ mod tests {
                 kind: None,
                 user: "carol".into(),
                 password: irlume_common::SecretBytes::new(b"pw".to_vec()),
+                wallet_salt: None,
+                wallet_salt_checked: true,
             },
             &peer(NOBODY),
             &mut e,
         ) {
             Response::Error(msg) => assert_eq!(msg, "not authorized to seal password for 'carol'"),
             other => panic!("foreign peer must be refused, got {other:?}"),
+        }
+        match dispatch(
+            Request::SealPassword {
+                kind: None,
+                user: "carol".into(),
+                password: irlume_common::SecretBytes::new(b"pw".to_vec()),
+                wallet_salt: None,
+                wallet_salt_checked: false,
+            },
+            &peer(0),
+            &mut e,
+        ) {
+            Response::Error(msg) => assert!(msg.contains("upgrade"), "{msg}"),
+            other => panic!("an old client must fail closed, got {other:?}"),
+        }
+        match dispatch(
+            Request::SealPassword {
+                kind: Some(irlume_common::KeyringSecretKind::KdeWalletKey),
+                user: "carol".into(),
+                password: irlume_common::SecretBytes::new(b"pw".to_vec()),
+                wallet_salt: None,
+                wallet_salt_checked: true,
+            },
+            &peer(0),
+            &mut e,
+        ) {
+            Response::Error(msg) => assert!(msg.contains("requires"), "{msg}"),
+            other => panic!("forced KDE without salt must fail, got {other:?}"),
+        }
+        match dispatch(
+            Request::SealPassword {
+                kind: Some(irlume_common::KeyringSecretKind::LoginPassword),
+                user: "carol".into(),
+                password: irlume_common::SecretBytes::new(b"pw".to_vec()),
+                wallet_salt: irlume_common::WalletSalt::new(vec![
+                    0x5a;
+                    irlume_common::kwallet_wire::SALT_LEN
+                ]),
+                wallet_salt_checked: true,
+            },
+            &peer(0),
+            &mut e,
+        ) {
+            Response::Error(msg) => assert!(msg.contains("forbid"), "{msg}"),
+            other => panic!("forced login-password with salt must fail, got {other:?}"),
         }
         // The empty-password refusal fires before any TPM operation, so this
         // is safe (and deterministic) on every host.
@@ -10874,6 +12012,8 @@ mod tests {
                 kind: None,
                 user: "carol".into(),
                 password: irlume_common::SecretBytes::new(Vec::new()),
+                wallet_salt: None,
+                wallet_salt_checked: true,
             },
             &peer(0),
             &mut e,
@@ -10998,6 +12138,42 @@ mod tests {
         match do_unseal_password(&user, None, &mut e) {
             Response::Error(msg) => assert!(msg.contains("no camera found"), "{msg}"),
             other => panic!("missing camera must be an Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sensor_policy_errors_refuse_both_granting_routes_before_convenience_or_capture() {
+        let _guard = env_lock();
+        let mut engine = engine();
+        let sb = sandbox("sensor-policy-grant-refusal");
+        let user = users::name_for_uid(0).unwrap();
+        plant_fake_envelope(&user);
+        for contents in [b"face_sensor_policy=typo\n".as_slice(), b"\xff".as_slice()] {
+            std::fs::write(sb.dir.join("config/settings.conf"), contents).unwrap();
+            let verify = dispatch(
+                Request::Authenticate {
+                    user: user.clone(),
+                    service: Some("plasmalogin".into()),
+                    structured_errors: false,
+                    intent_confirmation: None,
+                },
+                &peer(0),
+                &mut engine,
+            );
+            assert!(
+                matches!(verify, Response::AuthResult { granted: false, refused_by_policy: true, ref reason, .. } if reason.contains("sensor policy"))
+            );
+            let unseal = dispatch(
+                Request::UnsealPassword {
+                    user: user.clone(),
+                    service: Some("plasmalogin".into()),
+                },
+                &peer(0),
+                &mut engine,
+            );
+            assert!(
+                matches!(unseal, Response::Error(ref reason) if reason.contains("sensor policy"))
+            );
         }
     }
 
@@ -11223,6 +12399,8 @@ mod tests {
             Request::ResealPassword {
                 user: "carol".into(),
                 password: irlume_common::SecretBytes::new(b"pw".to_vec()),
+                wallet_salt: None,
+                wallet_salt_checked: true,
             },
             &peer(0),
             &mut e,
@@ -11236,6 +12414,8 @@ mod tests {
             Request::ResealPassword {
                 user: "carol".into(),
                 password: irlume_common::SecretBytes::new(Vec::new()),
+                wallet_salt: None,
+                wallet_salt_checked: true,
             },
             &peer(0),
             &mut e,
@@ -11459,6 +12639,27 @@ mod tests {
     }
 
     #[test]
+    fn set_cameras_syntax_preserves_empty_stable_and_custom_paths() {
+        for path in [
+            "",
+            "/dev/video0",
+            "/dev/v4l/by-id/usb-camera-video-index0",
+            "/custom/camera with spaces",
+            "/custom/camera=ir",
+        ] {
+            assert!(camera_path_is_serializable(path), "{path:?}");
+        }
+        for path in [
+            "video0",
+            " /dev/video0",
+            "/dev/video0\n",
+            "/dev/video0\u{85}",
+        ] {
+            assert!(!camera_path_is_serializable(path), "{path:?}");
+        }
+    }
+
+    #[test]
     fn set_cameras_requires_root_then_repoints_and_persists() {
         let _g = env_lock();
         let mut e = engine();
@@ -11504,6 +12705,30 @@ mod tests {
             irlume_common::config::read_kv("cameras.conf", "ir").as_deref(),
             Some(ir)
         );
+        let pin_path = irlume_common::config::config_path("cameras.conf");
+        let pin_before = std::fs::read(&pin_path).unwrap();
+        for invalid in [
+            "/dev/video0\ncapture_mode=concurrent",
+            "/dev/video0\r",
+            "/dev/video0\0",
+            " /dev/video0",
+            "/dev/video0 ",
+            "video0",
+        ] {
+            for (bad_rgb, bad_ir) in [(invalid, ir), (rgb, invalid)] {
+                let response = dispatch(
+                    Request::SetCameras {
+                        rgb: bad_rgb.into(),
+                        ir: bad_ir.into(),
+                    },
+                    &peer(0),
+                    &mut e,
+                );
+                assert!(matches!(response, Response::Error(_)));
+                assert_eq!((e.rgb_device(), e.ir_device()), (rgb, ir));
+                assert_eq!(std::fs::read(&pin_path).unwrap(), pin_before);
+            }
+        }
         // Restore the shared engine's baseline devices.
         e.set_devices(NO_RGB, NO_IR);
     }
@@ -11732,6 +12957,8 @@ mod tests {
                 kind: None,
                 user: "carol".into(),
                 password: irlume_common::SecretBytes::new(secret.clone()),
+                wallet_salt: None,
+                wallet_salt_checked: true,
             },
             &root,
             &mut e,

--- a/crates/irlume-daemon/src/operation_authorization.rs
+++ b/crates/irlume-daemon/src/operation_authorization.rs
@@ -67,7 +67,7 @@ fn request_binding(req: &Request) -> Result<SecretBytes, String> {
 
 /// An open proc directory keeps lookups on the original process even if its
 /// numeric PID is reused. Every read also checks for exit and UID changes.
-struct Subject {
+pub(super) struct Subject {
     directory: File,
     pid: u32,
     uid: u32,
@@ -75,7 +75,7 @@ struct Subject {
 }
 
 impl Subject {
-    fn capture(peer: &Peer) -> Result<Self, String> {
+    pub(super) fn capture(peer: &Peer) -> Result<Self, String> {
         let pid = u32::try_from(peer.pid)
             .ok()
             .filter(|pid| *pid != 0)
@@ -119,7 +119,7 @@ impl Subject {
         parse_start(&self.read(c"stat")?).ok_or_else(|| REFUSED.into())
     }
 
-    fn validate(&self, peer: &Peer) -> Result<(), String> {
+    pub(super) fn validate(&self, peer: &Peer) -> Result<(), String> {
         if peer.pid <= 0
             || peer.pid as u32 != self.pid
             || peer.uid != self.uid

--- a/crates/irlume-daemon/src/retry_recovery.rs
+++ b/crates/irlume-daemon/src/retry_recovery.rs
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! Connection-bound password verification. Never occupies the camera worker.
+
+use std::io::{Read, Write};
+use std::os::unix::fs::MetadataExt;
+use std::os::unix::net::UnixStream;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use super::{operation_authorization::Subject, pregate, retry_throttle::recovery::Recovery, Peer};
+use irlume_common::{Request, Response};
+
+const HELPER: &str = "/usr/libexec/irlume-password-verify";
+const SERVICE: &str = "/etc/pam.d/irlume-retry-reset";
+const UNAVAILABLE: &str = "password-only retry recovery is unavailable; use your password for normal login or ask an administrator";
+const REFUSED: &str = "password verification failed or was cancelled; retry state unchanged";
+const BUDGET: Duration = Duration::from_secs(12);
+
+fn trusted(path: &Path, executable: bool) -> bool {
+    // Both the configured path and resolved target must stay inside root-owned,
+    // non-writable ancestry (Nix and distribution libexec symlinks are allowed).
+    let Ok(resolved) = path.canonicalize() else {
+        return false;
+    };
+    for item in path.ancestors().chain(resolved.ancestors()) {
+        let Ok(m) = item.metadata() else {
+            return false;
+        };
+        if m.uid() != 0 || m.mode() & 0o022 != 0 {
+            return false;
+        }
+    }
+    let Ok(m) = resolved.metadata() else {
+        return false;
+    };
+    m.is_file() && m.mode() & 0o6000 == 0 && (!executable || m.mode() & 0o111 != 0)
+}
+
+fn available_at(helper: &Path, service: &Path) -> bool {
+    if !trusted(helper, true) || !trusted(service, false) {
+        return false;
+    }
+    let Ok(file) = std::fs::File::open(service) else {
+        return false;
+    };
+    let mut bytes = Vec::new();
+    if file.take(4097).read_to_end(&mut bytes).is_err() {
+        return false;
+    }
+    if bytes.len() > 4096 {
+        return false;
+    }
+    let Ok(text) = std::str::from_utf8(&bytes) else {
+        return false;
+    };
+    supported_service(text)
+}
+
+fn supported_service(text: &str) -> bool {
+    let rules: Vec<Vec<&str>> = text
+        .lines()
+        .map(|l| l.split('#').next().unwrap_or_default())
+        .map(|l| l.split_whitespace().collect::<Vec<_>>())
+        .filter(|l| !l.is_empty())
+        .collect();
+    rules
+        == [
+            vec!["auth", "required", "pam_unix.so", "nodelay"],
+            vec!["account", "required", "pam_unix.so"],
+        ]
+}
+
+fn available() -> bool {
+    // Keep NoNewPrivileges and existing confinement. An enforcing AppArmor
+    // transition needs separate runtime qualification before self-service use.
+    if super::apparmor_confinement().is_some_and(|label| label.contains("(enforce)")) {
+        return false;
+    }
+    available_at(Path::new(HELPER), Path::new(SERVICE))
+}
+
+fn verify(user: &str, password: &[u8], active: impl Fn() -> bool) -> Result<(), &'static str> {
+    if !available() {
+        return Err(UNAVAILABLE);
+    }
+    run_helper(Path::new(HELPER), user, password, BUDGET, active)
+}
+
+fn run_helper(
+    helper: &Path,
+    user: &str,
+    password: &[u8],
+    budget: Duration,
+    active: impl Fn() -> bool,
+) -> Result<(), &'static str> {
+    if password.is_empty() || password.len() > 4096 || password.contains(&0) || !active() {
+        return Err(REFUSED);
+    }
+    let mut child = Command::new(helper)
+        .arg(user)
+        .env_clear()
+        .env("LANG", "C")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|_| UNAVAILABLE)?;
+    let deadline = Instant::now() + budget;
+    // Linux pipes accommodate this bounded payload without waiting for the
+    // reader; no unbounded stream is accepted. EOF terminates the secret.
+    let written = child
+        .stdin
+        .take()
+        .ok_or(REFUSED)
+        .and_then(|mut pipe| pipe.write_all(password).map_err(|_| REFUSED));
+    if written.is_err() {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(REFUSED);
+    }
+    loop {
+        if !active() || Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(REFUSED);
+        }
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                return if status.success() && active() {
+                    Ok(())
+                } else {
+                    Err(REFUSED)
+                }
+            }
+            Ok(None) => std::thread::sleep(Duration::from_millis(20)),
+            Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(REFUSED);
+            }
+        }
+    }
+}
+
+pub(super) fn dispatch(req: &Request, peer: &Peer, stream: &UnixStream) -> Response {
+    dispatch_using(req, peer, stream, available(), |user, password, active| {
+        verify(user, password, active)
+    })
+}
+
+fn dispatch_using(
+    req: &Request,
+    peer: &Peer,
+    stream: &UnixStream,
+    is_available: bool,
+    verifier: impl FnOnce(&str, &[u8], &dyn Fn() -> bool) -> Result<(), &'static str>,
+) -> Response {
+    if let Some(response) = pregate(req, peer) {
+        return response;
+    }
+    let user = match req {
+        Request::RetryStatus { user } | Request::RetryReset { user, .. } => user,
+        _ => return Response::Error(UNAVAILABLE.into()),
+    };
+    let gate = match Recovery::for_user(user) {
+        Ok(gate) => gate,
+        Err(e) => return Response::Error(e.into()),
+    };
+    if matches!(req, Request::RetryStatus { .. }) {
+        return match gate.status() {
+            Ok(s) => Response::RetryStatus {
+                face_budget: Some(s.face_budget),
+                failures: s.failures,
+                cooldown_seconds: s.cooldown_seconds,
+                recovery_failures: s.recovery_failures,
+                recovery_cooldown_seconds: s.recovery_cooldown_seconds,
+                recovery_required: s.recovery_required,
+                password_reset_available: is_available,
+            },
+            Err(e) => Response::Error(e.into()),
+        };
+    }
+    let Request::RetryReset { password, .. } = req else {
+        unreachable!()
+    };
+    if peer.uid != 0 && !is_available {
+        return Response::Error(UNAVAILABLE.into());
+    }
+    let _slot = match Slot::acquire() {
+        Some(slot) => slot,
+        None => {
+            return Response::Error("another retry recovery is pending; try again shortly".into())
+        }
+    };
+    let binding = match Subject::capture(peer) {
+        Ok(b) => b,
+        Err(_) => return Response::Error(REFUSED.into()),
+    };
+    let deadline = Instant::now() + BUDGET;
+    let active =
+        || Instant::now() < deadline && connection_active(stream) && binding.validate(peer).is_ok();
+    match gate.reset(peer.uid == 0, active, || {
+        verifier(user, password.expose(), &active)
+    }) {
+        Ok(()) => Response::Ok("face retry state reset".into()),
+        Err(e) => Response::Error(e.into()),
+    }
+}
+
+/// Detect a closed write side even when unconsumed input hides EOF from recv.
+/// Recovery clients retain the full connection until the reset response.
+fn connection_active(stream: &UnixStream) -> bool {
+    use std::os::fd::AsRawFd;
+    let mut fd = libc::pollfd {
+        fd: stream.as_raw_fd(),
+        events: libc::POLLRDHUP,
+        revents: 0,
+    };
+    // SAFETY: fd is one initialized pollfd, held exclusively for this call;
+    // stream keeps its descriptor alive and a zero timeout cannot block.
+    let result = unsafe { libc::poll(&mut fd, 1, 0) };
+    result >= 0
+        && fd.revents & (libc::POLLRDHUP | libc::POLLHUP | libc::POLLERR | libc::POLLNVAL) == 0
+}
+
+static PENDING: std::sync::Mutex<usize> = std::sync::Mutex::new(0);
+struct Slot;
+impl Slot {
+    fn acquire() -> Option<Self> {
+        let mut n = PENDING.lock().ok()?;
+        if *n >= 8 {
+            return None;
+        }
+        *n += 1;
+        Some(Self)
+    }
+}
+impl Drop for Slot {
+    fn drop(&mut self) {
+        if let Ok(mut n) = PENDING.lock() {
+            *n -= 1;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/irlume-daemon/src/retry_recovery/tests.rs
+++ b/crates/irlume-daemon/src/retry_recovery/tests.rs
@@ -1,0 +1,261 @@
+use super::*;
+use std::os::unix::fs::PermissionsExt;
+use std::sync::atomic::{AtomicU64, Ordering};
+static SERIAL: AtomicU64 = AtomicU64::new(0);
+fn env_lock() -> std::sync::RwLockWriteGuard<'static, ()> {
+    crate::test_support::env_write()
+}
+struct Fixture {
+    path: std::path::PathBuf,
+    old: Option<std::ffi::OsString>,
+}
+impl Fixture {
+    fn new() -> Self {
+        let path = std::env::temp_dir().join(format!(
+            "irlume-retry-dispatch-{}-{}",
+            std::process::id(),
+            SERIAL.fetch_add(1, Ordering::SeqCst)
+        ));
+        std::fs::create_dir(&path).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o700)).unwrap();
+        let old = std::env::var_os("IRLUME_STATE_DIR");
+        std::env::set_var("IRLUME_STATE_DIR", &path);
+        Self { path, old }
+    }
+    fn face(&self, peer: &Peer, user: &str) -> std::path::PathBuf {
+        let dir = self.path.join("retry");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+        let file = dir.join(format!("{}.json", peer.uid));
+        irlume_common::write_atomic_reporting(&file,serde_json::to_string(&serde_json::json!({"version":1,"uid":peer.uid,"account":user,"strikes":4,"cooldown":null})).unwrap().as_bytes(),0o600).unwrap();
+        file
+    }
+    fn helper(&self, body: &str) -> std::path::PathBuf {
+        let file = self.path.join("helper");
+        std::fs::write(&file, format!("#!/bin/sh\n{body}\n")).unwrap();
+        std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o700)).unwrap();
+        file
+    }
+}
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        match &self.old {
+            Some(v) => std::env::set_var("IRLUME_STATE_DIR", v),
+            None => std::env::remove_var("IRLUME_STATE_DIR"),
+        }
+        std::fs::remove_dir_all(&self.path).unwrap();
+    }
+}
+fn peer() -> Peer {
+    // SAFETY: credential getters have no preconditions.
+    let (uid, gid) = unsafe { (libc::getuid(), libc::getgid()) };
+    Peer {
+        uid,
+        gid,
+        pid: std::process::id() as i32,
+    }
+}
+#[test]
+fn own_account_reset_binds_password_proof_and_preserves_state_on_refusal() {
+    let _env = env_lock();
+    let f = Fixture::new();
+    let peer = peer();
+    let user = crate::users::name_for_uid(peer.uid).unwrap();
+    let face = f.face(&peer, &user);
+    let (_client, server) = UnixStream::pair().unwrap();
+    let request = Request::RetryReset {
+        user: user.clone(),
+        password: irlume_common::SecretBytes::new(b"synthetic password".to_vec()),
+    };
+    if peer.uid != 0 {
+        let result = dispatch_using(&request, &peer, &server, true, |u, p, active| {
+            assert_eq!(u, user);
+            assert_eq!(p, b"synthetic password");
+            assert!(active());
+            Err(REFUSED)
+        });
+        assert!(matches!(result, Response::Error(_)));
+        let value: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&face).unwrap()).unwrap();
+        assert_eq!(value["strikes"], 4);
+    }
+    let result = dispatch_using(&request, &peer, &server, true, |_, _, active| {
+        assert!(active());
+        Ok(())
+    });
+    assert!(matches!(result, Response::Ok(_)), "{result:?}");
+    let value: serde_json::Value = serde_json::from_slice(&std::fs::read(face).unwrap()).unwrap();
+    assert_eq!(value["strikes"], 0);
+}
+#[test]
+fn cross_account_reset_refuses_before_creating_state_or_verifying() {
+    let _env = env_lock();
+    let f = Fixture::new();
+    let owner = peer();
+    let user = crate::users::name_for_uid(owner.uid).unwrap();
+    let other = Peer {
+        uid: owner.uid + 1,
+        gid: owner.gid,
+        pid: owner.pid,
+    };
+    let (_client, server) = UnixStream::pair().unwrap();
+    let request = Request::RetryReset {
+        user,
+        password: irlume_common::SecretBytes::new(b"synthetic".to_vec()),
+    };
+    let result = dispatch_using(&request, &other, &server, true, |_, _, _| {
+        panic!("unauthorized verifier")
+    });
+    assert!(matches!(result,Response::Error(ref e) if e.contains("not authorized")));
+    assert!(!f.path.join("retry").exists());
+}
+#[test]
+fn disconnected_client_cannot_reset_or_verify() {
+    let _env = env_lock();
+    let f = Fixture::new();
+    let peer = peer();
+    let user = crate::users::name_for_uid(peer.uid).unwrap();
+    let face = f.face(&peer, &user);
+    let (client, server) = UnixStream::pair().unwrap();
+    drop(client);
+    let request = Request::RetryReset {
+        user,
+        password: irlume_common::SecretBytes::new(b"synthetic".to_vec()),
+    };
+    assert!(matches!(
+        dispatch_using(&request, &peer, &server, true, |_, _, _| panic!(
+            "disconnected verifier"
+        )),
+        Response::Error(_)
+    ));
+    let value: serde_json::Value = serde_json::from_slice(&std::fs::read(face).unwrap()).unwrap();
+    assert_eq!(value["strikes"], 4);
+}
+#[test]
+fn verifier_timeout_kills_and_reaps_the_exact_process() {
+    let _env = env_lock();
+    let f = Fixture::new();
+    let pidfile = f.path.join("pid");
+    let helper = f.helper(&format!(
+        "echo $$ > '{}'\nexec /bin/sleep 60",
+        pidfile.display()
+    ));
+    let t = Instant::now();
+    assert!(run_helper(
+        &helper,
+        "fixture",
+        b"synthetic",
+        Duration::from_millis(100),
+        || true
+    )
+    .is_err());
+    assert!(t.elapsed() < Duration::from_secs(3));
+    let pid = std::fs::read_to_string(pidfile).unwrap();
+    assert!(!Path::new("/proc").join(pid.trim()).exists());
+}
+#[test]
+fn helper_exit_status_and_cancel_control_verification() {
+    let _env = env_lock();
+    let f = Fixture::new();
+    let success = f.helper("exit 0");
+    assert!(run_helper(
+        &success,
+        "fixture",
+        b"synthetic",
+        Duration::from_secs(2),
+        || true
+    )
+    .is_ok());
+    assert!(run_helper(
+        &success,
+        "fixture",
+        b"synthetic",
+        Duration::from_secs(2),
+        || false
+    )
+    .is_err());
+    let failure = f.helper("exit 1");
+    assert!(run_helper(
+        &failure,
+        "fixture",
+        b"synthetic",
+        Duration::from_secs(2),
+        || true
+    )
+    .is_err());
+    assert!(run_helper(&success, "fixture", b"", Duration::from_secs(2), || true).is_err());
+}
+
+#[test]
+fn only_the_qualified_password_service_is_accepted() {
+    let exact = "auth required pam_unix.so nodelay\naccount required pam_unix.so\n";
+    assert!(supported_service(exact));
+    assert!(supported_service("# local passwords\n auth   required pam_unix.so nodelay # no PAM delay\n\naccount required pam_unix.so\n"));
+    for unsupported in [
+        exact.replace("nodelay", "nullok"),
+        exact.replace("required", "sufficient"),
+        exact.replace("pam_unix.so", "pam_irlume.so"),
+        exact.replace(
+            "account required pam_unix.so",
+            "account include system-auth",
+        ),
+        format!("{exact}auth optional pam_permit.so\n"),
+        "auth required pam_unix.so nodelay\n".into(),
+    ] {
+        assert!(!supported_service(&unsupported), "{unsupported}");
+    }
+}
+
+#[test]
+fn retry_status_answers_while_models_are_not_ready() {
+    use std::io::BufRead;
+    let _env = env_lock();
+    let _fixture = Fixture::new();
+    let user = crate::users::name_for_uid(peer().uid).unwrap();
+    let arbiter = crate::arbiter::Arbiter::<crate::Queued>::new();
+    let ready = std::sync::atomic::AtomicBool::new(false);
+    let diagnostic = crate::diagnostics::DiagnosticState::default();
+    std::thread::scope(|scope| {
+        let (mut client, server) = UnixStream::pair().unwrap();
+        let worker = scope.spawn(|| crate::serve(server, &arbiter, &ready, &diagnostic).unwrap());
+        client
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .unwrap();
+        let wire = serde_json::to_vec(&Request::RetryStatus { user }).unwrap();
+        client.write_all(&wire).unwrap();
+        client.write_all(b"\n").unwrap();
+        let mut line = String::new();
+        std::io::BufReader::new(&client)
+            .read_line(&mut line)
+            .unwrap();
+        let response: Response = serde_json::from_str(&line).unwrap();
+        assert!(
+            matches!(response, Response::RetryStatus { failures: 0, .. }),
+            "{response:?}"
+        );
+        drop(client);
+        worker.join().unwrap();
+    });
+}
+
+#[test]
+fn buffered_input_cannot_hide_client_disconnect_from_reset() {
+    let _env = env_lock();
+    let f = Fixture::new();
+    let peer = peer();
+    let user = crate::users::name_for_uid(peer.uid).unwrap();
+    let face = f.face(&peer, &user);
+    let (mut client, server) = UnixStream::pair().unwrap();
+    client.write_all(b"extra").unwrap();
+    drop(client);
+    let request = Request::RetryReset {
+        user,
+        password: irlume_common::SecretBytes::new(b"synthetic".to_vec()),
+    };
+    let result = dispatch_using(&request, &peer, &server, true, |_, _, _| {
+        panic!("closed connection must not verify")
+    });
+    assert!(matches!(result, Response::Error(_)));
+    let value: serde_json::Value = serde_json::from_slice(&std::fs::read(face).unwrap()).unwrap();
+    assert_eq!(value["strikes"], 4);
+}

--- a/crates/irlume-daemon/src/retry_throttle.rs
+++ b/crates/irlume-daemon/src/retry_throttle.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright the irlume contributors.
 
-//! Recorded account failures survive daemon restarts. Terminal recording is not
-//! a write-ahead reservation of every matcher opportunity or an overall ceiling.
+//! Account requests are charged durably before face work. Ambiguous completion
+//! keeps its charge; only an admitted response or verified recovery resets it.
 //! Disk is authoritative: no cached counter can disagree with a visible rename.
 
 use irlume_common::{write_atomic_reporting, AtomicWrite};
@@ -13,8 +13,11 @@ use std::os::fd::AsRawFd;
 use std::os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt};
 use std::path::{Path, PathBuf};
 
+pub(crate) mod recovery;
+
 const MAX_RECORD: u64 = 4096;
 const NANOS: u64 = 1_000_000_000;
+const FACE_LIMIT: u32 = 50;
 pub(crate) const UNAVAILABLE: &str =
     "face retry state unavailable; use your password and ask an administrator to check /var/lib/irlume/retry";
 pub(crate) const LIMITED: &str = "too many recent face attempts; use your password";
@@ -29,7 +32,7 @@ struct Account {
     name: String,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct Policy {
     limit: u32,
     seconds: u64,
@@ -37,12 +40,29 @@ struct Policy {
 
 impl Policy {
     fn configured() -> Self {
-        Self {
-            limit: crate::env_or("IRLUME_RATE_LIMIT", "5").parse().unwrap_or(5),
-            seconds: crate::env_or("IRLUME_RATE_COOLDOWN_SECS", "30")
-                .parse()
-                .unwrap_or(30),
+        let (policy, invalid) = Self::parse(
+            &crate::env_or("IRLUME_RATE_LIMIT", "5"),
+            &crate::env_or("IRLUME_RATE_COOLDOWN_SECS", "30"),
+        );
+        if invalid {
+            eprintln!("irlumed: invalid face retry configuration; using safe defaults for invalid settings");
         }
+        policy
+    }
+
+    fn parse(limit: &str, seconds: &str) -> (Self, bool) {
+        let limit = limit.parse::<u32>().ok().filter(|n| (1..=5).contains(n));
+        let seconds = seconds
+            .parse::<u64>()
+            .ok()
+            .filter(|n| (30..=86400).contains(n));
+        (
+            Self {
+                limit: limit.unwrap_or(5),
+                seconds: seconds.unwrap_or(30),
+            },
+            limit.is_none() || seconds.is_none(),
+        )
     }
 }
 
@@ -106,6 +126,15 @@ struct Record {
     strikes: u32,
     #[serde(deserialize_with = "Option::deserialize")]
     cooldown: Option<Cooldown>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    budget: Option<FaceBudget>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct FaceBudget {
+    unsuccessful_requests: u32,
+    pending: bool,
 }
 
 impl Record {
@@ -116,11 +145,29 @@ impl Record {
             account: account.name.clone(),
             strikes: 0,
             cooldown: None,
+            budget: None,
         }
     }
 
+    fn initialize_budget(&mut self) {
+        self.version = 2;
+        self.budget = Some(FaceBudget {
+            unsuccessful_requests: 0,
+            pending: false,
+        });
+    }
+
+    fn reset(account: &Account) -> Self {
+        let mut record = Self::empty(account);
+        record.initialize_budget();
+        record
+    }
+
     fn validate(&self, account: &Account) -> io::Result<()> {
-        if self.version != 1
+        if !matches!((self.version, &self.budget), (1, None) | (2, Some(_)))
+            || self.budget.as_ref().is_some_and(|b| {
+                b.unsuccessful_requests > FACE_LIMIT || (b.pending && b.unsuccessful_requests == 0)
+            })
             || self.uid != account.uid
             || self.account != account.name
             || self.account.is_empty()
@@ -142,6 +189,26 @@ impl Record {
             duration_nanos: duration,
         });
         self.strikes = 0;
+        Ok(())
+    }
+
+    fn strike(&mut self, policy: Policy, now: &Tick) -> io::Result<()> {
+        if self.cooldown.is_none() {
+            self.strikes = self.strikes.checked_add(1).ok_or_else(invalid)?;
+            if self.strikes >= policy.limit {
+                self.arm(now, policy.seconds.checked_mul(NANOS).ok_or_else(invalid)?)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn settle_abandoned(&mut self, policy: Policy, now: &Tick) -> io::Result<()> {
+        if let Some(budget) = &mut self.budget {
+            if budget.pending {
+                budget.pending = false;
+                self.strike(policy, now)?;
+            }
+        }
         Ok(())
     }
 }
@@ -173,11 +240,54 @@ fn open_dir(path: &Path, owner: u32, private: bool) -> io::Result<File> {
     Ok(file)
 }
 
+/// Own the flock lifetime separately from duplicate File descriptors.
+/// Kept inside retry accounting; callers retain it for the complete operation.
+pub(crate) struct RetryLock {
+    file: File,
+    owner_pid: libc::pid_t,
+}
+
+impl RetryLock {
+    fn acquire(file: File, flags: libc::c_int) -> io::Result<Self> {
+        // SAFETY: file owns a live descriptor throughout acquisition.
+        if unsafe { libc::flock(file.as_raw_fd(), flags) } != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: getpid has no preconditions and identifies this acquisition's owner.
+        let owner_pid = unsafe { libc::getpid() };
+        Ok(Self { file, owner_pid })
+    }
+}
+
+impl std::ops::Deref for RetryLock {
+    type Target = File;
+
+    fn deref(&self) -> &File {
+        &self.file
+    }
+}
+
+impl Drop for RetryLock {
+    fn drop(&mut self) {
+        // flock belongs to the open file description shared by dup/fork. Closing
+        // our fd alone can leave the lock held by a child until exec. Conversely,
+        // a copied guard in that child must not unlock a still-active parent.
+        // SAFETY: getpid has no preconditions (including in a post-fork child).
+        if unsafe { libc::getpid() } == self.owner_pid {
+            // SAFETY: self.file remains live until after this destructor. Unlock
+            // explicitly before File closes; no other owner can clone this guard.
+            unsafe {
+                libc::flock(self.file.as_raw_fd(), libc::LOCK_UN);
+            }
+        }
+    }
+}
+
 impl Store {
     /// Open and exclusively lock the directory inode. All subsequent accesses are
     /// pinned through its fd, including the existing atomic writer, so a renamed
-    /// parent cannot redirect publication. Closing the fd releases flock even on error.
-    fn lock(&self) -> io::Result<File> {
+    /// parent cannot redirect publication. The owning guard releases flock on error.
+    fn lock(&self) -> io::Result<RetryLock> {
         let parent = open_dir(&self.parent, self.owner, false)?;
         let path = PathBuf::from(format!("/proc/self/fd/{}/retry", parent.as_raw_fd()));
         match std::fs::DirBuilder::new().mode(0o700).create(&path) {
@@ -188,11 +298,7 @@ impl Store {
         let dir = open_dir(&path, self.owner, true)?;
         // Also retries directory-creation durability following an earlier error.
         parent.sync_all()?;
-        // SAFETY: dir owns a valid fd throughout the lock lifetime.
-        if unsafe { libc::flock(dir.as_raw_fd(), libc::LOCK_EX) } != 0 {
-            return Err(io::Error::last_os_error());
-        }
-        Ok(dir)
+        RetryLock::acquire(dir, libc::LOCK_EX)
     }
 
     fn path(dir: &File, account: &Account) -> PathBuf {
@@ -204,14 +310,30 @@ impl Store {
     }
 
     fn read(&self, dir: &File, account: &Account) -> io::Result<Record> {
-        let path = Self::path(dir, account);
+        let Some(bytes) = self.read_bytes(dir, &Self::path(dir, account))? else {
+            return Ok(Record::empty(account));
+        };
+        // Version 1's original strict schema had no budget field, including
+        // null. Do not turn a malformed legacy record into a fresh epoch.
+        let shape: serde_json::Value = serde_json::from_slice(&bytes).map_err(|_| invalid())?;
+        if shape.get("version").and_then(serde_json::Value::as_u64) == Some(1)
+            && shape.get("budget").is_some()
+        {
+            return Err(invalid());
+        }
+        let record: Record = serde_json::from_slice(&bytes).map_err(|_| invalid())?;
+        record.validate(account)?;
+        Ok(record)
+    }
+
+    fn read_bytes(&self, dir: &File, path: &Path) -> io::Result<Option<Vec<u8>>> {
         let file = match OpenOptions::new()
             .read(true)
             .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_CLOEXEC)
             .open(path)
         {
             Ok(f) => f,
-            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(Record::empty(account)),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(None),
             Err(e) => return Err(e),
         };
         let meta = file.metadata()?;
@@ -228,14 +350,42 @@ impl Store {
         if bytes.len() > MAX_RECORD as usize {
             return Err(invalid());
         }
-        let record: Record = serde_json::from_slice(&bytes).map_err(|_| invalid())?;
-        record.validate(account)?;
         // A previous rename may have been visible but not durable. Re-read and
         // establish durability before permitting face again, including after a
         // process restart. There is no stale in-memory copy to restore on error.
         file.sync_all()?;
         dir.sync_all()?;
-        Ok(record)
+        Ok(Some(bytes))
+    }
+
+    fn operation(&self, account: &Account) -> io::Result<RetryLock> {
+        let dir = self.lock()?;
+        let path = format!(
+            "/proc/self/fd/{}/{}.operation",
+            dir.as_raw_fd(),
+            account.uid
+        );
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .mode(0o600)
+            .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_CLOEXEC)
+            .open(path)?;
+        let m = file.metadata()?;
+        if !m.is_file()
+            || m.uid() != self.owner
+            || m.mode() & 0o7777 != 0o600
+            || m.nlink() != 1
+            || m.len() != 0
+        {
+            return Err(invalid());
+        }
+        let file = RetryLock::acquire(file, libc::LOCK_EX | libc::LOCK_NB)?;
+        file.sync_all()?;
+        dir.sync_all()?;
+        Ok(file)
     }
 
     fn commit(&self, dir: &File, record: &Record, writer: Writer) -> io::Result<()> {
@@ -264,9 +414,6 @@ impl Store {
         clock: Clock,
         writer: Writer,
     ) -> io::Result<bool> {
-        if policy.limit == 0 {
-            return Ok(false);
-        }
         let now = clock()?;
         if !valid_boot(&now.boot) {
             return Err(invalid());
@@ -274,6 +421,7 @@ impl Store {
         let dir = self.lock()?;
         let mut record = self.read(&dir, account)?;
         let before = record.clone();
+        record.settle_abandoned(policy, &now)?;
         if let Some(c) = &record.cooldown {
             if c.boot_id != now.boot {
                 record.arm(&now, c.duration_nanos)?;
@@ -291,11 +439,16 @@ impl Store {
             self.commit(&dir, &record, writer)?;
         }
         Ok(record
-            .cooldown
+            .budget
             .as_ref()
-            .is_some_and(|c| now.nanos < c.deadline_nanos))
+            .is_some_and(|b| b.unsuccessful_requests >= FACE_LIMIT)
+            || record
+                .cooldown
+                .as_ref()
+                .is_some_and(|c| now.nanos < c.deadline_nanos))
     }
 
+    #[cfg(test)]
     fn record(
         &self,
         account: &Account,
@@ -304,9 +457,20 @@ impl Store {
         clock: Clock,
         writer: Writer,
     ) -> io::Result<()> {
-        if policy.limit == 0 {
-            return Ok(());
-        }
+        self.record_if(account, policy, outcome, clock, writer, || true)
+    }
+
+    #[cfg(test)]
+    #[allow(clippy::too_many_arguments)]
+    fn record_if(
+        &self,
+        account: &Account,
+        policy: Policy,
+        outcome: &irlume_auth::Outcome,
+        clock: Clock,
+        writer: Writer,
+        active: impl Fn() -> bool,
+    ) -> io::Result<()> {
         // Capture retryability and account strikes are separate decisions:
         // setup failures are terminal but must not spend or replenish history.
         // Keep this exhaustive so every new outcome needs an accounting choice.
@@ -334,6 +498,15 @@ impl Store {
         let dir = self.lock()?;
         let mut record = self.read(&dir, account)?;
         if outcome.granted {
+            // Lock acquisition and durable read may block. Revalidate after
+            // them and before replenishing history. Atomic persistence can
+            // itself cross expiry; callers must still gate response admission.
+            if !active() {
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "authentication no longer eligible",
+                ));
+            }
             record.strikes = 0;
             record.cooldown = None;
         } else if record.cooldown.is_none() {
@@ -343,6 +516,124 @@ impl Store {
             }
         }
         self.commit(&dir, &record, writer)
+    }
+}
+
+/// A durable account-exclusive reservation. Drop retains an ambiguous charge.
+pub(crate) struct FaceAttempt {
+    store: Store,
+    account: Account,
+    policy: Policy,
+    clock: Clock,
+    writer: Writer,
+    _operation: RetryLock,
+}
+
+impl FaceAttempt {
+    pub(crate) fn for_user(user: &str) -> Result<Self, &'static str> {
+        let result = account(user).and_then(|a| {
+            Self::begin(
+                production_store()?,
+                a,
+                Policy::configured(),
+                linux_clock,
+                write_atomic_reporting,
+            )
+        });
+        match result {
+            Ok(Some(attempt)) => Ok(attempt),
+            Ok(None) => Err(LIMITED),
+            Err(_) => Err(UNAVAILABLE),
+        }
+    }
+
+    fn begin(
+        store: Store,
+        account: Account,
+        policy: Policy,
+        clock: Clock,
+        writer: Writer,
+    ) -> io::Result<Option<Self>> {
+        let operation = store.operation(&account)?;
+        if store.check(&account, policy, clock, writer)? {
+            return Ok(None);
+        }
+        let dir = store.lock()?;
+        let mut record = store.read(&dir, &account)?;
+        if record.budget.is_none() {
+            // Prospective epoch only; v1 cannot reconstruct erased history.
+            record.initialize_budget();
+        }
+        let budget = record.budget.as_mut().ok_or_else(invalid)?;
+        if budget.unsuccessful_requests >= FACE_LIMIT {
+            return Ok(None);
+        }
+        budget.unsuccessful_requests = budget
+            .unsuccessful_requests
+            .checked_add(1)
+            .ok_or_else(invalid)?;
+        budget.pending = true;
+        store.commit(&dir, &record, writer)?;
+        drop(dir);
+        Ok(Some(Self {
+            store,
+            account,
+            policy,
+            clock,
+            writer,
+            _operation: operation,
+        }))
+    }
+
+    pub(crate) fn denied(self, outcome: &irlume_auth::Outcome) -> Result<(), &'static str> {
+        self.denied_inner(outcome).map_err(|_| UNAVAILABLE)
+    }
+
+    fn denied_inner(&self, outcome: &irlume_auth::Outcome) -> io::Result<()> {
+        if outcome.granted {
+            return Err(invalid());
+        }
+        let dir = self.store.lock()?;
+        let mut record = self.store.read(&dir, &self.account)?;
+        let budget = record.budget.as_mut().ok_or_else(invalid)?;
+        if !budget.pending {
+            return Err(invalid());
+        }
+        budget.pending = false;
+        use irlume_auth::OutcomeKind;
+        match outcome.kind {
+            OutcomeKind::NoFace
+            | OutcomeKind::Uncertain
+            | OutcomeKind::SpoofNoIrFace
+            | OutcomeKind::SetupUnavailable => (),
+            OutcomeKind::Granted
+            | OutcomeKind::Spoof
+            | OutcomeKind::BelowThreshold
+            | OutcomeKind::DeadlineExpired
+            | OutcomeKind::RuntimeUnavailable
+            | OutcomeKind::OtherDeny => {
+                let now = (self.clock)()?;
+                if !valid_boot(&now.boot) {
+                    return Err(invalid());
+                }
+                record.strike(self.policy, &now)?;
+            }
+        }
+        self.store.commit(&dir, &record, self.writer)
+    }
+
+    /// Called only after the daemon admitted and wrote the complete grant.
+    pub(crate) fn delivered(self) -> Result<(), &'static str> {
+        let reset = || -> io::Result<()> {
+            let dir = self.store.lock()?;
+            let record = self.store.read(&dir, &self.account)?;
+            if !record.budget.as_ref().is_some_and(|b| b.pending) {
+                return Err(invalid());
+            }
+            self.store
+                .commit(&dir, &Record::reset(&self.account), self.writer)
+        };
+        reset().map_err(|_| UNAVAILABLE)
     }
 }
 
@@ -390,30 +681,27 @@ fn production_store() -> io::Result<Store> {
     })
 }
 
-pub(crate) fn check(user: &str) -> Result<(), &'static str> {
-    let policy = Policy::configured();
-    if policy.limit == 0 {
-        return Ok(());
-    }
-    let result = account(user)
-        .and_then(|a| production_store()?.check(&a, policy, linux_clock, write_atomic_reporting));
-    match result {
-        Ok(false) => Ok(()),
-        Ok(true) => Err(LIMITED),
-        Err(e) => {
-            eprintln!("irlumed: face retry preflight failed: {e}");
-            Err(UNAVAILABLE)
-        }
-    }
+#[cfg(test)]
+pub(crate) fn record(user: &str, outcome: &irlume_auth::Outcome) -> Result<(), &'static str> {
+    record_if(user, outcome, || true)
 }
 
-pub(crate) fn record(user: &str, outcome: &irlume_auth::Outcome) -> Result<(), &'static str> {
+#[cfg(test)]
+pub(crate) fn record_if(
+    user: &str,
+    outcome: &irlume_auth::Outcome,
+    active: impl Fn() -> bool,
+) -> Result<(), &'static str> {
     let policy = Policy::configured();
-    if policy.limit == 0 {
-        return Ok(());
-    }
     let result = account(user).and_then(|a| {
-        production_store()?.record(&a, policy, outcome, linux_clock, write_atomic_reporting)
+        production_store()?.record_if(
+            &a,
+            policy,
+            outcome,
+            linux_clock,
+            write_atomic_reporting,
+            active,
+        )
     });
     result.map_err(|e| {
         eprintln!("irlumed: face retry recording failed: {e}");

--- a/crates/irlume-daemon/src/retry_throttle/recovery.rs
+++ b/crates/irlume-daemon/src/retry_throttle/recovery.rs
@@ -1,0 +1,253 @@
+//! Independently verified retry recovery; face policy is unchanged.
+use super::*;
+
+#[cfg(test)]
+mod tests;
+
+const LIMIT: u32 = 50;
+const DELAY_AFTER: u32 = 5;
+const DELAY: u64 = 30 * NANOS;
+const REFUSED: &str = "password verification failed or was cancelled; retry state unchanged";
+const UNCONFIRMED: &str = "retry reset was not confirmed; inspect retry status before trying again";
+const BLOCKED: &str =
+    "retry reset is rate limited; use your password for normal login or ask an administrator";
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Attempts {
+    version: u32,
+    uid: u32,
+    account: String,
+    failures: u32,
+    pending: bool,
+    #[serde(deserialize_with = "Option::deserialize")]
+    cooldown: Option<Cooldown>,
+}
+impl Attempts {
+    fn empty(a: &Account) -> Self {
+        Self {
+            version: 1,
+            uid: a.uid,
+            account: a.name.clone(),
+            failures: 0,
+            pending: false,
+            cooldown: None,
+        }
+    }
+    fn validate(&self, a: &Account) -> io::Result<()> {
+        if self.version != 1
+            || self.uid != a.uid
+            || self.account != a.name
+            || self.failures > LIMIT
+            || (self.pending && self.failures == 0)
+            || self.cooldown.as_ref().is_some_and(|c| {
+                !valid_boot(&c.boot_id)
+                    || c.duration_nanos != DELAY
+                    || c.deadline_nanos < DELAY
+                    || self.failures < DELAY_AFTER
+            })
+        {
+            return Err(invalid());
+        }
+        Ok(())
+    }
+    fn settle(&mut self, now: &Tick) -> io::Result<bool> {
+        let rearm = self.pending
+            || self
+                .cooldown
+                .as_ref()
+                .is_some_and(|c| c.boot_id != now.boot);
+        if rearm {
+            self.pending = false;
+            if self.failures >= DELAY_AFTER {
+                self.cooldown = Some(Cooldown {
+                    boot_id: now.boot.clone(),
+                    deadline_nanos: now.nanos.checked_add(DELAY).ok_or_else(invalid)?,
+                    duration_nanos: DELAY,
+                });
+            }
+            return Ok(true);
+        }
+        if let Some(c) = &self.cooldown {
+            if c.deadline_nanos.saturating_sub(now.nanos) > DELAY {
+                return Err(invalid());
+            }
+            if now.nanos >= c.deadline_nanos {
+                self.cooldown = None;
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+}
+
+pub(crate) struct Status {
+    pub face_budget: irlume_common::FaceRetryBudget,
+    pub failures: u32,
+    pub cooldown_seconds: u64,
+    pub recovery_failures: u32,
+    pub recovery_cooldown_seconds: u64,
+    pub recovery_required: bool,
+}
+
+pub(crate) struct Recovery {
+    store: Store,
+    account: Account,
+    clock: Clock,
+    writer: Writer,
+    _operation: RetryLock,
+}
+impl Recovery {
+    pub(crate) fn for_user(user: &str) -> Result<Self, &'static str> {
+        let a = account(user).map_err(|_| UNAVAILABLE)?;
+        Self::begin(
+            production_store().map_err(|_| UNAVAILABLE)?,
+            a,
+            linux_clock,
+            write_atomic_reporting,
+        )
+        .map_err(|_| UNAVAILABLE)
+    }
+    fn begin(store: Store, account: Account, clock: Clock, writer: Writer) -> io::Result<Self> {
+        let operation = store.operation(&account)?;
+        Ok(Self {
+            store,
+            account,
+            clock,
+            writer,
+            _operation: operation,
+        })
+    }
+    fn now(&self) -> io::Result<Tick> {
+        let t = (self.clock)()?;
+        if !valid_boot(&t.boot) {
+            return Err(invalid());
+        }
+        Ok(t)
+    }
+    fn path(&self, dir: &File) -> PathBuf {
+        PathBuf::from(format!(
+            "/proc/self/fd/{}/{}.reset.json",
+            dir.as_raw_fd(),
+            self.account.uid
+        ))
+    }
+    fn read(&self, dir: &File) -> io::Result<Attempts> {
+        let a = match self.store.read_bytes(dir, &self.path(dir))? {
+            Some(b) => serde_json::from_slice(&b).map_err(|_| invalid())?,
+            None => Attempts::empty(&self.account),
+        };
+        a.validate(&self.account)?;
+        Ok(a)
+    }
+    fn commit(&self, dir: &File, a: &Attempts) -> io::Result<()> {
+        a.validate(&self.account)?;
+        let bytes = serde_json::to_vec(a).map_err(|_| invalid())?;
+        if bytes.len() > MAX_RECORD as usize {
+            return Err(invalid());
+        }
+        match (self.writer)(&self.path(dir), &bytes, 0o600)? {
+            AtomicWrite::Durable => Ok(()),
+            AtomicWrite::VisibleNotDurable(e) => Err(e),
+        }
+    }
+    pub(crate) fn status(&self) -> Result<Status, &'static str> {
+        self.status_inner().map_err(|_| UNAVAILABLE)
+    }
+    fn status_inner(&self) -> io::Result<Status> {
+        let dir = self.store.lock()?;
+        let mut face = self.store.read(&dir, &self.account)?;
+        let mut recovery = self.read(&dir)?;
+        let now = self.now()?;
+        let before = face.clone();
+        face.settle_abandoned(Policy::configured(), &now)?;
+        if face != before {
+            self.store.commit(&dir, &face, self.writer)?;
+        }
+        if recovery.settle(&now)? {
+            self.commit(&dir, &recovery)?;
+        }
+        let remaining = |c: &Option<Cooldown>| {
+            c.as_ref().map_or(0, |c| {
+                let n = if c.boot_id == now.boot {
+                    c.deadline_nanos.saturating_sub(now.nanos)
+                } else {
+                    c.duration_nanos
+                };
+                n.div_ceil(NANOS)
+            })
+        };
+        Ok(Status {
+            face_budget: irlume_common::FaceRetryBudget {
+                unsuccessful_requests: face.budget.as_ref().map(|b| b.unsuccessful_requests),
+                limit: FACE_LIMIT,
+                reset_required: face
+                    .budget
+                    .as_ref()
+                    .is_some_and(|b| b.unsuccessful_requests >= FACE_LIMIT),
+            },
+            failures: face.strikes,
+            cooldown_seconds: remaining(&face.cooldown),
+            recovery_failures: recovery.failures,
+            recovery_cooldown_seconds: remaining(&recovery.cooldown),
+            recovery_required: recovery.failures >= LIMIT,
+        })
+    }
+    pub(crate) fn reset(
+        &self,
+        admin: bool,
+        active: impl Fn() -> bool,
+        verify: impl FnOnce() -> Result<(), &'static str>,
+    ) -> Result<(), &'static str> {
+        if !active() {
+            return Err(REFUSED);
+        }
+        {
+            let dir = self.store.lock().map_err(|_| UNAVAILABLE)?;
+            self.store
+                .read(&dir, &self.account)
+                .map_err(|_| UNAVAILABLE)?;
+            let mut a = self.read(&dir).map_err(|_| UNAVAILABLE)?;
+            if !admin {
+                let now = self.now().map_err(|_| UNAVAILABLE)?;
+                if a.settle(&now).map_err(|_| UNAVAILABLE)? {
+                    self.commit(&dir, &a).map_err(|_| UNAVAILABLE)?;
+                }
+                if a.failures >= LIMIT || a.cooldown.is_some() {
+                    return Err(BLOCKED);
+                }
+                a.failures += 1;
+                a.pending = true;
+                self.commit(&dir, &a).map_err(|_| UNAVAILABLE)?;
+            }
+        }
+        if !admin && (!active() || verify().is_err()) {
+            // A completed refusal or abandoned reservation retains its charge.
+            // Settlement arms the delay from completion, not verifier start.
+            self.status()?;
+            return Err(REFUSED);
+        }
+        let dir = self.store.lock().map_err(|_| UNAVAILABLE)?;
+        self.store
+            .read(&dir, &self.account)
+            .map_err(|_| UNAVAILABLE)?;
+        self.read(&dir).map_err(|_| UNAVAILABLE)?;
+        if !active() {
+            return Err(REFUSED);
+        }
+        self.store
+            .commit(&dir, &Record::reset(&self.account), self.writer)
+            .map_err(|_| UNCONFIRMED)?;
+        // Face first: a torn two-file reset leaves a conservative recovery
+        // charge. It cannot replenish password guesses without verified proof.
+        if !active() {
+            return Err(UNCONFIRMED);
+        }
+        self.commit(&dir, &Attempts::empty(&self.account))
+            .map_err(|_| UNCONFIRMED)?;
+        if !active() {
+            return Err(UNCONFIRMED);
+        }
+        Ok(())
+    }
+}

--- a/crates/irlume-daemon/src/retry_throttle/recovery/tests.rs
+++ b/crates/irlume-daemon/src/retry_throttle/recovery/tests.rs
@@ -1,0 +1,427 @@
+use super::*;
+use std::sync::atomic::{AtomicU64, Ordering};
+thread_local! { static TICK: std::cell::Cell<u64> = const { std::cell::Cell::new(100) }; }
+static SERIAL: AtomicU64 = AtomicU64::new(0);
+fn now() -> io::Result<Tick> {
+    Ok(Tick {
+        boot: "00000000-0000-0000-0000-000000000001".into(),
+        nanos: TICK.get() * NANOS,
+    })
+}
+struct Fixture(PathBuf);
+impl Fixture {
+    fn new() -> Self {
+        let p = std::env::temp_dir().join(format!(
+            "irlume-reset-{}-{}",
+            std::process::id(),
+            SERIAL.fetch_add(1, Ordering::SeqCst)
+        ));
+        std::fs::DirBuilder::new().mode(0o700).create(&p).unwrap();
+        Self(p)
+    }
+    fn store(&self) -> Store {
+        Store {
+            parent: self.0.clone(),
+            // SAFETY: geteuid has no preconditions.
+            owner: unsafe { libc::geteuid() },
+        }
+    }
+    fn identity(&self) -> Account {
+        Account {
+            uid: 1234,
+            name: "fixture".into(),
+        }
+    }
+    fn open(&self) -> Recovery {
+        Recovery::begin(self.store(), self.identity(), now, write_atomic_reporting).unwrap()
+    }
+    fn plant_face(&self) {
+        let s = self.store();
+        let d = s.lock().unwrap();
+        let mut r = Record::empty(&self.identity());
+        r.strikes = 4;
+        s.commit(&d, &r, write_atomic_reporting).unwrap();
+    }
+    fn face(&self) -> Record {
+        let s = self.store();
+        let d = s.lock().unwrap();
+        s.read(&d, &self.identity()).unwrap()
+    }
+}
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        std::fs::remove_dir_all(&self.0).unwrap();
+    }
+}
+#[test]
+fn reset_requires_verified_password_and_preserves_face_on_refusal() {
+    let f = Fixture::new();
+    f.plant_face();
+    let gate = f.open();
+    assert!(gate
+        .reset(false, || true, || Err("wrong password"))
+        .is_err());
+    assert_eq!(f.face().strikes, 4);
+    gate.reset(false, || true, || Ok(())).unwrap();
+    assert_eq!(f.face().strikes, 0);
+}
+
+#[test]
+fn cumulative_status_does_not_migrate_legacy_and_verified_reset_starts_epoch() {
+    let _env = crate::test_support::env_read();
+    let f = Fixture::new();
+    {
+        let gate = f.open();
+        assert_eq!(
+            gate.status().unwrap().face_budget.unsuccessful_requests,
+            None
+        );
+        assert!(!f.0.join("retry/1234.json").exists());
+    }
+    f.plant_face();
+    let before = std::fs::read(f.0.join("retry/1234.json")).unwrap();
+    let gate = f.open();
+    assert_eq!(
+        gate.status().unwrap().face_budget.unsuccessful_requests,
+        None
+    );
+    assert_eq!(std::fs::read(f.0.join("retry/1234.json")).unwrap(), before);
+    gate.reset(false, || true, || Ok(())).unwrap();
+    assert_eq!(
+        gate.status().unwrap().face_budget.unsuccessful_requests,
+        Some(0)
+    );
+    assert_eq!(f.face().version, 2);
+}
+
+#[test]
+fn cumulative_face_exhaustion_does_not_exhaust_password_recovery() {
+    let _env = crate::test_support::env_read();
+    let f = Fixture::new();
+    {
+        let s = f.store();
+        let d = s.lock().unwrap();
+        let mut face = Record::reset(&f.identity());
+        face.budget.as_mut().unwrap().unsuccessful_requests = FACE_LIMIT;
+        s.commit(&d, &face, write_atomic_reporting).unwrap();
+    }
+    let gate = f.open();
+    let status = gate.status().unwrap();
+    assert!(status.face_budget.reset_required);
+    assert!(!status.recovery_required);
+    assert_eq!(status.recovery_failures, 0);
+    gate.reset(false, || true, || Err("synthetic refusal"))
+        .unwrap_err();
+    assert_eq!(
+        gate.status().unwrap().face_budget.unsuccessful_requests,
+        Some(50)
+    );
+    gate.reset(false, || true, || Ok(())).unwrap();
+    assert_eq!(
+        gate.status().unwrap().face_budget.unsuccessful_requests,
+        Some(0)
+    );
+}
+#[test]
+fn reset_admin_override_does_not_call_password_verifier() {
+    let f = Fixture::new();
+    f.plant_face();
+    f.open()
+        .reset(
+            true,
+            || true,
+            || panic!("root override must not call verifier"),
+        )
+        .unwrap();
+    assert_eq!(f.face().strikes, 0);
+}
+#[test]
+fn cancelled_reset_does_not_clear_history() {
+    let f = Fixture::new();
+    f.plant_face();
+    assert!(f
+        .open()
+        .reset(
+            false,
+            || false,
+            || panic!("inactive request must not verify")
+        )
+        .is_err());
+    assert_eq!(f.face().strikes, 4);
+}
+
+#[test]
+fn reset_budget_survives_reopen_and_delays_every_attempt_after_five() {
+    let f = Fixture::new();
+    for n in 1..=50 {
+        let gate = f.open();
+        assert!(gate.reset(false, || true, || Err("wrong")).is_err());
+        assert_eq!(gate.status().unwrap().recovery_failures, n);
+        if n >= 5 {
+            assert!(gate
+                .reset(false, || true, || panic!("cooldown must block verifier"))
+                .is_err());
+            TICK.set(TICK.get() + 30);
+        }
+    }
+    let gate = f.open();
+    assert!(gate.status().unwrap().recovery_required);
+    assert!(gate
+        .reset(false, || true, || panic!("ceiling must block verifier"))
+        .is_err());
+    gate.reset(true, || true, || panic!("administrator override"))
+        .unwrap();
+    assert_eq!(gate.status().unwrap().recovery_failures, 0);
+}
+#[test]
+fn interrupted_verifier_keeps_a_durable_charge() {
+    let f = Fixture::new();
+    f.plant_face();
+    let gate = f.open();
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let _ = gate.reset(false, || true, || panic!("interrupted verifier"));
+    }));
+    assert!(result.is_err());
+    drop(gate);
+    assert_eq!(f.open().status().unwrap().recovery_failures, 1);
+    assert_eq!(f.face().strikes, 4);
+}
+#[test]
+fn face_and_recovery_operations_cannot_overlap() {
+    let f = Fixture::new();
+    let face = f.store().operation(&f.identity()).unwrap();
+    assert!(Recovery::begin(f.store(), f.identity(), now, write_atomic_reporting).is_err());
+    drop(face);
+    let gate = f.open();
+    assert!(f.store().operation(&f.identity()).is_err());
+    drop(gate);
+    assert!(f.store().operation(&f.identity()).is_ok());
+}
+fn fail_face(path: &Path, bytes: &[u8], mode: u32) -> io::Result<AtomicWrite> {
+    if path.file_name().unwrap() == "1234.json" {
+        return Err(io::Error::other("face write failed"));
+    }
+    write_atomic_reporting(path, bytes, mode)
+}
+#[test]
+fn reset_write_failure_preserves_face_and_does_not_replenish_password_guesses() {
+    let f = Fixture::new();
+    f.plant_face();
+    let gate = Recovery::begin(f.store(), f.identity(), now, fail_face).unwrap();
+    assert!(gate.reset(false, || true, || Ok(())).is_err());
+    assert_eq!(f.face().strikes, 4);
+    assert_eq!(gate.status().unwrap().recovery_failures, 1);
+}
+#[test]
+fn successful_password_with_expired_request_does_not_reset_face() {
+    let f = Fixture::new();
+    f.plant_face();
+    let gate = f.open();
+    let calls = std::cell::Cell::new(0);
+    assert!(gate
+        .reset(
+            false,
+            || {
+                calls.set(calls.get() + 1);
+                calls.get() < 3
+            },
+            || Ok(())
+        )
+        .is_err());
+    assert_eq!(f.face().strikes, 4);
+    assert_eq!(gate.status().unwrap().recovery_failures, 1);
+}
+#[test]
+fn malformed_recovery_state_is_never_replaced_with_empty_history() {
+    let f = Fixture::new();
+    f.plant_face();
+    let gate = f.open();
+    let dir = gate.store.lock().unwrap();
+    write_atomic_reporting(&gate.path(&dir), br#"{"version":99}"#, 0o600).unwrap();
+    drop(dir);
+    assert!(gate
+        .reset(false, || true, || panic!("unsafe state must not verify"))
+        .is_err());
+    assert!(gate
+        .reset(true, || true, || panic!("unsafe state must not verify"))
+        .is_err());
+    assert_eq!(f.face().strikes, 4);
+}
+
+#[test]
+fn recovery_cooldown_rearms_after_reboot_without_replenishing_attempts() {
+    let f = Fixture::new();
+    let gate = f.open();
+    for _ in 0..5 {
+        assert!(gate.reset(false, || true, || Err("wrong")).is_err());
+    }
+    let dir = gate.store.lock().unwrap();
+    let mut record = gate.read(&dir).unwrap();
+    record.cooldown.as_mut().unwrap().boot_id = "00000000-0000-0000-0000-000000000002".into();
+    gate.commit(&dir, &record).unwrap();
+    drop(dir);
+    let status = gate.status().unwrap();
+    assert_eq!(status.recovery_failures, 5);
+    assert_eq!(status.recovery_cooldown_seconds, 30);
+    assert!(gate
+        .reset(
+            false,
+            || true,
+            || panic!("reboot must not permit immediate guessing")
+        )
+        .is_err());
+}
+
+fn fail_reservation(_: &Path, _: &[u8], _: u32) -> io::Result<AtomicWrite> {
+    Err(io::Error::other("reservation write failed"))
+}
+#[test]
+fn failed_durable_reservation_never_invokes_password_verifier() {
+    let f = Fixture::new();
+    f.plant_face();
+    let gate = Recovery::begin(f.store(), f.identity(), now, fail_reservation).unwrap();
+    assert!(gate
+        .reset(
+            false,
+            || true,
+            || panic!("unreserved guessing must not run")
+        )
+        .is_err());
+    assert_eq!(f.face().strikes, 4);
+    assert_eq!(gate.status().unwrap().recovery_failures, 0);
+}
+
+fn fail_cleared_recovery(path: &Path, bytes: &[u8], mode: u32) -> io::Result<AtomicWrite> {
+    let value: serde_json::Value = serde_json::from_slice(bytes).unwrap();
+    if path.file_name().unwrap() == "1234.reset.json" && value["failures"] == 0 {
+        return Err(io::Error::other("recovery reset failed"));
+    }
+    write_atomic_reporting(path, bytes, mode)
+}
+#[test]
+fn torn_verified_reset_reports_uncertainty_and_retains_password_charge() {
+    let f = Fixture::new();
+    f.plant_face();
+    let gate = Recovery::begin(f.store(), f.identity(), now, fail_cleared_recovery).unwrap();
+    assert_eq!(gate.reset(false, || true, || Ok(())), Err(UNCONFIRMED));
+    assert_eq!(f.face().strikes, 0);
+    assert_eq!(gate.status().unwrap().recovery_failures, 1);
+}
+
+// A duplicate models the shared open file description inherited across fork.
+// These tests never wait for another process to exec or hide contention in a retry.
+#[test]
+fn operation_owner_drop_releases_lock_while_duplicate_remains_open() {
+    let f = Fixture::new();
+    let operation = f.store().operation(&f.identity()).unwrap();
+    let duplicate = operation.try_clone().unwrap();
+    assert_eq!(
+        f.store().operation(&f.identity()).err().unwrap().kind(),
+        io::ErrorKind::WouldBlock
+    );
+    drop(operation);
+    let next = f
+        .store()
+        .operation(&f.identity())
+        .expect("owner drop must unlock despite duplicate");
+    // Closing an old, released description cannot unlock a new operation owner.
+    drop(duplicate);
+    assert_eq!(
+        f.store().operation(&f.identity()).err().unwrap().kind(),
+        io::ErrorKind::WouldBlock
+    );
+    drop(next);
+    assert!(f.store().operation(&f.identity()).is_ok());
+}
+
+#[test]
+fn directory_owner_drop_and_unwind_release_lock_with_duplicate() {
+    for unwind in [false, true] {
+        let f = Fixture::new();
+        let dir = f.store().lock().unwrap();
+        let duplicate = dir.try_clone().unwrap();
+        let contender = File::open(f.0.join("retry")).unwrap();
+        // SAFETY: contender owns a valid, independently opened directory fd.
+        let blocked = unsafe { libc::flock(contender.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+        assert_eq!(blocked, -1);
+        assert_eq!(io::Error::last_os_error().kind(), io::ErrorKind::WouldBlock);
+        if unwind {
+            assert!(std::panic::catch_unwind(move || {
+                let _dir = dir;
+                panic!("synthetic directory-owner unwind");
+            })
+            .is_err());
+        } else {
+            drop(dir);
+        }
+        // Nonblocking: a regression fails immediately instead of deadlocking.
+        // SAFETY: contender still owns the same live descriptor.
+        let acquired = unsafe { libc::flock(contender.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+        assert_eq!(acquired, 0, "directory owner did not release its flock");
+        drop(duplicate);
+    }
+}
+
+#[test]
+fn recovery_owner_unwind_releases_lock_but_keeps_durable_charge_with_duplicate() {
+    let f = Fixture::new();
+    f.plant_face();
+    let gate = f.open();
+    let duplicate = gate._operation.try_clone().unwrap();
+    assert!(
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+            let _ = gate.reset(false, || true, || panic!("synthetic interrupted verifier"));
+        }))
+        .is_err()
+    );
+    let reopened = f.open();
+    assert_eq!(reopened.status().unwrap().recovery_failures, 1);
+    assert_eq!(f.face().strikes, 4);
+    drop(duplicate);
+}
+
+#[test]
+fn forked_child_dropping_operation_cannot_unlock_active_parent() {
+    let f = Fixture::new();
+    let operation = f.store().operation(&f.identity()).unwrap();
+    let contender = File::open(f.0.join("retry/1234.operation")).unwrap();
+    // SAFETY: after fork the child only drops the File/PID lock guard and calls
+    // leaf libc syscalls; it never allocates, locks Rust state or unwinds, and
+    // _exit skips inherited test/fixture destructors. The parent always reaps it.
+    let child = unsafe { libc::fork() };
+    assert!(child >= 0, "fork failed: {}", io::Error::last_os_error());
+    if child == 0 {
+        drop(operation);
+        // SAFETY: inherited contender is live; flock is a nonblocking Linux
+        // syscall and errno is thread-local. _exit does not run Rust destructors.
+        unsafe {
+            let result = libc::flock(contender.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB);
+            let blocked = result == -1 && *libc::__errno_location() == libc::EWOULDBLOCK;
+            libc::_exit(if blocked { 0 } else { 1 });
+        }
+    }
+    let mut status = 0;
+    loop {
+        // SAFETY: status is writable, and child is the pid returned above.
+        let waited = unsafe { libc::waitpid(child, &mut status, 0) };
+        if waited == child {
+            break;
+        }
+        assert_eq!(
+            io::Error::last_os_error().kind(),
+            io::ErrorKind::Interrupted
+        );
+    }
+    assert!(libc::WIFEXITED(status));
+    assert_eq!(
+        libc::WEXITSTATUS(status),
+        0,
+        "child released the parent's live lock"
+    );
+    assert_eq!(
+        f.store().operation(&f.identity()).err().unwrap().kind(),
+        io::ErrorKind::WouldBlock
+    );
+    drop(operation);
+    assert!(f.store().operation(&f.identity()).is_ok());
+}

--- a/crates/irlume-daemon/src/retry_throttle/tests.rs
+++ b/crates/irlume-daemon/src/retry_throttle/tests.rs
@@ -134,6 +134,32 @@ impl Drop for Fixture {
     }
 }
 
+#[test]
+fn cumulative_reservation_survives_abandoned_requests() {
+    let f = Fixture::new();
+    cumulative::TIME.set(100);
+    for _ in 0..50 {
+        let attempt = cumulative::start_attempt(&f)
+            .unwrap()
+            .expect("within budget");
+        drop(attempt);
+        f.store
+            .check(
+                &account_one(),
+                POLICY,
+                cumulative::clock,
+                write_atomic_reporting,
+            )
+            .unwrap();
+        cumulative::TIME.set(cumulative::TIME.get() + 31);
+    }
+    assert!(
+        cumulative::start_attempt(&f).unwrap().is_none(),
+        "51st abandoned request must not admit face work"
+    );
+    assert_eq!(f.saved().budget.unwrap().unsuccessful_requests, 50);
+}
+
 // Migrated original consent-throttle regressions: the real persistent store now
 // replaces direct inspection/deletion of a process-local map.
 #[test]
@@ -256,32 +282,338 @@ fn rate_throttle_trips_after_the_limit_and_resets_on_grant() {
     assert!(!absent.path().exists());
     f.record(Kind::Spoof);
     let before = f.bytes();
-    let disabled = Policy { limit: 0, ..POLICY };
-    for _ in 0..20 {
-        f.store
-            .record(
-                &account_one(),
-                disabled,
-                &outcome(Kind::Spoof),
-                bad_clock,
-                before_rename,
-            )
-            .unwrap();
-    }
+    // Zero no longer bypasses storage: configured policy falls back safely.
+    let (safe, invalid_setting) = Policy::parse("0", "30");
+    assert!(invalid_setting);
+    assert_eq!(safe.limit, 5);
     f.store
         .record(
             &account_one(),
-            disabled,
+            safe,
             &outcome(Kind::Granted),
             bad_clock,
             before_rename,
         )
-        .unwrap();
-    assert!(!f
+        .unwrap_err();
+    assert!(f
         .store
-        .check(&account_one(), disabled, bad_clock, before_rename)
-        .unwrap());
-    assert_eq!(f.bytes(), before, "disable must retain history");
+        .check(&account_one(), safe, bad_clock, before_rename)
+        .is_err());
+    assert_eq!(f.bytes(), before, "failed persistence must retain history");
+}
+
+mod cumulative {
+    use super::*;
+    thread_local! { pub(super) static TIME: std::cell::Cell<u64> = const { std::cell::Cell::new(100) }; }
+    pub(super) fn clock() -> io::Result<Tick> {
+        Ok(Tick {
+            boot: BOOT.into(),
+            nanos: TIME.get() * NANOS,
+        })
+    }
+    fn store(f: &Fixture) -> Store {
+        Store {
+            parent: f.store.parent.clone(),
+            owner: f.store.owner,
+        }
+    }
+    pub(super) fn start_attempt(f: &Fixture) -> io::Result<Option<FaceAttempt>> {
+        FaceAttempt::begin(
+            store(f),
+            account_one(),
+            POLICY,
+            clock,
+            write_atomic_reporting,
+        )
+    }
+
+    #[test]
+    fn neutral_requests_are_charged_and_fiftieth_success_resets() {
+        let f = Fixture::new();
+        for n in 1..50 {
+            start_attempt(&f)
+                .unwrap()
+                .unwrap()
+                .denied(&outcome(Kind::NoFace))
+                .unwrap();
+            assert_eq!(f.saved().budget.unwrap().unsuccessful_requests, n);
+        }
+        let successful = start_attempt(&f).unwrap().unwrap();
+        assert_eq!(f.saved().budget.unwrap().unsuccessful_requests, 50);
+        successful.delivered().unwrap();
+        assert_eq!(f.saved().budget.unwrap().unsuccessful_requests, 0);
+        assert!(start_attempt(&f).unwrap().is_some());
+    }
+
+    #[test]
+    fn reservation_write_failures_never_admit_work() {
+        for writer in [before_rename as Writer, after_rename as Writer] {
+            let f = Fixture::new();
+            assert!(FaceAttempt::begin(store(&f), account_one(), POLICY, clock, writer).is_err());
+            if f.path().exists() {
+                assert_eq!(f.saved().budget.unwrap().unsuccessful_requests, 1);
+            }
+        }
+    }
+
+    #[test]
+    fn prospective_migration_preserves_short_history() {
+        let f = Fixture::new();
+        f.record(Kind::Spoof);
+        f.record(Kind::Spoof);
+        assert_eq!(f.saved().version, 1);
+        assert!(f.saved().budget.is_none());
+        let attempt = start_attempt(&f).unwrap().unwrap();
+        let saved = f.saved();
+        assert_eq!(saved.version, 2);
+        assert_eq!(saved.strikes, 2);
+        assert_eq!(saved.budget.unwrap().unsuccessful_requests, 1);
+        drop(attempt);
+    }
+
+    #[test]
+    fn owner_blocks_recovery_and_drop_releases_without_reset() {
+        let f = Fixture::new();
+        let attempt = start_attempt(&f).unwrap().unwrap();
+        assert!(f.store.operation(&account_one()).is_err());
+        drop(attempt);
+        assert!(f.store.operation(&account_one()).is_ok());
+        assert_eq!(f.saved().budget.unwrap().unsuccessful_requests, 1);
+    }
+
+    #[test]
+    fn invalid_configuration_uses_safe_defaults_without_disable() {
+        for limit in ["0", "6", "-1", "wat", "4294967296"] {
+            let (p, invalid) = Policy::parse(limit, "30");
+            assert!(invalid);
+            assert_eq!(p.limit, 5);
+        }
+        for seconds in ["0", "29", "86401", "-1", "18446744073709551616"] {
+            let (p, invalid) = Policy::parse("5", seconds);
+            assert!(invalid);
+            assert_eq!(p.seconds, 30);
+        }
+        assert_eq!(
+            Policy::parse("1", "86400"),
+            (
+                Policy {
+                    limit: 1,
+                    seconds: 86400
+                },
+                false
+            )
+        );
+    }
+
+    fn grant_reply(f: &Fixture) -> crate::WorkerReply {
+        crate::WorkerReply {
+            response: crate::Response::AuthResult {
+                granted: true,
+                score: 1.0,
+                live: true,
+                reason: "synthetic".into(),
+                declined_by_gesture: false,
+                refused_by_policy: false,
+                situation: String::new(),
+            },
+            completion: Some(crate::FaceCompletion {
+                attempt: start_attempt(f).unwrap().unwrap(),
+                window: irlume_auth::AuthenticationWindow::for_service(None),
+            }),
+        }
+    }
+
+    #[test]
+    fn delivery_success_alone_resets_and_synchronous_return_does_not() {
+        let _env = crate::test_support::env_read();
+        let f = Fixture::new();
+        let reply = grant_reply(&f);
+        assert!(f.store.operation(&account_one()).is_err());
+        let _response = reply.response;
+        drop(reply.completion);
+        assert_eq!(f.saved().budget.unwrap().unsuccessful_requests, 1);
+        let reply = grant_reply(&f);
+        let (server, client) = std::os::unix::net::UnixStream::pair().unwrap();
+        reply.respond(server).unwrap();
+        let mut text = String::new();
+        (&client).read_to_string(&mut text).unwrap();
+        assert!(text.contains("\"granted\":true"));
+        assert_eq!(f.saved().budget.unwrap().unsuccessful_requests, 0);
+        assert!(f.store.operation(&account_one()).is_ok());
+    }
+
+    #[test]
+    fn disconnected_delivery_and_dropped_channel_keep_charge() {
+        let _env = crate::test_support::env_read();
+        let f = Fixture::new();
+        let reply = grant_reply(&f);
+        let (server, client) = std::os::unix::net::UnixStream::pair().unwrap();
+        drop(client);
+        assert!(reply.respond(server).is_err());
+        assert_eq!(f.saved().budget.unwrap().unsuccessful_requests, 1);
+        let (tx, rx) = std::sync::mpsc::channel();
+        let reply = grant_reply(&f);
+        drop(rx);
+        drop(tx.send(reply).unwrap_err());
+        assert_eq!(f.saved().budget.unwrap().unsuccessful_requests, 2);
+        assert!(f.store.operation(&account_one()).is_ok());
+    }
+
+    #[test]
+    fn peer_write_shutdown_cancels_before_first_response_byte() {
+        let _env = crate::test_support::env_read();
+        let f = Fixture::new();
+        let reply = grant_reply(&f);
+        let (server, mut client) = std::os::unix::net::UnixStream::pair().unwrap();
+        client.shutdown(std::net::Shutdown::Write).unwrap();
+        assert!(crate::peer_gone(&server));
+        assert!(reply.respond(server).is_err());
+        let mut bytes = Vec::new();
+        client.read_to_end(&mut bytes).unwrap();
+        assert!(bytes.is_empty());
+        assert_eq!(f.saved().budget.unwrap().unsuccessful_requests, 1);
+        assert!(f.store.operation(&account_one()).is_ok());
+    }
+
+    #[test]
+    fn ordinary_ok_response_cannot_acknowledge_a_face_token() {
+        let _env = crate::test_support::env_read();
+        let f = Fixture::new();
+        let mut reply = grant_reply(&f);
+        reply.response = crate::Response::Ok("diagnostic completed".into());
+        let (server, _client) = std::os::unix::net::UnixStream::pair().unwrap();
+        reply.respond(server).unwrap();
+        assert_eq!(f.saved().budget.unwrap().unsuccessful_requests, 1);
+    }
+
+    #[test]
+    fn expired_reply_sends_no_bytes_and_keeps_reservation() {
+        let _env = crate::test_support::env_write();
+        let previous = std::env::var_os("IRLUME_GRACE_MS");
+        std::env::set_var("IRLUME_GRACE_MS", "1");
+        let f = Fixture::new();
+        let reply = grant_reply(&f);
+        match previous {
+            Some(v) => std::env::set_var("IRLUME_GRACE_MS", v),
+            None => std::env::remove_var("IRLUME_GRACE_MS"),
+        }
+        let window = reply.completion.as_ref().unwrap().window;
+        while window.check().is_ok() {
+            std::thread::yield_now();
+        }
+        let (server, client) = std::os::unix::net::UnixStream::pair().unwrap();
+        assert!(reply.respond(server).is_err());
+        let mut bytes = Vec::new();
+        (&client).read_to_end(&mut bytes).unwrap();
+        assert!(bytes.is_empty());
+        assert_eq!(f.saved().budget.unwrap().unsuccessful_requests, 1);
+        assert!(f.store.operation(&account_one()).is_ok());
+    }
+
+    #[test]
+    fn malformed_v2_budget_never_becomes_new_epoch() {
+        for budget in [
+            r#"{"unsuccessful_requests":51,"pending":false}"#,
+            r#"{"unsuccessful_requests":0,"pending":true}"#,
+            r#"{"unsuccessful_requests":1}"#,
+            r#"{"unsuccessful_requests":1,"pending":false,"extra":0}"#,
+        ] {
+            let f = Fixture::new();
+            let value = format!(
+                r#"{{"version":2,"uid":1001,"account":"synthetic-one","strikes":0,"cooldown":null,"budget":{budget}}}"#
+            );
+            f.plant(value.as_bytes());
+            assert!(start_attempt(&f).is_err());
+            assert_eq!(f.bytes(), value.as_bytes());
+        }
+        let f = Fixture::new();
+        f.plant(br#"{"version":1,"uid":1001,"account":"synthetic-one","strikes":0,"cooldown":null,"budget":null}"#);
+        assert!(start_attempt(&f).is_err());
+    }
+
+    #[test]
+    fn stalled_partial_response_keeps_charge_and_releases_owner() {
+        use std::os::fd::AsRawFd;
+        let _env = crate::test_support::env_write();
+        let previous = std::env::var_os("IRLUME_GRACE_MS");
+        std::env::set_var("IRLUME_GRACE_MS", "500");
+        let f = Fixture::new();
+        let mut reply = grant_reply(&f);
+        match previous {
+            Some(v) => std::env::set_var("IRLUME_GRACE_MS", v),
+            None => std::env::remove_var("IRLUME_GRACE_MS"),
+        }
+        if let crate::Response::AuthResult { reason, .. } = &mut reply.response {
+            *reason = "synthetic".repeat(32768);
+        }
+        let (server, client) = std::os::unix::net::UnixStream::pair().unwrap();
+        let size: libc::c_int = 4096;
+        assert_eq!(
+            // SAFETY: server is live and size is a correctly sized integer option.
+            unsafe {
+                libc::setsockopt(
+                    server.as_raw_fd(),
+                    libc::SOL_SOCKET,
+                    libc::SO_SNDBUF,
+                    std::ptr::from_ref(&size).cast(),
+                    std::mem::size_of_val(&size) as libc::socklen_t,
+                )
+            },
+            0
+        );
+        assert!(reply.respond(server).is_err());
+        let mut bytes = Vec::new();
+        (&client).read_to_end(&mut bytes).unwrap();
+        assert!(!bytes.ends_with(b"\n"), "no complete reply was written");
+        assert_eq!(f.saved().budget.unwrap().unsuccessful_requests, 1);
+        assert!(f.store.operation(&account_one()).is_ok());
+    }
+
+    #[test]
+    fn reboot_cannot_refill_exhausted_budget_and_other_accounts_stay_independent() {
+        let f = Fixture::new();
+        for _ in 0..50 {
+            start_attempt(&f)
+                .unwrap()
+                .unwrap()
+                .denied(&outcome(Kind::NoFace))
+                .unwrap();
+        }
+        assert!(f
+            .store
+            .check(&account_one(), POLICY, reboot, write_atomic_reporting)
+            .unwrap());
+        assert!(FaceAttempt::begin(
+            store(&f),
+            account_one(),
+            POLICY,
+            reboot,
+            write_atomic_reporting
+        )
+        .unwrap()
+        .is_none());
+        let other = Account {
+            uid: 1002,
+            name: "synthetic-two".into(),
+        };
+        let granted = FaceAttempt::begin(store(&f), other, POLICY, reboot, write_atomic_reporting)
+            .unwrap()
+            .unwrap();
+        granted.delivered().unwrap();
+        assert_eq!(f.saved().budget.unwrap().unsuccessful_requests, 50);
+    }
+
+    #[test]
+    fn failed_success_reset_keeps_the_durable_reservation() {
+        let f = Fixture::new();
+        let mut attempt = start_attempt(&f).unwrap().unwrap();
+        attempt.writer = before_rename;
+        assert!(attempt.delivered().is_err());
+        let saved = f.saved().budget.unwrap();
+        assert_eq!(saved.unsuccessful_requests, 1);
+        assert!(saved.pending);
+        assert!(f.store.operation(&account_one()).is_ok());
+    }
 }
 
 #[test]
@@ -772,4 +1104,20 @@ fn record_owner_and_nested_cooldown_schema_are_checked() {
             .check(&account_one(), POLICY, now, write_atomic_reporting)
             .is_err());
     }
+}
+
+#[test]
+fn authentication_budget_expired_before_commit_preserves_retry_history() {
+    let fixture = Fixture::new();
+    fixture.record(Kind::Spoof);
+    let result = fixture.store.record_if(
+        &account_one(),
+        POLICY,
+        &outcome(Kind::Granted),
+        now,
+        write_atomic_reporting,
+        || false,
+    );
+    assert!(result.is_err(), "expired success must not commit");
+    assert_eq!(fixture.saved().strikes, 1);
 }

--- a/crates/irlume-kwallet-init/Cargo.toml
+++ b/crates/irlume-kwallet-init/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 [dependencies]
 irlume-common.workspace = true
 libc.workspace = true
+zeroize.workspace = true
 
 [lints]
 workspace = true

--- a/crates/irlume-kwallet-init/src/main.rs
+++ b/crates/irlume-kwallet-init/src/main.rs
@@ -25,11 +25,13 @@
 //! Spawned from the daemon it would live in `irlumed.service`, and restarting
 //! irlume would take the user's wallet daemon down with it.
 
-use irlume_common::kwallet_wire::{KEY_LEN, LOGIN_ENV, SOCKET_NAME};
+use irlume_common::kwallet_wire::{KEY_LEN, LOGIN_ENV, SALT_ABSENT_EXIT, SALT_LEN, SOCKET_NAME};
 use std::ffi::CString;
-use std::io::Read;
+use std::io::{Read, Write};
+use std::os::fd::AsFd as _;
 use std::os::unix::ffi::OsStrExt;
 use std::path::PathBuf;
+use zeroize::{Zeroize as _, Zeroizing};
 
 /// Binaries that understand `--pam-login`, most specific first.
 ///
@@ -49,6 +51,25 @@ fn main() -> std::process::ExitCode {
         eprintln!("usage: irlume-kwallet-init <username>  (key on stdin)");
         return std::process::ExitCode::from(2);
     };
+    if user == "--read-salt" {
+        let Some(user) = args.next() else {
+            return std::process::ExitCode::from(2);
+        };
+        if args.next().is_some() {
+            return std::process::ExitCode::from(2);
+        }
+        return match read_salt_mode(&user.to_string_lossy()) {
+            Ok(salt) => match write_salt(salt.expose()) {
+                Ok(()) => std::process::ExitCode::SUCCESS,
+                Err(_) => std::process::ExitCode::FAILURE,
+            },
+            Err(SaltReadError::Absent) => std::process::ExitCode::from(SALT_ABSENT_EXIT as u8),
+            Err(SaltReadError::Failed) => std::process::ExitCode::FAILURE,
+        };
+    }
+    if args.next().is_some() {
+        return std::process::ExitCode::from(2);
+    }
     let user = user.to_string_lossy().into_owned();
 
     match run(&user) {
@@ -66,18 +87,21 @@ fn main() -> std::process::ExitCode {
     }
 }
 
+fn write_salt(salt: &[u8]) -> std::io::Result<()> {
+    let stdout = std::io::stdout();
+    write_salt_to(stdout.lock(), salt)
+}
+
+fn write_salt_to(mut out: impl Write, salt: &[u8]) -> std::io::Result<()> {
+    out.write_all(salt)?;
+    out.flush()
+}
+
 fn run(user: &str) -> Result<PathBuf, String> {
     // Read the key first. If it is not exactly KEY_LEN bytes, stop before any
     // process is spawned: ksecretd blocks forever on a short key and silently
     // truncates a long one, so neither failure would be visible at a login.
-    let mut key = vec![0u8; KEY_LEN];
-    std::io::stdin()
-        .read_exact(&mut key)
-        .map_err(|e| format!("expected {KEY_LEN} bytes of wallet key on stdin: {e}"))?;
-    let mut extra = [0u8; 1];
-    if let Ok(1) = std::io::stdin().read(&mut extra) {
-        return Err(format!("more than {KEY_LEN} bytes on stdin; refusing"));
-    }
+    let mut key = read_wallet_key_from_stdin()?;
 
     let pw = lookup_user(user)?;
     let runtime_dir = PathBuf::from(format!("/run/user/{}", pw.uid));
@@ -131,6 +155,12 @@ fn run(user: &str) -> Result<PathBuf, String> {
         unsafe {
             libc::close(status_read);
             libc::close(write_fd);
+            // The parent alone writes the key to ksecretd. `fork` replicated
+            // the allocation into this child but did not inherit its mlock;
+            // wipe those bytes before either execve or the `_exit` failure
+            // branch. Slice zeroization is allocation-free and does not run a
+            // Vec destructor in the post-fork child.
+            wipe_fork_child_key(&mut key);
             child_exec(&exe, read_fd, listener, &plan);
             // Only reached when execve failed. The byte distinguishes that from
             // the EOF a successful exec produces.
@@ -169,6 +199,39 @@ fn run(user: &str) -> Result<PathBuf, String> {
         libc::close(write_fd)
     };
     Ok(sock_path)
+}
+
+fn read_wallet_key_from_stdin() -> Result<Zeroizing<Vec<u8>>, String> {
+    // Stdin's Read implementation retains a second copy in a global buffer.
+    // An unbuffered File reads directly into our protected allocation; cloning
+    // its descriptor preserves stdin ownership and closes the copy before fork.
+    let input = std::fs::File::from(
+        std::io::stdin()
+            .as_fd()
+            .try_clone_to_owned()
+            .map_err(|e| format!("expected {KEY_LEN} bytes of wallet key on stdin: {e}"))?,
+    );
+    read_wallet_key(input)
+}
+
+fn read_wallet_key(mut input: impl Read) -> Result<Zeroizing<Vec<u8>>, String> {
+    let mut key = Zeroizing::new(vec![0u8; KEY_LEN]);
+    // Protect the allocation before input can place even a partial key in it.
+    // The lock remains best effort so login behavior is unchanged when the
+    // process lacks sufficient RLIMIT_MEMLOCK.
+    irlume_common::memlock::lock_slice(&key);
+    input
+        .read_exact(&mut key)
+        .map_err(|e| format!("expected {KEY_LEN} bytes of wallet key on stdin: {e}"))?;
+    let mut extra = Zeroizing::new([0u8; 1]);
+    if let Ok(1) = input.read(&mut *extra) {
+        return Err(format!("more than {KEY_LEN} bytes on stdin; refusing"));
+    }
+    Ok(key)
+}
+
+fn wipe_fork_child_key(key: &mut [u8]) {
+    key.zeroize();
 }
 
 /// Become the target user, permanently.
@@ -254,6 +317,7 @@ struct User {
     uid: libc::uid_t,
     gid: libc::gid_t,
     name: CString,
+    home: PathBuf,
 }
 
 fn lookup_user(user: &str) -> Result<User, String> {
@@ -265,7 +329,13 @@ fn lookup_user(user: &str) -> Result<User, String> {
         return Err(format!("no such user: {user}"));
     }
     #[expect(clippy::undocumented_unsafe_blocks, reason = "doc backlog")]
-    let (uid, gid) = unsafe { ((*pw).pw_uid, (*pw).pw_gid) };
+    let (uid, gid, home) = unsafe {
+        (
+            (*pw).pw_uid,
+            (*pw).pw_gid,
+            std::ffi::CStr::from_ptr((*pw).pw_dir).to_bytes().to_vec(),
+        )
+    };
     if uid == 0 {
         return Err("refusing to open a wallet for uid 0".to_string());
     }
@@ -273,7 +343,220 @@ fn lookup_user(user: &str) -> Result<User, String> {
         uid,
         gid,
         name: cname,
+        home: PathBuf::from(std::ffi::OsStr::from_bytes(&home)),
     })
+}
+
+const MAX_SALT_BYTES: u64 = 4096;
+const SALT_RELPATH: &str = ".local/share/kwalletd/kdewallet.salt";
+
+enum SaltReadError {
+    Absent,
+    Failed,
+}
+
+fn read_salt_mode(user: &str) -> Result<irlume_common::SecretBytes, SaltReadError> {
+    let pw = lookup_salt_user(user, lookup_user)?;
+    enter_user(&pw).map_err(|_| SaltReadError::Failed)?;
+    read_salt_at(&pw.home.join(SALT_RELPATH))
+}
+
+fn lookup_salt_user(
+    user: &str,
+    lookup: impl FnOnce(&str) -> Result<User, String>,
+) -> Result<User, SaltReadError> {
+    if user.is_empty()
+        || user.len() > 255
+        || user.starts_with('-')
+        || !user
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-' | b'.' | b'$'))
+    {
+        return Err(SaltReadError::Failed);
+    }
+    lookup(user).map_err(|_| SaltReadError::Failed)
+}
+
+fn read_salt_at(path: &std::path::Path) -> Result<irlume_common::SecretBytes, SaltReadError> {
+    use std::os::unix::fs::{FileTypeExt as _, OpenOptionsExt as _};
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NONBLOCK | libc::O_NOFOLLOW)
+        .open(path)
+        .map_err(|error| {
+            if error.kind() == std::io::ErrorKind::NotFound {
+                SaltReadError::Absent
+            } else {
+                SaltReadError::Failed
+            }
+        })?;
+    let meta = file.metadata().map_err(|_| SaltReadError::Failed)?;
+    if !meta.file_type().is_file() || meta.file_type().is_fifo() || meta.len() > MAX_SALT_BYTES {
+        return Err(SaltReadError::Failed);
+    }
+    let mut raw = Vec::with_capacity(meta.len() as usize);
+    file.take(MAX_SALT_BYTES)
+        .read_to_end(&mut raw)
+        .map_err(|_| SaltReadError::Failed)?;
+    if raw.len() < SALT_LEN {
+        return Err(SaltReadError::Failed);
+    }
+    raw.truncate(SALT_LEN);
+    Ok(irlume_common::SecretBytes::new(raw))
+}
+
+#[expect(
+    clippy::undocumented_unsafe_blocks,
+    reason = "libc credential queries have no Rust wrapper"
+)]
+fn enter_user(pw: &User) -> Result<(), String> {
+    let (ruid, euid, rgid, egid) = unsafe {
+        (
+            libc::getuid(),
+            libc::geteuid(),
+            libc::getgid(),
+            libc::getegid(),
+        )
+    };
+    if ruid == 0 && euid == 0 && rgid == 0 && egid == 0 {
+        drop_privileges(pw)?;
+    } else if ruid != pw.uid || euid != pw.uid || rgid != pw.gid || egid != pw.gid {
+        return Err("mixed or wrong credentials".into());
+    }
+    clear_capabilities()?;
+    verify_credentials(pw)
+}
+
+#[expect(
+    clippy::undocumented_unsafe_blocks,
+    reason = "Linux capability operations have no libc wrapper"
+)]
+fn clear_capabilities() -> Result<(), String> {
+    let mut header = CapHeader {
+        version: 0x2008_0522,
+        pid: 0,
+    };
+    let data = [CapData {
+        effective: 0,
+        permitted: 0,
+        inheritable: 0,
+    }; 2];
+    if unsafe { libc::syscall(libc::SYS_capset, &mut header, data.as_ptr()) } != 0
+        || unsafe {
+            libc::prctl(
+                libc::PR_CAP_AMBIENT,
+                libc::PR_CAP_AMBIENT_CLEAR_ALL,
+                0,
+                0,
+                0,
+            )
+        } != 0
+    {
+        return Err("could not clear capabilities".into());
+    }
+    Ok(())
+}
+
+#[expect(
+    clippy::undocumented_unsafe_blocks,
+    reason = "Linux credential and capability queries have no safe wrapper"
+)]
+fn verify_credentials(pw: &User) -> Result<(), String> {
+    let mut uids = [0; 3];
+    let mut gids = [0; 3];
+    if unsafe { libc::getresuid(&mut uids[0], &mut uids[1], &mut uids[2]) } != 0
+        || unsafe { libc::getresgid(&mut gids[0], &mut gids[1], &mut gids[2]) } != 0
+        || uids != [pw.uid; 3]
+        || gids != [pw.gid; 3]
+    {
+        return Err("saved credentials retained".into());
+    }
+    let fsuid = unsafe { libc::setfsuid(libc::uid_t::MAX) };
+    let fsgid = unsafe { libc::setfsgid(libc::gid_t::MAX) };
+    if fsuid as libc::uid_t != pw.uid || fsgid as libc::gid_t != pw.gid {
+        return Err("filesystem credentials differ".into());
+    }
+    verify_groups(pw)?;
+    let mut header = CapHeader {
+        version: 0x2008_0522,
+        pid: 0,
+    };
+    let mut data = [CapData {
+        effective: 0,
+        permitted: 0,
+        inheritable: 0,
+    }; 2];
+    if unsafe { libc::syscall(libc::SYS_capget, &mut header, data.as_mut_ptr()) } != 0
+        || data
+            .iter()
+            .any(|x| x.effective != 0 || x.permitted != 0 || x.inheritable != 0)
+    {
+        return Err("capabilities retained".into());
+    }
+    for capability in 0..64 {
+        let held = unsafe {
+            libc::prctl(
+                libc::PR_CAP_AMBIENT,
+                libc::PR_CAP_AMBIENT_IS_SET,
+                capability,
+                0,
+                0,
+            )
+        };
+        if held > 0 {
+            return Err("ambient capability retained".into());
+        }
+    }
+    Ok(())
+}
+
+#[repr(C)]
+struct CapHeader {
+    version: u32,
+    pid: i32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct CapData {
+    effective: u32,
+    permitted: u32,
+    inheritable: u32,
+}
+
+#[expect(
+    clippy::undocumented_unsafe_blocks,
+    reason = "libc group-list queries have no Rust wrapper"
+)]
+fn verify_groups(pw: &User) -> Result<(), String> {
+    let mut count = 0;
+    unsafe { libc::getgrouplist(pw.name.as_ptr(), pw.gid, std::ptr::null_mut(), &mut count) };
+    if count <= 0 {
+        return Err("account groups unavailable".into());
+    }
+    let mut expected = vec![0; count as usize];
+    if unsafe { libc::getgrouplist(pw.name.as_ptr(), pw.gid, expected.as_mut_ptr(), &mut count) }
+        < 0
+    {
+        return Err("account groups changed".into());
+    }
+    expected.truncate(count as usize);
+    let actual_count = unsafe { libc::getgroups(0, std::ptr::null_mut()) };
+    if actual_count < 0 {
+        return Err("process groups unavailable".into());
+    }
+    let mut actual = vec![0; actual_count as usize];
+    if unsafe { libc::getgroups(actual_count, actual.as_mut_ptr()) } < 0 {
+        return Err("process groups unavailable".into());
+    }
+    expected.sort_unstable();
+    expected.dedup();
+    actual.sort_unstable();
+    actual.dedup();
+    if actual != expected {
+        return Err("supplementary groups differ".into());
+    }
+    Ok(())
 }
 
 /// Whether this process holds privilege that the environment must not steer.
@@ -546,8 +829,229 @@ fn write_all(fd: libc::c_int, mut buf: &[u8]) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{LaunchPlan, LOGIN_ENV};
+    use super::{
+        enter_user, lookup_salt_user, read_salt_at, read_wallet_key, verify_credentials,
+        wipe_fork_child_key, write_salt_to, LaunchPlan, User, KEY_LEN, LOGIN_ENV, SALT_LEN,
+    };
     use std::ffi::{CStr, CString};
+    use std::os::unix::ffi::OsStrExt as _;
+
+    #[test]
+    #[ignore = "fresh-exec child invoked by wallet_stdin_does_not_buffer_key_bytes"]
+    fn wallet_stdin_child() {
+        let error = super::read_wallet_key_from_stdin().expect_err("oversized input must fail");
+        assert!(error.contains("more than 56 bytes"));
+        let mut remaining: libc::c_int = 0;
+        // SAFETY: stdin is the parent-provided pipe and FIONREAD writes one int
+        // through this valid pointer; it neither reads key bytes nor owns the fd.
+        let result = unsafe { libc::ioctl(libc::STDIN_FILENO, libc::FIONREAD, &mut remaining) };
+        assert_eq!(result, 0);
+        assert_eq!(
+            remaining, 43,
+            "only the key and one-byte probe may leave the pipe"
+        );
+    }
+
+    #[test]
+    fn wallet_stdin_does_not_buffer_key_bytes() {
+        use std::io::Write as _;
+        let mut child = std::process::Command::new(std::env::current_exe().unwrap())
+            .args(["--ignored", "--exact", "tests::wallet_stdin_child"])
+            .stdin(std::process::Stdio::piped())
+            .spawn()
+            .unwrap();
+        let mut input = child.stdin.take().unwrap();
+        input.write_all(&[0x5a; 100]).unwrap();
+        drop(input);
+        assert!(child.wait().unwrap().success());
+    }
+
+    #[test]
+    fn wallet_key_input_is_exact_and_owned_by_a_wiping_buffer() {
+        let exact = vec![0x41; KEY_LEN];
+        let key: zeroize::Zeroizing<Vec<u8>> =
+            read_wallet_key(std::io::Cursor::new(exact.clone())).unwrap();
+        assert_eq!(&**key, &exact);
+
+        let short = read_wallet_key(std::io::Cursor::new(vec![0x42; KEY_LEN - 1]))
+            .expect_err("a partial key must fail");
+        assert!(short.contains("expected 56 bytes"));
+
+        let oversized = read_wallet_key(std::io::Cursor::new(vec![0x43; KEY_LEN + 1]))
+            .expect_err("a 57th byte must fail");
+        assert!(oversized.contains("more than 56 bytes"));
+
+        struct FailedRead;
+        impl std::io::Read for FailedRead {
+            fn read(&mut self, _: &mut [u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::other("synthetic input failure"))
+            }
+        }
+        let failed = read_wallet_key(FailedRead).expect_err("input errors must fail");
+        assert!(failed.contains("synthetic input failure"));
+    }
+
+    #[test]
+    #[expect(
+        clippy::undocumented_unsafe_blocks,
+        reason = "fork/pipe verify child-only zeroization and parent copy-on-write isolation"
+    )]
+    fn fork_child_wipes_its_key_without_changing_the_parent() {
+        use std::io::Read as _;
+        use std::os::fd::FromRawFd as _;
+
+        let mut key = vec![0x5a; KEY_LEN];
+        let mut fds = [-1; 2];
+        assert_eq!(unsafe { libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC) }, 0);
+        let pid = unsafe { libc::fork() };
+        assert!(pid >= 0);
+        if pid == 0 {
+            unsafe { libc::close(fds[0]) };
+            wipe_fork_child_key(&mut key);
+            unsafe {
+                libc::write(fds[1], key.as_ptr().cast(), key.len());
+                libc::close(fds[1]);
+                libc::_exit(0);
+            }
+        }
+        unsafe { libc::close(fds[1]) };
+        let mut reader = unsafe { std::fs::File::from_raw_fd(fds[0]) };
+        let mut child_key = vec![0xff; KEY_LEN];
+        reader.read_exact(&mut child_key).unwrap();
+        let mut status = 0;
+        assert_eq!(unsafe { libc::waitpid(pid, &mut status, 0) }, pid);
+        assert_eq!(status, 0);
+        assert_eq!(child_key, vec![0; KEY_LEN]);
+        assert_eq!(key, vec![0x5a; KEY_LEN]);
+    }
+
+    #[test]
+    #[ignore = "fresh-exec child invoked by salt_reader_boundaries"]
+    fn salt_reader_child() {
+        let path = std::env::var_os("IRLUME_TEST_SALT_PATH").expect("path");
+        let expected = std::env::var("IRLUME_TEST_SALT_EXPECT").expect("expectation");
+        match (read_salt_at(std::path::Path::new(&path)), expected.as_str()) {
+            (Ok(salt), "ok") => assert_eq!(salt.expose(), &[7; SALT_LEN]),
+            (Err(super::SaltReadError::Absent), "absent")
+            | (Err(super::SaltReadError::Failed), "fail") => {}
+            _ => panic!("unexpected salt-read result"),
+        }
+    }
+
+    #[test]
+    #[ignore = "fresh-exec child invoked by broken_reader_is_reported"]
+    #[expect(
+        clippy::undocumented_unsafe_blocks,
+        reason = "pipe setup and ownership transfer require libc/raw-fd calls"
+    )]
+    fn salt_stdout_child() {
+        use std::os::fd::FromRawFd as _;
+        let mut fds = [-1; 2];
+        assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0);
+        assert_eq!(unsafe { libc::close(fds[0]) }, 0);
+        let writer = std::io::BufWriter::with_capacity(SALT_LEN * 2, unsafe {
+            std::fs::File::from_raw_fd(fds[1])
+        });
+        let error = write_salt_to(writer, &[7; SALT_LEN]).expect_err("reader is closed");
+        assert_eq!(error.kind(), std::io::ErrorKind::BrokenPipe);
+    }
+
+    #[test]
+    fn broken_reader_is_reported() {
+        let mut child = std::process::Command::new(std::env::current_exe().unwrap())
+            .args(["--ignored", "--exact", "tests::salt_stdout_child"])
+            .stdout(std::process::Stdio::null())
+            .spawn()
+            .unwrap();
+        assert!(child.wait().unwrap().success());
+    }
+
+    #[test]
+    fn salt_lookup_accepts_the_daemons_machine_account_grammar_only() {
+        let expected = User {
+            uid: 123,
+            gid: 456,
+            name: CString::new("host$").unwrap(),
+            home: "/synthetic/home".into(),
+        };
+        let found = lookup_salt_user("host$", |name| {
+            assert_eq!(name, "host$");
+            Ok(expected)
+        })
+        .unwrap_or_else(|_| panic!("a daemon-accepted machine account must reach NSS lookup"));
+        assert_eq!(found.name.as_bytes(), b"host$");
+
+        for invalid in ["bad/name", "bad\0name", "bad!name"] {
+            assert!(
+                lookup_salt_user(invalid, |_| panic!("invalid names must not reach NSS")).is_err()
+            );
+        }
+    }
+
+    fn child_result(path: &std::path::Path, expected: &str) {
+        let status = std::process::Command::new(std::env::current_exe().unwrap())
+            .args(["--ignored", "--exact", "tests::salt_reader_child"])
+            .env("IRLUME_TEST_SALT_PATH", path)
+            .env("IRLUME_TEST_SALT_EXPECT", expected)
+            .status()
+            .unwrap();
+        assert!(status.success());
+    }
+
+    #[test]
+    #[expect(
+        clippy::undocumented_unsafe_blocks,
+        reason = "mkfifo has no Rust standard-library wrapper"
+    )]
+    fn salt_reader_boundaries_run_in_fresh_processes() {
+        use std::os::unix::fs::{symlink, PermissionsExt as _};
+        let root = std::env::temp_dir().join(format!("irlume-salt-reader-{}", std::process::id()));
+        let home = root.join("home");
+        let outside = root.join("outside");
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::create_dir_all(outside.join("share/kwalletd")).unwrap();
+        symlink(root.join("outside"), home.join(".local")).unwrap();
+        let salt = outside.join("share/kwalletd/kdewallet.salt");
+        let relocated_salt = home.join(".local/share/kwalletd/kdewallet.salt");
+        std::fs::write(&salt, vec![7; SALT_LEN]).unwrap();
+        child_result(&relocated_salt, "ok");
+        std::fs::set_permissions(root.join("outside"), std::fs::Permissions::from_mode(0o0))
+            .unwrap();
+        child_result(&salt, "fail");
+        std::fs::set_permissions(root.join("outside"), std::fs::Permissions::from_mode(0o700))
+            .unwrap();
+        std::fs::write(&salt, vec![7; SALT_LEN - 1]).unwrap();
+        child_result(&salt, "fail");
+        std::fs::write(&salt, vec![7; 4097]).unwrap();
+        child_result(&salt, "fail");
+        std::fs::remove_file(&salt).unwrap();
+        child_result(&salt, "absent");
+        symlink("/dev/null", &salt).unwrap();
+        child_result(&salt, "fail");
+        std::fs::remove_file(&salt).unwrap();
+        let c = CString::new(salt.as_os_str().as_bytes()).unwrap();
+        assert_eq!(unsafe { libc::mkfifo(c.as_ptr(), 0o600) }, 0);
+        child_result(&salt, "fail");
+        std::fs::remove_file(&salt).unwrap();
+        std::fs::create_dir(&salt).unwrap();
+        child_result(&salt, "fail");
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn credential_verifier_rejects_retained_or_wrong_identity() {
+        let name = std::env::var("USER").unwrap();
+        let current = super::lookup_user(&name).unwrap();
+        enter_user(&current).expect("self mode must permanently normalize credentials");
+        verify_credentials(&current).expect("ordinary login credentials are exact");
+        let wrong = User {
+            uid: current.uid.wrapping_add(1),
+            gid: current.gid,
+            name: current.name.clone(),
+            home: current.home.clone(),
+        };
+        assert!(enter_user(&wrong).is_err());
+    }
 
     /// Read back an argv/envp array the way `execve` would: pointers until NULL.
     ///

--- a/crates/irlume-pam/src/lib.rs
+++ b/crates/irlume-pam/src/lib.rs
@@ -330,19 +330,33 @@ impl PamServiceModule for IrlumePam {
             //
             //  * Passive peek (everything else: sudo verify, lock screen `wait`): just
             //    read PAM_AUTHTOK if some earlier module/greeter already set it. We must
-            //    NOT actively prompt here: in `wait` mode KDE runs us as a PARALLEL
-            //    biometric device (kde-fingerprint) and cancels us natively the moment
-            //    a key is pressed, so an echo-off password probe here would hijack the
-            //    password field. A privileged one-shot service offers its explicit
+            //    NOT actively prompt here: a dedicated biometric transaction must
+            //    leave password input to the frontend's password transaction.
+            //    Cancellation depends on that frontend's worker lifecycle; a queued
+            //    PAM conversation cancellation may not interrupt our synchronous
+            //    daemon request (see docs/DESKTOP-AUTH.md).
+            //    A privileged one-shot service offers its explicit
             //    face-intent choice only after this password-first check, then obtains
             //    the ordinary PAM token so a non-`yes` password is not asked twice.
             let typed = if unseal && !wait && !facefirst {
-                pamh.get_authtok(Some("Password: "))
+                match pamh.get_authtok(Some("Password: ")) {
+                    Ok(Some(token)) => Some(token),
+                    // Only an explicitly returned empty token chooses face.
+                    // Cancellation/EOF or a missing token is not empty input:
+                    // leave the stack before any daemon or credential request.
+                    Ok(None) | Err(_) => return PamError::IGNORE,
+                }
             } else {
-                pamh.get_cached_authtok()
+                pamh.get_cached_authtok().ok().flatten()
             };
-            if let Ok(Some(tok)) = typed {
+            if let Some(tok) = typed {
                 if !tok.to_bytes().is_empty() {
+                    return PamError::IGNORE;
+                }
+                // The active probe caches even an empty answer. It selected
+                // face, not an empty Unix password: consume it so a timeout or
+                // refusal lets the next provider ask for a fresh password.
+                if unseal && !wait && !facefirst && pamh.clear_authtok().is_err() {
                     return PamError::IGNORE;
                 }
             }
@@ -509,9 +523,15 @@ fn try_reseal_session(pamh: &Pam, user: &str) {
         // took a path that never set a token); nothing to heal.
         _ => return,
     };
+    let wallet_salt = match irlume_common::client::read_wallet_salt(user) {
+        Ok(salt) => salt,
+        Err(_) => return,
+    };
     let _ = request(&Request::ResealPassword {
         user: user.to_string(),
         password: pw,
+        wallet_salt,
+        wallet_salt_checked: true,
     });
 }
 

--- a/crates/irlume-pam/tests/pamwrap.rs
+++ b/crates/irlume-pam/tests/pamwrap.rs
@@ -63,6 +63,8 @@ struct Harness {
     config_dir: PathBuf,
     /// Where this test's fake daemon listens (IRLUME_SOCKET).
     socket: PathBuf,
+    /// Closed machine-protocol salt helper; absent is the default fixture.
+    salt_helper: PathBuf,
     root: PathBuf,
 }
 
@@ -107,6 +109,14 @@ impl Harness {
         std::fs::create_dir_all(&service_dir).unwrap();
         let config_dir = root.join("cfg");
         std::fs::create_dir_all(&config_dir).unwrap();
+        let salt_helper = root.join("wallet-salt-helper");
+        std::fs::write(
+            &salt_helper,
+            "#!/bin/sh\n[ \"$1\" = --read-salt ] && [ \"$2\" = tester ] && [ \"$#\" -eq 2 ] || exit 1\nexit 3\n",
+        )
+        .unwrap();
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(&salt_helper, std::fs::Permissions::from_mode(0o700)).unwrap();
         Some(Harness {
             wrapper,
             set_items,
@@ -115,6 +125,7 @@ impl Harness {
             service_dir,
             config_dir,
             root,
+            salt_helper,
         })
     }
 
@@ -168,6 +179,7 @@ impl Harness {
             .env("PAM_WRAPPER_SERVICE_DIR", &self.service_dir)
             .env("IRLUME_SOCKET", &self.socket)
             .env("IRLUME_CONFIG_DIR", &self.config_dir)
+            .env("IRLUME_KWALLET_INIT", &self.salt_helper)
             .env_remove("IRLUME_CREDENTIAL_RELEASE_CHALLENGE")
             .env_remove("IRLUME_CONSENT_GESTURE")
             .stdin(Stdio::piped())
@@ -428,6 +440,7 @@ fn pamwrap_granting_daemon_face_path() {
 }
 
 const FACE_INTENT_INFO: &str = "Type yes to use face authentication";
+
 const FIXED_TEST_TOKEN: &str = "fixed-test-token";
 const WRONG_TEST_TOKEN: &str = "wrong-fixed-token";
 
@@ -1090,6 +1103,44 @@ fn pamwrap_typed_password_never_fires_the_camera() {
     );
 }
 
+/// EOF fails the active PAM conversation; it is not an explicit empty reply.
+/// A failed/cancelled password probe must never start a face or release request.
+#[test]
+#[ignore = "needs pam_wrapper + pamtester (CI installs them; see this file's header)"]
+fn pamwrap_failed_password_probe_never_contacts_daemon() {
+    for (index, flags) in ["unseal", "unseal ondemand", "unseal ondemand kr"]
+        .iter()
+        .enumerate()
+    {
+        let Some(h) = Harness::try_new(&format!("failed-probe-{index}")) else {
+            return;
+        };
+        h.write_service(
+            "kde",
+            &[
+                h.auth_line("sufficient", flags),
+                "auth required pam_deny.so".into(),
+            ],
+        );
+        let log = serve(&h.socket, |req| match req {
+            Request::UnsealPassword { .. } => Response::UnsealUnavailable {
+                reason: "synthetic warm screen unlock".into(),
+            },
+            Request::Authenticate { .. } => grant(),
+            _ => Response::Error("unexpected request".into()),
+        });
+        // Closed stdin makes pamtester's conversation fail instead of returning
+        // the explicit empty token supplied by "\n" in the positive tests.
+        let (ok, out) = h.run("kde", &["authenticate"], "", None);
+        let reqs = log.lock().unwrap();
+        assert!(
+            reqs.is_empty(),
+            "failed password probe must not contact daemon ({flags}): {reqs:?}; {out}"
+        );
+        assert!(!ok, "cancelled probe must not grant ({flags}): {out}");
+    }
+}
+
 /// A daemon that answers with a line that is not JSON: the reply fails to
 /// parse, the module IGNOREs, and the stack fails closed.
 #[test]
@@ -1430,8 +1481,15 @@ fn pamwrap_reseal_stashes_on_auth_and_reseals_on_session() {
         other => panic!("expected the delivery query second, got {other:?}"),
     }
     match &reqs[0] {
-        Request::ResealPassword { user, password } => {
+        Request::ResealPassword {
+            user,
+            password,
+            wallet_salt,
+            wallet_salt_checked,
+        } => {
             assert_eq!(user, "tester");
+            assert!(*wallet_salt_checked);
+            assert!(wallet_salt.is_none());
             assert_eq!(
                 password.expose(),
                 b"hunter2",
@@ -1667,5 +1725,47 @@ fn pamwrap_removed_gesture_settings_do_not_change_privileged_confirmation() {
                 assert!(!out.contains(removed), "{out}");
             }
         }
+    }
+}
+
+/// A bounded face attempt must return to a fresh password prompt without
+/// granting or starting a second scan, on both desktop and privileged paths.
+#[test]
+#[ignore = "needs pam_wrapper + pamtester (CI installs them; see this file's header)"]
+fn pamwrap_authentication_deadline_keeps_fresh_password_fallback() {
+    for (service, flags, consent) in [("kde", "unseal ondemand", "\n"), ("sudo", "", "yes\n")] {
+        let Some(h) = Harness::try_new(&format!("deadline-{service}")) else {
+            return;
+        };
+        let checker = h.token_checker("deadline", FIXED_TEST_TOKEN);
+        h.write_service(
+            service,
+            &[
+                h.auth_line("sufficient", flags),
+                format!(
+                    "auth required pam_exec.so expose_authtok {}",
+                    checker.display()
+                ),
+            ],
+        );
+        let log = serve(&h.socket, |_| {
+            Response::Error(irlume_common::Error::DeadlineExpired.to_string())
+        });
+        let (ok, out) = h.run(
+            service,
+            &["authenticate"],
+            &format!("{consent}{FIXED_TEST_TOKEN}\n"),
+            None,
+        );
+        assert!(
+            ok,
+            "expiry must reach a fresh password prompt: {service}: {out}"
+        );
+        assert!(!out.contains(FIXED_TEST_TOKEN));
+        assert_eq!(
+            log.lock().unwrap().len(),
+            1,
+            "expiry cannot trigger another face request"
+        );
     }
 }

--- a/crates/irlume-password-verify/Cargo.toml
+++ b/crates/irlume-password-verify/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "irlume-password-verify"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[dependencies]
+libc.workspace = true
+zeroize.workspace = true
+
+[dev-dependencies]
+tempfile = "3"
+
+[lints]
+workspace = true

--- a/crates/irlume-password-verify/README.md
+++ b/crates/irlume-password-verify/README.md
@@ -1,0 +1,42 @@
+# Private retry password verifier
+
+`/usr/libexec/irlume-password-verify USER` is a root-only, **non-setuid**
+helper. Both real and effective UID must be zero. The daemon supplies a cleared
+environment and a private stdin pipe containing 1–4096 raw password bytes,
+terminated by EOF. NUL is invalid; no newline is added or removed. The fixed
+PAM service is `irlume-retry-reset`. Exit codes are 0 (verified), 1 (denied),
+and 2 (invalid or unavailable). It prints no password or prompt.
+
+The helper requires successful authentication and account management, one
+password prompt, and an unchanged final PAM_USER. Conversation failures remain
+latched through PAM cleanup. Owned input is zeroized on normal returns. Core
+dumps are disabled, and an intrinsic ten-second deadline terminates a wedged
+input/PAM transaction. The signal handler uses `_exit`, so deadline termination
+reclaims process memory without running Rust destructors. The daemon separately
+bounds, cancels and reaps the process.
+
+The shipped service uses only `pam_unix` authentication and account checks;
+it has no session, password-changing, biometric, include, nullok, or failure-tally
+modules. This is a local Linux password boundary. LDAP, SSSD and homed are not
+qualified. Administrators can modify their system PAM policy, but the daemon
+refuses a service that differs from the reviewed stack.
+
+Run `scripts/test-password-helper.sh` from the repository. It builds the helper
+and a private synthetic PAM module, runs an unprivileged refusal, then uses
+`sudo -n setpriv` to run the actual libpam suite with no-new-privileges and only
+DAC_OVERRIDE/FOWNER in its capability bounding set. The suite requires a C
+compiler, PAM development headers, pam_wrapper and util-linux. Missing root or
+wrapper prerequisites fail; the ordinary Cargo invocation leaves the explicitly
+ignored root fixture unrun. Tests never alter installed PAM files, read a real
+password database or authenticate a real account.
+
+AppArmor profiles contain a dedicated helper child profile; only that child
+receives shadow access. Enforcing AppArmor recovery remains unavailable until
+its transition under no-new-privileges is qualified. Policy parsing is not
+runtime qualification. The existing daemon capability set and no-new-privileges
+setting remain unchanged. The Fedora SELinux policy currently runs the daemon
+in `unconfined_service_t`; this change adds no SELinux shadow permission and
+makes no claim of a new isolated SELinux helper domain. Package installation,
+real pam_unix local-account behavior on each supported distribution and actual
+AppArmor transitions require separate qualification before enabling a cumulative
+face ceiling.

--- a/crates/irlume-password-verify/src/main.rs
+++ b/crates/irlume-password-verify/src/main.rs
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//! Private, non-setuid local-password verifier. Linux-PAM ABI follows
+//! security/pam_appl.h and pam_conv(3). The root daemon bounds its lifetime,
+//! supplies a cleared environment, and owns stdin/stdout/stderr pipes.
+use std::ffi::{CStr, CString};
+use std::os::unix::ffi::OsStrExt;
+use std::process::ExitCode;
+use std::ptr;
+use zeroize::Zeroizing;
+
+const UNAVAILABLE: u8 = 2;
+const PAM_CONV_ERR: libc::c_int = 19;
+const PAM_BUF_ERR: libc::c_int = 5;
+const PAM_USER: libc::c_int = 2;
+const PAM_FLAGS: libc::c_int = 0x8000 | 1; // SILENT | DISALLOW_NULL_AUTHTOK
+
+#[repr(C)]
+struct Message {
+    style: libc::c_int,
+    text: *const libc::c_char,
+}
+#[repr(C)]
+struct Response {
+    text: *mut libc::c_char,
+    code: libc::c_int,
+}
+#[repr(C)]
+struct Conversation {
+    callback: unsafe extern "C" fn(
+        libc::c_int,
+        *const *const Message,
+        *mut *mut Response,
+        *mut libc::c_void,
+    ) -> libc::c_int,
+    data: *mut libc::c_void,
+}
+#[link(name = "pam")]
+unsafe extern "C" {
+    fn pam_start(
+        service: *const libc::c_char,
+        user: *const libc::c_char,
+        conv: *const Conversation,
+        handle: *mut *mut libc::c_void,
+    ) -> libc::c_int;
+    fn pam_authenticate(handle: *mut libc::c_void, flags: libc::c_int) -> libc::c_int;
+    fn pam_acct_mgmt(handle: *mut libc::c_void, flags: libc::c_int) -> libc::c_int;
+    fn pam_get_item(
+        handle: *mut libc::c_void,
+        item: libc::c_int,
+        value: *mut *const libc::c_void,
+    ) -> libc::c_int;
+    fn pam_end(handle: *mut libc::c_void, status: libc::c_int) -> libc::c_int;
+}
+
+struct Exchange<'a> {
+    secret: &'a [u8],
+    prompted: bool,
+    failed: bool,
+}
+
+// PAM modules are trusted native code. Linux-PAM supplies an array of count
+// valid message pointers, a writable response pointer and our live Exchange.
+// On success PAM owns calloc allocations and must scrub/free responses; on
+// failure we retain ownership and release every allocation before returning.
+unsafe extern "C" fn converse(
+    count: libc::c_int,
+    messages: *const *const Message,
+    output: *mut *mut Response,
+    data: *mut libc::c_void,
+) -> libc::c_int {
+    if data.is_null() {
+        return PAM_CONV_ERR;
+    }
+    // SAFETY: pam_start receives the unique Exchange pointer, live through pam_end.
+    let exchange = unsafe { &mut *data.cast::<Exchange<'_>>() };
+    let previous_failure = exchange.failed;
+    exchange.failed = true;
+    if output.is_null() {
+        return PAM_CONV_ERR;
+    }
+    // SAFETY: the callback contract supplies a writable response pointer.
+    unsafe {
+        *output = ptr::null_mut();
+    }
+    if previous_failure {
+        return PAM_CONV_ERR;
+    }
+    if !(1..=32).contains(&count) || messages.is_null() {
+        return PAM_CONV_ERR;
+    }
+    // SAFETY: Linux-PAM supplies count message pointers; count was bounded above.
+    let messages = unsafe { std::slice::from_raw_parts(messages, count as usize) };
+    let mut password_index = None;
+    for (index, message) in messages.iter().enumerate() {
+        if message.is_null() {
+            return PAM_CONV_ERR;
+        }
+        // SAFETY: each non-null message pointer is valid for the callback.
+        match unsafe { (**message).style } {
+            1 if !exchange.prompted && password_index.is_none() => password_index = Some(index),
+            3 | 4 => {} // Discard informational/error text without copying or printing it.
+            _ => return PAM_CONV_ERR,
+        }
+    }
+    // SAFETY: bounded positive count and correct C layout; calloc is free-compatible.
+    let responses =
+        unsafe { libc::calloc(count as usize, size_of::<Response>()).cast::<Response>() };
+    if responses.is_null() {
+        return PAM_BUF_ERR;
+    }
+    if let Some(index) = password_index {
+        // SAFETY: secret length is <=4096; calloc reserves its NUL terminator.
+        let password = unsafe { libc::calloc(exchange.secret.len() + 1, 1).cast::<u8>() };
+        if password.is_null() {
+            // SAFETY: responses is our live allocation; no child allocations exist.
+            unsafe {
+                libc::free(responses.cast());
+            }
+            return PAM_BUF_ERR;
+        }
+        // SAFETY: source and destination are disjoint and valid for the bounded
+        // length; index is within the response allocation. PAM assumes ownership.
+        unsafe {
+            ptr::copy_nonoverlapping(exchange.secret.as_ptr(), password, exchange.secret.len());
+            (*responses.add(index)).text = password.cast();
+        }
+        exchange.prompted = true;
+    }
+    // SAFETY: output is writable; ownership passes to the PAM caller on success.
+    unsafe {
+        *output = responses;
+    }
+    exchange.failed = false;
+    0
+}
+
+fn verify(user: &CStr, secret: &[u8]) -> u8 {
+    let mut exchange = Exchange {
+        secret,
+        prompted: false,
+        failed: false,
+    };
+    let conv = Conversation {
+        callback: converse,
+        data: (&mut exchange as *mut Exchange<'_>).cast(),
+    };
+    let mut handle = ptr::null_mut();
+    // SAFETY: strings and conversation remain live until pam_end; handle is writable.
+    let start = unsafe {
+        pam_start(
+            c"irlume-retry-reset".as_ptr(),
+            user.as_ptr(),
+            &conv,
+            &mut handle,
+        )
+    };
+    if start != 0 || handle.is_null() {
+        return UNAVAILABLE;
+    }
+    // SAFETY: pam_start succeeded and handle remains exclusively owned here.
+    let mut status = unsafe { pam_authenticate(handle, PAM_FLAGS) };
+    if status == 0 {
+        // SAFETY: the same live authenticated transaction is used for account policy.
+        status = unsafe { pam_acct_mgmt(handle, PAM_FLAGS) };
+    }
+    let mut identity = ptr::null();
+    // SAFETY: live handle and writable item output; PAM owns the returned string.
+    let identity_status = unsafe { pam_get_item(handle, PAM_USER, &mut identity) };
+    let identity_matches = identity_status == 0 && !identity.is_null()
+        // SAFETY: PAM_USER is a NUL-terminated string owned by this live handle.
+        && unsafe { CStr::from_ptr(identity.cast()) } == user;
+    // SAFETY: release this successful pam_start exactly once, with its last status.
+    // Cleanup callbacks may converse, so inspect the latched failure only AFTER
+    // pam_end. The borrowed identity was compared before the handle was freed.
+    if unsafe { pam_end(handle, status) } != 0 {
+        return UNAVAILABLE;
+    }
+    if exchange.failed || !identity_matches {
+        UNAVAILABLE
+    } else if status == 0 {
+        if exchange.prompted {
+            0
+        } else {
+            UNAVAILABLE
+        }
+    } else if matches!(status, 6..=8 | 10..=13 | 16 | 27) {
+        1
+    } else {
+        UNAVAILABLE
+    }
+}
+
+unsafe extern "C" fn timeout(_: libc::c_int) {
+    // SAFETY: _exit is async-signal-safe; no core or credential diagnostics.
+    // Rust destructors cannot safely run in a signal handler. The kernel
+    // reclaims the process's memory; ordinary returns scrub owned input.
+    unsafe {
+        libc::_exit(UNAVAILABLE.into());
+    }
+}
+
+fn run() -> u8 {
+    // SAFETY: getuid/geteuid are memory-free queries. Both must be root so a
+    // mistakenly setuid-installed binary never authenticates an ordinary caller.
+    if unsafe { libc::getuid() != 0 || libc::geteuid() != 0 } {
+        return UNAVAILABLE;
+    }
+    // SAFETY: PR_SET_DUMPABLE accepts a scalar zero; prevents credential core dumps.
+    if unsafe { libc::prctl(libc::PR_SET_DUMPABLE, 0, 0, 0, 0) } != 0 {
+        return UNAVAILABLE;
+    }
+    let limit = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+    // SAFETY: valid rlimit pointer; only lowering this process's core limit.
+    if unsafe { libc::setrlimit(libc::RLIMIT_CORE, &limit) } != 0 {
+        return UNAVAILABLE;
+    }
+    // SAFETY: zero initializes sigaction; sigemptyset initializes its mask;
+    // the handler uses only async-signal-safe _exit. No other threads exist.
+    unsafe {
+        let mut action: libc::sigaction = std::mem::zeroed();
+        action.sa_sigaction = timeout as *const () as libc::sighandler_t;
+        libc::sigemptyset(&mut action.sa_mask);
+        if libc::sigaction(libc::SIGALRM, &action, ptr::null_mut()) != 0 {
+            return UNAVAILABLE;
+        }
+        let mut alarm_mask: libc::sigset_t = std::mem::zeroed();
+        libc::sigemptyset(&mut alarm_mask);
+        libc::sigaddset(&mut alarm_mask, libc::SIGALRM);
+        if libc::sigprocmask(libc::SIG_UNBLOCK, &alarm_mask, ptr::null_mut()) != 0 {
+            return UNAVAILABLE;
+        }
+        libc::alarm(10);
+    }
+    let mut args = std::env::args_os().skip(1);
+    let Some(user) = args.next() else {
+        return UNAVAILABLE;
+    };
+    if args.next().is_some() || user.is_empty() || user.as_bytes().len() > 256 {
+        return UNAVAILABLE;
+    }
+    let Ok(user) = CString::new(user.as_bytes()) else {
+        return UNAVAILABLE;
+    };
+    // Fixed allocation avoids realloc leaving old secret copies unsanitized.
+    let mut secret = Zeroizing::new([0u8; 4097]);
+    let mut length = 0;
+    loop {
+        let remaining = &mut secret[length..];
+        // SAFETY: stdin is the inherited input descriptor; remaining is a live,
+        // exclusively borrowed writable slice for exactly the supplied length.
+        // A direct read avoids std::io::Stdin's unsanitized global input buffer.
+        let read = unsafe {
+            libc::read(
+                libc::STDIN_FILENO,
+                remaining.as_mut_ptr().cast(),
+                remaining.len(),
+            )
+        };
+        if read == 0 {
+            break;
+        }
+        if read < 0 {
+            // An interrupted read transfers no bytes. Retry within the existing
+            // SIGALRM deadline; every other OS error makes recovery unavailable.
+            if std::io::Error::last_os_error().kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            return UNAVAILABLE;
+        }
+        // read(2) returns at most remaining.len(), so this addition stays within
+        // the fixed allocation; the extra byte detects an oversized input.
+        length += read as usize;
+        if length > 4096 {
+            return UNAVAILABLE;
+        }
+    }
+    if length == 0 || secret[..length].contains(&0) {
+        return UNAVAILABLE;
+    }
+    verify(&user, &secret[..length])
+}
+
+fn main() -> ExitCode {
+    ExitCode::from(run())
+}

--- a/crates/irlume-password-verify/tests/fixture.c
+++ b/crates/irlume-password-verify/tests/fixture.c
@@ -1,0 +1,50 @@
+/* Synthetic credentials only; never reads a host password database. */
+#include <security/pam_appl.h>
+#include <security/pam_modules.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+
+static int exchange(pam_handle_t *pamh, int style) {
+    const struct pam_conv *conv = NULL;
+    if (pam_get_item(pamh, PAM_CONV, (const void **)&conv)) return PAM_SYSTEM_ERR;
+    struct pam_message message = {style, "Synthetic prompt"};
+    const struct pam_message *messages[] = {&message};
+    struct pam_response *response = NULL;
+    int result = conv->conv(1, messages, &response, conv->appdata_ptr);
+    if (result != PAM_SUCCESS) return result;
+    int good = response && response->resp &&
+        strcmp(response->resp, "synthetic-test-password") == 0;
+    if (response) {
+        if (response->resp) {
+            explicit_bzero(response->resp, strlen(response->resp));
+            free(response->resp);
+        }
+        free(response);
+    }
+    return good ? PAM_SUCCESS : PAM_AUTH_ERR;
+}
+static void cleanup(pam_handle_t *pamh, void *data, int status) {
+    (void)data; (void)status;
+    exchange(pamh, PAM_PROMPT_ECHO_OFF);
+}
+int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, const char **argv) {
+    (void)flags;
+    const char *mode = argc ? argv[0] : "normal";
+    if (!strcmp(mode, "hang")) { sleep(60); return PAM_SUCCESS; }
+    if (!strcmp(mode, "no-prompt")) return PAM_SUCCESS;
+    int result = exchange(pamh, !strcmp(mode, "echo") ? PAM_PROMPT_ECHO_ON : PAM_PROMPT_ECHO_OFF);
+    if (result) return result;
+    if (!strcmp(mode, "repeat")) return exchange(pamh, PAM_PROMPT_ECHO_OFF);
+    if (!strcmp(mode, "ignore-repeat-info")) { exchange(pamh, PAM_PROMPT_ECHO_OFF); exchange(pamh, PAM_TEXT_INFO); return PAM_SUCCESS; }
+    if (!strcmp(mode, "ignore-repeat")) { exchange(pamh, PAM_PROMPT_ECHO_OFF); return PAM_SUCCESS; }
+    if (!strcmp(mode, "end-repeat")) return pam_set_data(pamh, "fixture-cleanup", NULL, cleanup);
+    if (!strcmp(mode, "mutate")) return pam_set_item(pamh, PAM_USER, "different-user");
+    return PAM_SUCCESS;
+}
+int pam_sm_acct_mgmt(pam_handle_t *pamh, int flags, int argc, const char **argv) {
+    (void)pamh; (void)flags;
+    if (argc && !strcmp(argv[0], "expired")) return PAM_ACCT_EXPIRED;
+    if (argc && !strcmp(argv[0], "change-required")) return PAM_NEW_AUTHTOK_REQD;
+    return PAM_SUCCESS;
+}

--- a/crates/irlume-password-verify/tests/pam.rs
+++ b/crates/irlume-password-verify/tests/pam.rs
@@ -1,0 +1,220 @@
+//! Actual helper + libpam tests. Explicit root-only synthetic fixture suite:
+//! cargo test -p irlume-password-verify --test pam --no-run
+//! sudo -n <test-binary> --ignored --nocapture
+//! Requires cc, Linux-PAM headers and pam_wrapper; missing prerequisites FAIL.
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Output, Stdio};
+
+fn run(args: &[&str], secret: &[u8], fixture: Option<(&Path, &Path)>) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_irlume-password-verify"));
+    command
+        .env_clear()
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    if let Some((wrapper, directory)) = fixture {
+        command
+            .env("LD_PRELOAD", wrapper)
+            .env("PAM_WRAPPER", "1")
+            .env("PAM_WRAPPER_SERVICE_DIR", directory);
+    }
+    let mut child = command.spawn().unwrap();
+    // A rejected invocation can close the pipe before we finish writing.
+    let _ = child.stdin.take().unwrap().write_all(secret);
+    child.wait_with_output().unwrap()
+}
+
+#[test]
+fn unprivileged_invocation_is_unavailable() {
+    // SAFETY: getuid has no preconditions or borrowed memory.
+    if unsafe { libc::getuid() } == 0 {
+        return;
+    }
+    let output = run(&["synthetic-user"], b"synthetic-test-password", None);
+    assert_eq!(output.status.code(), Some(2));
+    assert!(output.stdout.is_empty());
+    assert!(output.stderr.is_empty());
+}
+
+#[test]
+#[ignore = "requires root, cc and pam_wrapper; private synthetic fixtures only"]
+fn actual_pam_contract() {
+    assert_eq!(
+        // SAFETY: getuid has no preconditions or borrowed memory.
+        unsafe { libc::getuid() },
+        0,
+        "run this synthetic fixture as root"
+    );
+    let wrapper = [
+        "/usr/lib64/libpam_wrapper.so",
+        "/usr/lib/x86_64-linux-gnu/libpam_wrapper.so",
+    ]
+    .into_iter()
+    .map(Path::new)
+    .find(|p| p.exists())
+    .expect("pam_wrapper required");
+    let temp = tempfile::tempdir().unwrap();
+    let module = temp.path().join("fixture.so");
+    assert!(Command::new("cc")
+        .args(["-shared", "-fPIC", "-Wall", "-Wextra", "-Werror"])
+        .arg(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixture.c"))
+        .arg("-lpam")
+        .arg("-o")
+        .arg(&module)
+        .status()
+        .unwrap()
+        .success());
+    let service = temp.path().join("irlume-retry-reset");
+    let cases: Vec<(&str, &[&str], Vec<u8>, i32)> = vec![
+        (
+            "normal",
+            &["synthetic-user"],
+            b"synthetic-test-password".to_vec(),
+            0,
+        ),
+        ("normal", &["synthetic-user"], b"wrong".to_vec(), 1),
+        (
+            "expired",
+            &["synthetic-user"],
+            b"synthetic-test-password".to_vec(),
+            1,
+        ),
+        (
+            "change-required",
+            &["synthetic-user"],
+            b"synthetic-test-password".to_vec(),
+            1,
+        ),
+        (
+            "no-prompt",
+            &["synthetic-user"],
+            b"synthetic-test-password".to_vec(),
+            2,
+        ),
+        (
+            "echo",
+            &["synthetic-user"],
+            b"synthetic-test-password".to_vec(),
+            2,
+        ),
+        (
+            "repeat",
+            &["synthetic-user"],
+            b"synthetic-test-password".to_vec(),
+            2,
+        ),
+        (
+            "ignore-repeat",
+            &["synthetic-user"],
+            b"synthetic-test-password".to_vec(),
+            2,
+        ),
+        (
+            "ignore-repeat-info",
+            &["synthetic-user"],
+            b"synthetic-test-password".to_vec(),
+            2,
+        ),
+        (
+            "mutate",
+            &["synthetic-user"],
+            b"synthetic-test-password".to_vec(),
+            2,
+        ),
+        (
+            "end-repeat",
+            &["synthetic-user"],
+            b"synthetic-test-password".to_vec(),
+            2,
+        ),
+        ("normal", &[], b"synthetic-test-password".to_vec(), 2),
+        (
+            "normal",
+            &["synthetic-user", "other"],
+            b"synthetic-test-password".to_vec(),
+            2,
+        ),
+        ("normal", &[""], b"synthetic-test-password".to_vec(), 2),
+        ("normal", &["synthetic-user"], Vec::new(), 2),
+        ("normal", &["synthetic-user"], vec![b'x'; 4097], 2),
+        (
+            "normal",
+            &["synthetic-user"],
+            b"synthetic-test-password\0".to_vec(),
+            2,
+        ),
+        ("normal", &["synthetic-user"], vec![b'x'; 4096], 1),
+        (
+            "hang",
+            &["synthetic-user"],
+            b"synthetic-test-password".to_vec(),
+            2,
+        ),
+    ];
+    for (mode, args, secret, expected) in cases {
+        std::fs::write(
+            &service,
+            format!(
+                "auth required {} {mode}\naccount required {} {mode}\n",
+                module.display(),
+                module.display()
+            ),
+        )
+        .unwrap();
+        let output = run(args, &secret, Some((wrapper, temp.path())));
+        assert_eq!(
+            output.status.code(),
+            Some(expected),
+            "case {mode}, args {args:?}, input size {}",
+            secret.len()
+        );
+        assert!(output.stdout.is_empty(), "stdout in {mode}");
+        assert!(
+            !output
+                .stderr
+                .windows(b"synthetic-test-password".len())
+                .any(|s| s == b"synthetic-test-password"),
+            "credential in stderr"
+        );
+    }
+    // On oversized input, consume only the bounded 4097-byte rejection probe.
+    // Retaining a duplicate read end lets us observe unread transport bytes
+    // after the actual helper exits, without inspecting secret memory.
+    let (mut sender, mut receiver) = std::os::unix::net::UnixStream::pair().unwrap();
+    let input: std::os::fd::OwnedFd = receiver.try_clone().unwrap().into();
+    let child = Command::new(env!("CARGO_BIN_EXE_irlume-password-verify"))
+        .env_clear()
+        .arg("synthetic-user")
+        .stdin(Stdio::from(input))
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    sender.write_all(&[b'x'; 6000]).unwrap();
+    sender.shutdown(std::net::Shutdown::Write).unwrap();
+    let output = child.wait_with_output().unwrap();
+    assert_eq!(output.status.code(), Some(2));
+    assert!(output.stdout.is_empty());
+    assert!(output.stderr.is_empty());
+    let mut unread = Vec::new();
+    std::io::Read::read_to_end(&mut receiver, &mut unread).unwrap();
+    assert_eq!(
+        unread.len(),
+        6000 - 4097,
+        "helper must not buffer beyond its rejection bound"
+    );
+
+    std::fs::write(service, "auth required /nonexistent/irlume-test-module.so\naccount required /nonexistent/irlume-test-module.so\n").unwrap();
+    assert_eq!(
+        run(
+            &["synthetic-user"],
+            b"synthetic-test-password",
+            Some((wrapper, temp.path()))
+        )
+        .status
+        .code(),
+        Some(2)
+    );
+}

--- a/crates/irlume-vision/src/align.rs
+++ b/crates/irlume-vision/src/align.rs
@@ -368,6 +368,29 @@ pub fn flip_h(chip: &[u8]) -> Vec<u8> {
     out
 }
 
+/// Normalize a finite, nonzero embedding without overflowing its norm.
+/// Returns `None` for empty, zero, or non-finite vectors. Dimensions and
+/// embedding-space compatibility remain the caller's responsibility.
+pub fn normalize_embedding(values: &[f32]) -> Option<Vec<f32>> {
+    let mut squared_norm = 0.0f64;
+    for &value in values {
+        if !value.is_finite() {
+            return None;
+        }
+        squared_norm += f64::from(value) * f64::from(value);
+    }
+    if squared_norm == 0.0 {
+        return None;
+    }
+    let norm = squared_norm.sqrt();
+    Some(
+        values
+            .iter()
+            .map(|&v| (f64::from(v) / norm) as f32)
+            .collect(),
+    )
+}
+
 /// Cosine similarity of two L2-normalized embeddings = dot product, clamped.
 /// Mismatched lengths return -1.0 (a definitive non-match) rather than
 /// panicking; see the guard below.
@@ -405,6 +428,30 @@ pub fn cosine(a: &[f32], b: &[f32]) -> f32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn normalize_embedding_preserves_direction_at_extreme_scales() {
+        for scale in [f32::MAX, f32::from_bits(1), 1.0] {
+            let normalized = normalize_embedding(&[scale, scale]).unwrap();
+            for value in &normalized {
+                assert!((value - std::f32::consts::FRAC_1_SQRT_2).abs() < 1e-6);
+            }
+            assert!((cosine(&normalized, &normalized) - 1.0).abs() < 1e-6);
+        }
+    }
+
+    #[test]
+    fn normalize_embedding_rejects_invalid_vectors() {
+        for values in [
+            vec![],
+            vec![0.0, -0.0],
+            vec![1.0, f32::NAN],
+            vec![1.0, f32::INFINITY],
+            vec![1.0, f32::NEG_INFINITY],
+        ] {
+            assert!(normalize_embedding(&values).is_none());
+        }
+    }
 
     #[test]
     fn cosine_identity_is_one() {

--- a/crates/irlume-vision/src/lib.rs
+++ b/crates/irlume-vision/src/lib.rs
@@ -683,14 +683,71 @@ mod onnx {
             Self::load_from_memory(&bytes)
         }
 
-        /// Adapt one IR embedding -> adapted vector (already L2-normalized).
+        /// Adapt one finite, nonzero 512-D IR embedding into a normalized vector.
         #[expect(clippy::missing_errors_doc, reason = "doc backlog")]
         pub fn apply(&mut self, emb: &[f32]) -> irlume_common::Result<Vec<f32>> {
+            validate_adapter_embedding(emb)?;
             let tensor =
                 Tensor::from_array(([1i64, emb.len() as i64], emb.to_vec())).map_err(err)?;
             let outputs = self.session.run(ort::inputs![tensor]).map_err(err)?;
             let (_shape, raw) = outputs[0].try_extract_tensor::<f32>().map_err(err)?;
-            Ok(raw.to_vec())
+            adapter_output(raw)
+        }
+    }
+
+    fn adapter_output(raw: &[f32]) -> irlume_common::Result<Vec<f32>> {
+        validate_adapter_embedding(raw)?;
+        crate::align::normalize_embedding(raw).ok_or_else(|| err("invalid adapter embedding"))
+    }
+
+    fn validate_adapter_embedding(values: &[f32]) -> irlume_common::Result<()> {
+        if values.len() != EMBED_DIM
+            || values.iter().any(|v| !v.is_finite())
+            || values.iter().all(|&v| v == 0.0)
+        {
+            return Err(err("adapter requires a finite, nonzero 512-D embedding"));
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    mod adapter_contract_tests {
+        use super::*;
+
+        #[test]
+        fn adapter_output_is_normalized_without_changing_direction() {
+            let mut raw = vec![0.0; EMBED_DIM];
+            raw[0] = 3.0;
+            raw[1] = 4.0;
+            let output = adapter_output(&raw).unwrap();
+            assert_eq!(output.len(), EMBED_DIM);
+            assert!((output[0] - 0.6).abs() < 1e-6);
+            assert!((output[1] - 0.8).abs() < 1e-6);
+        }
+
+        #[test]
+        fn adapter_output_rejects_invalid_dimension_and_values() {
+            for raw in [
+                vec![],
+                vec![1.0; EMBED_DIM - 1],
+                vec![1.0; EMBED_DIM + 1],
+                vec![0.0; EMBED_DIM],
+                vec![f32::NAN; EMBED_DIM],
+                vec![f32::INFINITY; EMBED_DIM],
+                vec![f32::NEG_INFINITY; EMBED_DIM],
+            ] {
+                assert!(adapter_output(&raw).is_err());
+                assert!(validate_adapter_embedding(&raw).is_err());
+            }
+        }
+
+        #[test]
+        fn adapter_input_validation_preserves_valid_custom_input() {
+            let input = vec![2.0; EMBED_DIM];
+            assert!(validate_adapter_embedding(&input).is_ok());
+            let output = adapter_output(&input).unwrap();
+            let norm = output.iter().map(|v| v * v).sum::<f32>();
+            assert!((norm - 1.0).abs() < 1e-6);
         }
     }
 

--- a/docs/APP-INTEGRATION.md
+++ b/docs/APP-INTEGRATION.md
@@ -19,15 +19,20 @@ pieces:
 2. Your desktop's polkit agent (KDE or GNOME) opens its dialog, which names
    the app and the action being approved, and starts a PAM conversation on the
    `polkit-1` service.
-3. `pam_irlume` asks for hidden literal `yes`. Enter, cancellation, or any other
+3. By default, `pam_irlume` asks for hidden literal `yes`. Enter, cancellation, or any other
    response selects password/fingerprint without opening the camera. `yes`
    authorizes exactly one face attempt.
 4. `irlumed` verifies the face and automatic passive PAD. The app learns only
    the final verdict.
 
 Both the KDE and GNOME agents start the PAM conversation the moment the dialog
-appears, but irlume does not open the camera until it receives the hidden `yes`.
-This conventional response is mandatory and cannot be disabled.
+appears, but the default Irlume policy waits for the hidden `yes` before opening the
+camera. The machine owner can opt into hands-free privileged prompts using
+`sudo irlume auth consent hands-free --yes` or TUI Settings > Privileged
+consent [p]. A prompt raised by an app, script or another person can then
+authenticate while you are in view. Restore the default with
+`sudo irlume auth consent required`. See [the scope and override
+rules](SETUP.md#choosing-privileged-face-confirmation).
 
 ## Enabling
 
@@ -42,7 +47,7 @@ This adds one verify-only line to the `polkit-1` PAM stack (Fedora gets an
 edit-in-place with a `.pre-irlume` backup). `sudo irlume login disable --apply`
 removes it along with everything else, flag or no flag.
 
-Privileged intent is fixed: type hidden literal `yes` for one face attempt.
+With the default policy, type hidden literal `yes` for one face attempt.
 Automatic PAD remains mandatory before a face grant. Head gestures have been
 removed; old settings no longer add a challenge. Stored legacy eyes-open policy
 still blocks authentication until `irlume profiles eyes-open off` clears it.

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -30,6 +30,7 @@ Conventions that apply everywhere:
 | `irlume doctor` | platform checks in one pass: TPM, Secure Boot, camera, models, polkit app prompts, login-keyring lock state + provider (ksecretd/kwalletd/gnome-keyring), the authselect/pam-auth-update regeneration guard, and install hygiene (leftover backup files next to the managed binaries, hand-installed builds overlaying the packaged ones); `doctor --json` uses the read-only public [machine API](MACHINE-API.md) |
 | `irlume deps` | verify runtime dependencies (onnxruntime, models, TPM) |
 | `irlume version` | print the installed version (`--version` / `-V` also work); `version --json` uses the public [machine API](MACHINE-API.md) |
+| `irlume auth sensor <status\|preflight [user]\|dual\|ir-only --yes>` | inspect or select the machine-wide face sensor policy. `ir-only --yes` is a root-only experimental opt-in; `dual` restores the default. `preflight` is camera-free and reports prerequisites only, never capture success, login readiness, or qualification |
 
 ## Enrollment and profiles
 

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -103,8 +103,10 @@ walking up), ~5 seconds for `sudo`/`su` (you're already at the terminal, so it
 drops to the password prompt quickly). Only presence-class failures retry (no
 face, off-angle, or the transient "RGB face / no IR face" a user makes while
 settling); a below-threshold match or a real spoof verdict settles immediately.
-`IRLUME_GRACE_MS` on the daemon overrides both windows; `0` restores the old
-one-shot behavior.
+`IRLUME_GRACE_MS` on the daemon accepts 0–60,000 milliseconds and overrides
+both windows; `0` restores the old one-shot behavior. Malformed or out-of-range
+values use the normal service window, so an accidental excessive value cannot
+indefinitely postpone password fallback.
 
 When grouped authentication expires before complete evidence is accepted, its
 final situation is `timed out`. PAM says "authentication timed out; use your

--- a/docs/DESKTOP-AUTH.md
+++ b/docs/DESKTOP-AUTH.md
@@ -1,0 +1,104 @@
+# On-demand desktop face authentication
+
+Irlume's desktop direction is on-demand consent through stock authentication
+interfaces. Select a face attempt explicitly; ordinary password authentication
+remains available. Experimental automatic desktop integration has been retired.
+Contributors may propose future frontend support, but it is not an active
+Irlume implementation target or a promised upstream feature.
+
+## Existing desktop flow
+
+The current on-demand PAM path waits for input. A successfully returned empty
+password response selects one face attempt. A nonempty password proceeds to the
+password provider. Cancelling the initial conversation, EOF, or a missing token
+returns without contacting the daemon. The consumed empty face-selection token
+is cleared so a refusal or timeout can reach a fresh password prompt.
+
+Existing greeter compatibility remains supported: the established `facefirst`,
+`ondemand`, and legacy `wait` arguments are retained where existing deployments
+use them. The standard on-demand desktop setup does not use `wait`. This cleanup
+does not migrate existing PAM files or change credential-release behavior.
+
+The separate `irlume auth consent` setting controls typed confirmation for
+privileged sudo/polkit requests. Its existing owner opt-in is retained and does
+not enable automatic desktop scanning.
+
+The separate experimental sensor policy is also machine-wide and owner-selected.
+Absent configuration remains dual RGB+IR; root must use
+`irlume auth sensor ir-only --yes` to write
+`face_sensor_policy=ir-only-experimental`, and `irlume auth sensor dual` restores
+the default. It is independent of PAM `Method`, sequential/concurrent capture
+scheduling, and privileged confirmation. IR-only attempts use the configured,
+enrollment-bound IR target with mandatory IR PAD and compatible enrollment; they
+never probe or silently fall back to RGB. The mode remains experimental; source
+availability is not authentication qualification.
+
+`irlume auth sensor preflight [user]` is camera-free. A ready result means only
+that prerequisites were observed. It does not establish capture timing, a usable
+login, or qualification. Missing prerequisites, old/unexpected daemon responses,
+and unknown readiness values fail to the password path.
+
+## Bounded attempts and cleanup
+
+One monotonic authentication window covers engine setup, presence retries and
+final daemon response admission. The normal defaults are unchanged: 15 seconds
+for login, lock, and unknown services; 5 seconds for short privileged services
+including sudo, doas, and polkit. These are maximum admission windows, not
+required scan durations. A completed denial or a retry that cannot fit may finish
+earlier. `IRLUME_GRACE_MS` remains the explicit 0–60000 ms override; zero retains
+legacy single-attempt behavior. A measured
+fixed-startup empty-view IR capture on one Minihost took about 5.5 seconds before
+identity work, so prerequisite-ready does not imply the five-second services can
+complete. IR-only opt-in does not silently extend a service window or adopt the
+separately measured adaptive startup experiment.
+
+Matches and prepared credentials observed after expiry are discarded. Capture
+checks expiry before and after returned driver calls and at inference
+boundaries. Expiry does not trigger camera recovery, hardware demotion or
+another scan. Camera and emitter owners perform their normal cleanup.
+Disconnect cancellation and these deadline protections are shared with
+on-demand requests and remain in place.
+
+A driver, inference, TPM operation or enrollment-loader cleanup already in
+progress can return later. These windows are not hard physical camera-off
+guarantees. PAM bounds the complete response-reading phase to 25 seconds,
+including partial reads. Connection/send time precedes that read budget; daemon
+queue waiting after the send consumes it. Queue waiting precedes the separate
+engine authentication window.
+The legacy PAM `wait` loop is outside this bounded on-demand contract.
+
+The daemon durably reserves one unsuccessful request before engine work; a
+reservation write failure prevents the attempt. A grant is admitted immediately
+before the first response byte, then the complete response is written and flushed.
+Only after that delivery succeeds does the daemon durably reset the face budget.
+If reset persistence reports failure, the already delivered grant cannot be
+retracted and the reset is unconfirmed. The charge may remain and block the next
+face request. If the reset rename became visible but was not confirmed durable, a
+later successful authoritative read may sync and recognize that visible reset. A
+partial or failed response delivery retains the charge and never attempts reset.
+
+## Frontend boundary
+
+Irlume does not supply the experimental native desktop scanning integration,
+an automatic desktop toggle, a custom KDE fork, or a background unlock
+controller. Legacy `facefirst` still scans immediately in existing compatibility
+deployments; it is preserved rather than expanded by this decision. The
+experimental `kde-face` service classification and its native integration plan
+have been removed. Unknown services retain the existing restrictive policy;
+the supported `kde` service remains a screen unlock.
+
+Esc-to-cancel and typing-to-switch during an active face request are not
+shortcuts implemented by Irlume. A stock frontend owns its password UI and PAM
+worker lifecycle; cancellation of a queued PAM conversation does not itself
+interrupt a synchronous daemon request or invalidate a queued success.
+Supported frontend lifecycle integration would need separate contributor and
+upstream work. No integration is enabled based solely on a service name.
+
+## Validation scope
+
+Controlled tests cover expiry before capture, late grants, capture and inference
+boundaries, retry accounting, partial socket replies, and fresh password fallback
+through a real userspace PAM stack. They do not establish a universal hardware
+release time. Physical camera-descriptor release measurements must be reported
+with the actual test window and sampling limits; descriptor closure and logged
+emitter restoration do not independently prove optical darkness.

--- a/docs/DISABLE.md
+++ b/docs/DISABLE.md
@@ -105,15 +105,20 @@ sudo irlume fingerprint disable
   after about 5 seconds, then the password takes over. `IRLUME_GRACE_MS`
   overrides this if you want shorter.
 
-There is no failed-scan lockout class: any miss falls to the password. After
-repeated failures the camera itself rests while the password keeps working
-(5 strikes by default, then a 30-second camera cooldown; `IRLUME_RATE_LIMIT`
-and `IRLUME_RATE_COOLDOWN_SECS` adjust both).
+Face verification and face-gated credential release share a durable limit of
+50 consecutive unsuccessful requests per account. Each request reserves one
+charge before engine work; its internal presence retries, grouped capture and
+fallbacks share that reservation. At 50, face stands down until independently
+verified password recovery or an explicit administrator reset. Ordinary password
+login remains available. A successfully admitted and completely written face
+grant resets the count, so successful everyday unlocks do not exhaust it.
 
-A deliberate head-shake cancellation ends the request without adding a failure
-or clearing previous failures. No-face and uncertain-evidence outcomes also do
-not consume strikes; hard spoof and below-threshold rejections do. Login face
-verification and face-gated password release share this per-user counter.
+Cancellation, errors, interrupted requests and completed no-face/setup outcomes
+retain their cumulative charge. No cumulative neutral refund is made. Separately,
+the short throttle defaults to five strikes followed by a 30-second camera rest.
+No-face and uncertain-evidence outcomes do not consume short strikes; hard spoof
+and below-threshold rejections do. An abandoned reservation conservatively adds
+one short strike when it is next observed.
 Missing or empty enrollment, scans belonging only to a different recognition
 model, a retired eyes-open setting, and invalid or retired consent settings end
 the request without adding or clearing strikes. Fixing those
@@ -121,34 +126,46 @@ settings does not erase earlier face rejections or cancel an active cooldown.
 Camera-binding refusals, PAD failures and grouped
 capture timeouts retain their existing strike behavior.
 
-A face grant or cooldown expiry resets it. Recorded failures and an active
-cooldown survive daemon restarts. Profiles and PAM services for the same Linux
-account share the budget. The counter does not receive password-success events
-and is not an overall cumulative attempt ceiling.
+A cooldown expiry clears only the short throttle, never the cumulative budget.
+Both survive daemon restarts; profiles, modes and PAM services for one Linux
+account share them. Ordinary password login does not send a reset event; use
+`irlume retry reset` when face is blocked.
 
 ### Persistent retry records
 
-The daemon stores version-1 records in `/var/lib/irlume/retry/<uid>.json`.
+The daemon stores version-2 records in `/var/lib/irlume/retry/<uid>.json`.
 The directory is root-owned mode 0700; files are root-owned mode 0600. A record
-contains the account UID/name, consecutive count, and an optional monotonic
+contains the account UID/name, short strikes, cumulative count, pending request
+flag, and an optional monotonic
 clock deadline, boot identifier and original cooldown duration. It contains no
 biometric data or credentials. The retry location is fixed; enrollment path
-overrides do not redirect it. No same-user command can reset these records.
+overrides do not redirect it. The explicit `irlume retry reset` command can reset
+these records after independently verifying the account password, as described
+below; ordinary password login does not notify the counter.
 
 A daemon restart in the same boot keeps the original deadline. Civil-clock
 changes do not affect it. After reboot, partial failures remain and a recorded
 cooldown starts again for its original duration; this can extend the wait.
-`IRLUME_RATE_LIMIT=0` disables enforcement without deleting history. Re-enabling
-it restores that history; lowering the limit cannot replenish recorded strikes.
+`IRLUME_RATE_LIMIT` accepts 1–5; `IRLUME_RATE_COOLDOWN_SECS` accepts 30–86400.
+Invalid values, including zero, use safe defaults (5 and 30 respectively) with a
+fixed diagnostic. These settings cannot disable or increase the cumulative limit.
 
-Missing records start empty on adoption. Existing malformed, oversized,
+The first reservation starts an explicitly prospective epoch for a missing or
+strictly valid version-1 record, preserving its short strikes/cooldown. Earlier
+cycles cannot be reconstructed and are not counted or presented as known.
+Status does not migrate records; it distinguishes unknown legacy history from a
+known zero count. Existing malformed, oversized,
 unreadable, wrongly owned or unsafe records refuse the face path with a password
 fallback message. UID/name mismatches also refuse: a reused UID or renamed
-account must be reconciled by an administrator. A successful face match cannot
-return a grant or release a sealed password until its reset is durably committed.
-If publication succeeds but its durability check fails, that request still
-refuses; the next operation re-reads and synchronizes the visible state before
-allowing face again.
+account must be reconciled by an administrator. No engine work starts until its
+reservation is durably committed. The daemon holds the account lock through
+response delivery and clears a successful request only after final admission and
+successful write/flush. A crash after delivery but before reset can conservatively
+retain a charge. A failed reset after delivery cannot retract the grant; the next
+operation re-reads and synchronizes authoritative disk state. Admission checks
+the original window immediately before the first byte and bounds the write
+timeout to remaining time where possible; partially written bytes cannot be
+retracted if cancellation or expiry arrives during the write.
 
 For repair, use password authentication and inspect `journalctl -u irlumed`.
 Stop `irlumed.socket` and `irlumed.service` while correcting the affected
@@ -158,13 +175,60 @@ they can be established. Inspect the exact UID with `id -u <account>` and do not
 follow symlinks or change other users' records. Removing the affected record is
 an explicit root reset of its history; do so only if the administrator intends
 that reset, then start the socket and daemon. Corrected state is re-read automatically.
-An older daemon ignores these records: downgrading loses persistence enforcement
-until the new daemon returns, even if the files remain. Do not delete them as
-part of a binary rollback.
+Version-1-only daemons refuse version-2 records; older daemons without persistent
+retry support do not enforce this limit. Do not delete records or restore older,
+smaller counts as part of a binary rollback.
 
-This protects recorded state across restarts, not root deletion, disk rollback,
-or a crash before a terminal outcome is committed. A crash-proof cumulative
-ceiling and independently verified recovery remain separate policy work.
+Write-ahead charges survive crashes and reboot, but cannot resist root deletion
+or disk rollback. Fifty bounds requested composite authentication decisions, not
+individual frames/comparisons or a qualified false-accept probability. The
+independent reset-password budget below also reserves before verification.
+
+### Password-verified retry reset
+
+```sh
+irlume retry status
+irlume retry reset
+sudo irlume retry reset --user <account>   # explicit administrator override
+```
+
+`status` inspects face and reset-password counters without requesting a camera
+or password. `reset` probes daemon support and the recovery gate before asking
+for the current login password without terminal echo. Non-root requests are
+limited to the caller's own account. Successful independent password verification
+clears the face retry record and the reset-password budget; it does not change
+the login password, enrollment, template key, or consent settings. A root reset
+is an explicit administrative action and does not ask for the account password.
+Malformed or unsafe records still require the repair procedure above.
+
+A reset commits the face state first, then clears the reset-password budget.
+Interruption or a storage failure between these writes can clear face history
+while retaining a conservative password-check charge. If the command cannot
+confirm the reset, run `irlume retry status` before trying again.
+
+This path requires an updated daemon and the packaged root-only password verifier
+with its fixed `irlume-retry-reset` PAM service. The initial backend is local
+Linux passwords through `pam_unix`; LDAP, SSSD and systemd-homed accounts are not
+qualified. Self-service reset is unavailable under enforcing AppArmor in this
+release. Keep normal password login available and ask an administrator when
+status reports reset unavailable. An older daemon is refused before prompting;
+updating the client alone does not add recovery support.
+
+Reset-password guessing has its own persistent record at
+`/var/lib/irlume/retry/<uid>.reset.json`, with the same private ownership and
+permissions as face records. After five failed checks, each further check needs
+a 30-second wait; the wait never erases failures. At 50 failed checks, an
+administrator must reset the budget. A verification attempt is charged durably
+before the helper runs, so interruption or unknown completion also consumes an
+attempt. This budget survives daemon restarts; reboot can restart its recorded
+cooldown. None of these limits block ordinary password login or introduce a
+cumulative ceiling for face authentication.
+
+`irlume recovery restore` is separate: it uses the recovery passphrase to restore
+the template key and never clears retry counters. A desktop/polkit approval or
+an already open keyring also does not satisfy password verification for retry
+reset. Keep both face and reset-password records when rolling back binaries;
+older daemons do not offer this reset path or enforce the reset-password budget.
 
 ## Remove everything
 

--- a/docs/FAIRNESS.md
+++ b/docs/FAIRNESS.md
@@ -3,8 +3,8 @@
 irlume publishes its demographic error rates rather than hiding them. Face
 recognition has well-documented demographic differentials (NIST FRVT Part 3);
 irlume is not exempt. This document states the
-measured variance, the recognizer trade-off we accepted, and the policy that
-keeps the residual gap from becoming a security hole.
+measured variance, the recognizer trade-off we accepted, and the remaining
+evidence needed to assess the deployed acceptance rule.
 
 ## Measured demographic FAR with AuraFace
 
@@ -25,8 +25,8 @@ throughout this document):
 | Southeast Asian | 7.46×10⁻⁴ |
 | **East Asian** | **1.04×10⁻³** |
 
-**Spread ≈ 10×.** At the 0.50 measurement threshold, only the
-best-served group meets NIST FMR ≤ 1×10⁻⁴; the others exceed it within-group.
+**Spread ≈ 10×.** At the 0.50 measurement threshold, every reported
+group exceeds NIST FMR ≤ 1×10⁻⁴; the best-served group is close at 1.05×10⁻⁴.
 A single fixed threshold that holds FAR ≤ 1×10⁻⁴ for **every** group requires
 ≈ **0.69** (bound by the worst groups). A cross-check on real faces (LFW,
 13,233 images, 87M PAIRS, same YuNet→AuraFace pipeline) measured an all-pairs
@@ -42,9 +42,13 @@ is unconstrained web imagery (varied pose and lighting) which aligns less
 cleanly than FairFace's curated
 crops, so real-world faces are the harder test. The shipped RGB threshold is
 stricter than the 0.50 measurement point (0.55, with template-count scaling up
-to +0.10; the IR path uses 0.55 native / 0.40 adapted, and calibrated RGB+IR
-fusion grants at probability ≥ 0.50), and the mandatory password fallback
-bounds the residual either way.
+to +0.10). IR fallback, dark-path matching and weighted RGB+IR fusion are
+additional acceptance arms with distinct thresholds. Their combined deployed
+false-match rate is not established by the table above. In particular, the
+fusion score is not a validated current-pipeline probability. Password fallback
+provides recovery when face authentication refuses; it does not reduce false
+matches that already grant. See the
+[acceptance-rule evidence limits](THREAT_MODEL.md#acceptance-rule-evidence-limits).
 
 ## Against the Windows Hello bars
 
@@ -59,11 +63,12 @@ percent). Stated in exactly those terms, irlume's own measurements above:
 | FAR < 0.001% (1×10⁻⁵) | worst-group FAR 1.04×10⁻³ at the 0.50 measurement point (best group 1.05×10⁻⁴) | **No.** Only the best-served group approaches it; irlume does not claim Hello's FAR bar |
 | TAR > 95% (FRR < 5%) | FRR 4.65% at the matched-FAR (1×10⁻³) operating point (AuraFace) | Yes, at that operating point |
 
-The comparison is deliberately like-for-like and deliberately not a
-marketing table: irlume publishes its per-group variance (above) where a
-single certified bar cannot, and bounds the residual differently, with two
-presentation-attack-detection models on every capture and a mandatory
-password fallback rather than a certified-hardware program.
+These benchmark figures describe their recorded operating points; they are
+not a matched-protocol evaluation of the current deployed rule. irlume
+publishes the per-group variance above alongside the single Hello target. PAD
+and password fallback address presentation attacks and recovery; they do not establish a measured bound on the combined
+identity acceptance rule. The benchmark comparison is not certification of the
+current deployment.
 
 **Multiple enrolled users.** Hello raises its match threshold automatically
 when several users are enrolled on one machine (Microsoft's Windows Hello
@@ -137,32 +142,28 @@ generator AuraFace embeds well) or real consented diverse data, plus a
 commercial license (DigiFace is non-commercial). The ~30% result stands as proof
 the lever exists; this particular adapter is not the one to ship.
 
-## Policy: a single conservative threshold + uniform fallback
+## Policy: no demographic threshold selection, with recovery after refusal
 
-irlume does **not** classify a user's demographic group at authentication time to
-pick a threshold. Runtime demographic classification is privacy-invasive,
-unreliable, and self-defeating for a fairness goal, and it is unnecessary. The
-right direction is a **single fixed threshold chosen conservatively against the
-worst-performing group's curve**. The shipped 0.55 (vs the 0.50 measurement
-point) moves that way, though fully bounding every group at 1×10⁻⁴ would need
-≈0.69 and a real FRR cost; the residual gap is bounded by the mandatory
-password fallback, never by relaxing FAR. Users in better-served
-groups pay a slightly higher False Reject Rate than strictly necessary; that cost
-is absorbed **uniformly** by the mandatory non-biometric fallback.
+irlume does **not** classify a user's demographic group at authentication time
+to pick a threshold. The policy goal is to choose operating points against the
+worst-performing group's curve, while accounting for false non-matches. The
+shipped RGB base of 0.55 is stricter than the 0.50 measurement point. The
+reported approximately 0.69 benchmark threshold and its FRR cost do not by
+themselves calibrate every deployed acceptance arm.
 
-Because the biometric is **one MFA factor with a mandatory fallback** (see
-`docs/THREAT_MODEL.md`), residual demographic variance manifests as a *convenience*
-cost (an occasional password/PIN prompt), never as a security hole:
+Password fallback lets users recover from false non-matches without lowering
+the identity threshold for a demographic group:
 
-1. The PAM module captures and scores the frame.
-2. On a sub-threshold (or low-confidence) match it returns control to the stack
-   rather than hard-failing; the existing greeter/sudo/lockscreen fallback to
-   `pam_unix` (password) engages.
-3. The user authenticates with the secondary factor; FAR is never relaxed to
-   accommodate a harder-to-match face.
+1. The face path applies its capture, liveness, PAD and identity checks.
+2. If it refuses, the existing PAM stack can continue to the configured
+   non-biometric method, such as a password.
+3. A successful face grant is not retroactively checked by that fallback.
 
-This is the "MFA as equalizer" principle: tune the threshold for the worst case,
-let the fallback absorb the FRR, and never trade away the false-accept bound.
+Fallback is an alternative route, not evidence that two factors were verified
+on every successful face authentication. Residual false-match disparities remain
+an accuracy and security evaluation question; false non-matches create recovery
+burden that should also be measured across groups. Preserve recovery while
+validating the complete acceptance rule before claiming an error-rate bound.
 
 ## Roadmap to closing the gap cleanly
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -169,11 +169,14 @@ password/fingerprint without opening the camera; `yes` authorizes one face
 attempt. Login, logout, lock-screen, and credential-release flows do not gain
 this extra irlume prompt.
 
-That prompt is on by default and can be turned off per machine with
+That prompt is on by default. Use TUI Settings > Privileged consent [p], or
+`sudo irlume auth consent hands-free --yes`, to opt out per machine. This saves
 `privileged_face_consent=0` in `/etc/irlume/settings.conf`, the machine owner's
 waiver: a privileged face attempt then starts when the PAM prompt appears, with
 no per-attempt word. The trade is that
 every `sudo` then opens the camera, including one typed by someone else at the
-machine; passive PAD and the password fallback are unaffected.
+machine; passive PAD and the password fallback are unaffected. Restore confirmation with
+`sudo irlume auth consent required`; inspect it with `irlume auth consent status`.
+This setting does not change how desktop login or lock screens start a scan.
 
 </details>

--- a/docs/IR_ONLY_QUALIFICATION.md
+++ b/docs/IR_ONLY_QUALIFICATION.md
@@ -1,0 +1,240 @@
+# Optional IR-only qualification protocol
+
+Status: contributor evaluation protocol, not a qualification result. Dual-camera
+RGB+IR authentication remains the default. Irlume provides an explicit
+machine-owner IR-only policy whose production route has separate integration and
+granting-policy coverage. Sequential/concurrent remains a separate dual-camera
+scheduling choice. This document neither enables the policy nor certifies it.
+
+## What this evaluates
+
+Use the [non-granting diagnostic](research/2026-09-08-ir-only-evaluation.md) to
+exercise live IR capture, provenance and illumination handling, detection,
+liveness, mandatory FLIR PAD, compatible enrollment and the complete existing IR
+identity decision. `candidate_match` is an experimental decision, never login
+permission. No authentication, PAM grant or credential release belongs in this
+phase. Its absence of RGB scene/cross-spectrum evidence is part of the policy
+being evaluated, not evidence that those checks are unnecessary.
+
+The older [PAD self-test](PAD_SELFTEST.md) measures a component; `padcapture`,
+`padreport`, or recorded-frame PAD replay cannot substitute for this full-path
+study. Do not use their raw-signal logging for this protocol. No claim of Windows
+Hello parity, superiority, ISO conformity, FIDO approval or lab certification
+follows from completing an engineering campaign.
+
+## 1. Freeze a campaign before observing evaluation results
+
+Copy the [campaign and report template](research/ir-only-campaign-template.md).
+Declare the campaign **development**, **pilot**, or **qualification**. A pilot is
+useful for finding faults but cannot become qualification by relabeling it after
+seeing results. A qualification campaign needs a recorded maintainer review of:
+
+- The exact commit plus local patch hash, executable/model/adapter hashes,
+  recognizer space, profile/template-count strata, matching/PAD/gate thresholds,
+  capture budget and external watchdog. Record kernel/driver and sensor models,
+  capture backend, illumination/metadata behavior and topology, without serials.
+- The intended deployment scope: sensor/configuration combinations, ordinary
+  lighting/pose/distance range, enrollment procedure and intended population.
+  Dim-light testing is excluded from this campaign; make no dim-light claim.
+- Separate development and evaluation partitions, the sampling unit, planned
+  trial counts per sensor and attack species, ordering, treatment of missing
+  data and statistical analysis. Fix the schedule before seeing outcomes.
+- Numerical acceptance targets and confidence requirements for impostor candidate
+  decisions, attack candidate decisions, genuine failed attempts and capture
+  failures. Define acceptable data coverage and what evidence each claim needs.
+
+There are **no adopted numerical full-path release targets in this protocol**.
+The legacy component targets do not automatically become full-path targets.
+An unfilled or unapproved target/sampling plan means **not qualified**; do not
+invent a target after collecting data. Choosing release risk tolerance is a
+recorded product/security decision, distinct from selecting a model threshold.
+Any successful attack or zero-effort impostor candidate is an immediate stop for
+investigation, independent of aggregate targets. Do not retune against evaluation
+results and then report the same partition as held out.
+
+## 2. Independence and coverage
+
+Split by people, attack instruments and collection sessions, not by frames. New
+frames from a previously used person/banner remain development/regression
+material for those dimensions. Evaluation participants may enroll using the
+frozen enrollment procedure, but their evaluation sessions must be separate and
+must not influence global tuning. Reusing a device model is expected when testing
+that model; claim cross-device generalization only with separate device evidence.
+
+Include consenting enrolled participants and consenting non-enrolled participants
+presenting their own faces against a different enrolled target (zero effort).
+Keep local participant/instrument linkage private; publish aggregate coverage,
+not names, account identifiers or face-derived records. Do not infer demographic
+attributes from images. Any demographic study needs explicit participant consent
+and an appropriate independent privacy plan; otherwise limit the population claim.
+
+| Required stratum | Evidence to collect |
+|---|---|
+| Genuine users | Ordinary position and declared pose/distance variation; distinct enrollment and evaluation sessions; all failures retained |
+| Zero-effort impostors | Live non-target faces against enrolled targets; separately sampled from attack artifacts |
+| Printed artifacts | Target-identity matte, glossy, vinyl, and bent/cutout variants; independently sourced instruments |
+| Display replay | Target-identity still and video presentations on declared phone/tablet/laptop devices |
+| Higher-capability attacks | Masks, active IR artifacts and sensor injection assessed separately; unavailable coverage remains an explicit gap |
+| Sensor/configuration | Every claimed camera/driver/model/adapter configuration; no automatic transfer from ASUS to NexiGo or another topology |
+| Identity decision | Best-template and calibrated-centroid arms, profile/template counts and adapter/no-adapter configurations actually claimed |
+| Lifecycle/failure | Empty view, cancellation, expiry, contention, disconnect and incompatible enrollment; separate controlled cases, not accuracy samples |
+
+Check that an artifact depicts its intended enrolled target and is presented
+within the declared procedure; otherwise its rejection cannot qualify targeted
+attack resistance. Record artifact coverage without saving its image. Do not
+claim paper or screens can never produce a detectable IR face.
+
+Diagnostic schema 4 exposes which existing identity predicates passed as the
+bounded `identity_acceptance` label: `best_template`, `centroid`, or `both` for a
+final `candidate_match`, and null for every other category. Synthetic tests verify
+the arm logic, but they cannot establish empirical arm coverage. Instrumentation
+makes that coverage measurable; only predeclared, completed trials can supply it.
+Never infer arm coverage from older `candidate_match` records, disable an arm to
+pass evaluation, or count a component-only match as the union policy result.
+
+Independent public IR datasets can extend component testing, subject to verified
+modality, preprocessing, provenance, license and published splits. They cannot
+supply live provenance, emitter lifecycle or local full-policy evidence. FLIR
+training-data overlap is unknown; state this limitation even for locally held-out
+data. Do not substitute an unverified Kaggle mirror for publisher access terms.
+
+## 3. Run without granting access or retaining biometrics
+
+1. Use a test account/device under the operator's control with a working password
+   fallback. New participant enrollment is a separate consented operation; do not
+   alter the owner's enrollment or weaken an existing service configuration.
+2. Follow the diagnostic's real build/preflight instructions. Record the source
+   and executable identity. Never paste the maintainer's `/dev/videoN` choices onto
+   another host. Independently verify IR image/metadata topology, device binding,
+   required models and protected-state preservation. The current contributor
+   example needs a vetted IR image+metadata interface distinct from RGB; other
+   topologies require harness adaptation and review. The production route uses the
+   shared configured target and may accept an exact topology that explicitly has
+   no metadata companion; that does not broaden this harness campaign.
+3. Run camera-free preflight. Only after fresh readiness and an explicit start cue
+   run one evaluation for the scheduled presentation. Release the participant from
+   positioning after each group. No unattended scans or reused readiness.
+4. Supervise with a reviewed watchdog and an allowlist for the diagnostic's exact
+   schema/categories. Trace only video-device open/close metadata; discard other
+   paths and raw stderr. Reject unknown fields/categories and any grant indication.
+   For schema 4, require a bounded non-null identity acceptance label only for a
+   final candidate and require null for interruption, refusal and error categories.
+   Use the [contributor harness](../scripts/ir-evaluation/README.md) with an
+   explicit private host configuration. Its Linux/systemd topology and tracing
+   checks are conservative; each new host still needs review and attended lifecycle
+   validation. Passing the harness is not a qualification verdict.
+5. Retain one categorical outcome per started attempt, nullable stage timings and
+   release evidence. Include malformed output, process failure and watchdog cleanup
+   as harness failures in the attempt ledger. They never count as PAD successes.
+   Cancelled planned controls are separate from accuracy trials; an unplanned
+   cancellation in an accuracy trial remains in its failed-attempt count.
+6. Verify expected IR-only opens, all successful closes, idle state and protected
+   files after each attempt. Stop on any grant, attack/impostor candidate, unexpected
+   device access, cleanup or preservation failure. Keep the evidence; do not replace
+   the attempt, change thresholds, reset counters or continue until reviewed.
+
+No new images, frames, embeddings, templates, landmarks, similarity/PAD scores,
+raw errors, account names or private paths may enter campaign artifacts, shared
+memory or issue attachments. Do not turn on debug capture. Timing/aggregate
+outcomes and public code/model hashes suffice. Descriptor close is not optical
+emitter-off measurement; an optical claim requires its own measurement method.
+
+## 4. Account for every attempt
+
+Let `N` be all started accuracy attempts of a given ground-truth class and
+sensor/species stratum. Let `C` be its `candidate_match` count. All diagnostic
+categories plus harness-failure counts must sum to `N`.
+
+| Measure | Definition and limit |
+|---|---|
+| Genuine failed-attempt fraction | `(N - C) / N`; includes no-face, PAD/liveness/identity refusal, capture/model/enrollment errors, unplanned cancellation, deadline and harness failure |
+| Attack candidate fraction | `C / N` per species and configuration; diagnostic full-policy proxy, not certified IAPAR and not actual login grants |
+| Zero-effort impostor candidate fraction | `C / N` separately; full-policy proxy, not an isolated comparator FMR |
+| Capture/infrastructure outcomes | Each camera/lease/model/enrollment/harness error and timeout count separately, against all started attempts |
+| Decision detail | Separate `no_face`, `liveness_refused`, `pad_refused`, `identity_mismatch`, cancellation and other categories; never relabel no-face or hardware failure as PAD refusal |
+| Stage coverage | Count which timed stages were reached; stages not reached are missing evidence, not passed tests |
+
+Also report candidate fractions among assessment outcomes, using exactly
+`candidate_match`, `identity_mismatch`, `no_face`, `liveness_refused` and
+`pad_refused` for that conditional denominator. List its count explicitly; this
+does not imply every inference stage ran. All other categories remain outside
+this conditional denominator and inside the all-started denominator. Missing capture/infrastructure evidence
+must not make an attack result appear stronger: qualification also needs the
+predeclared adequacy gate, a sufficiently broad attack set and genuine controls.
+A run of unusable frames may produce zero candidates while qualifying nothing.
+
+Component APCER/BPCER or comparator FMR/FNMR requires a separate protocol and
+appropriate denominators. This diagnostic's staged, short-circuit output is not a
+complete PAD confusion matrix. In particular, `liveness_refused` combines multiple
+reasons and cannot automatically become BPCER. Report raw counts per stratum,
+worst supported stratum and uncertainty; never average away a weak species/device.
+If `N = 0`, the result is unavailable, not zero errors.
+
+## 5. Statistical claims
+
+State whether confidence bounds are one-sided or two-sided, their confidence
+level and the independent sampling unit. Use an analysis justified by the sampling
+design. Repeated frames, attempts from the same person/instrument, and all pairwise
+comparisons among a small cohort are not automatically independent trials. Report
+those clusters and seek statistical review before a population claim. Ordinary
+bootstrap resampling of an all-zero error sample cannot prove a tiny error rate.
+
+For **independent Bernoulli trials only**, zero errors in `n` trials has one-sided
+95% exact upper bound `1 - 0.05^(1/n)`. These are planning examples, not release
+targets or valid bounds for our correlated banner trials:
+
+| Zero-error independent trials | One-sided 95% upper bound |
+|---:|---:|
+| 6 | 39.304% |
+| 20 | 13.911% |
+| 59 | 4.951% |
+| 299 | 0.997% |
+| 29,956 | 0.00999994% |
+
+For nonzero errors use the declared exact-binomial or other justified method;
+account for clustering and multiple simultaneous stratum claims. Do not repeatedly
+peek and extend the campaign until an ordinary fixed-sample interval passes.
+[NIST's exact-binomial reference](https://www.itl.nist.gov/div898/software/dataplot/refman2/auxillar/exacbino.htm)
+explains one-sided versus two-sided limits. The older self-test's 0/20 example uses
+a two-sided 95% interval, so its upper limit is different.
+
+As external context, NIST SP800-63B-4 states FMR at most 1/10,000, recommends FNMR
+below 5%, and recommends deployment IAPAR below 7% in its biometric authentication
+requirements. It also requires biometrics to be part of MFA with a physical
+authenticator. These are not interchangeable metrics or automatic Irlume desktop
+release criteria. Do not claim NIST compliance from this experiment.
+[Current NIST biometric requirements](https://pages.nist.gov/800-63-4/sp800-63b.html#biometrics).
+
+## 6. Qualification decision and product integration
+
+A report may conclude **not qualified**, **inconclusive**, or **evidence meets the
+predeclared campaign targets for the stated scope**. Missing targets, inadequate
+independence/coverage, unresolved stop conditions or unverified arm coverage cannot
+be called a pass. State untested scope explicitly, including masks/injection where
+absent. The report is reviewed independently of the implementer before acceptance.
+
+Even accepted diagnostic evidence does not turn `candidate_match` into authority.
+The experimental product route has separate integration and isolated
+granting-policy tests covering the explicit root opt-in and dual default, supported
+target/model/enrollment binding, mandatory IR PAD, consent, password fallback,
+cancellation and late-result rejection, durable retry/recovery accounting, and
+credential release. Production derives its own ordinary authentication outcome; it
+does not grant from the diagnostic category. Camera-free preflight establishes
+prerequisites only. The existing product windows remain 15 seconds for login/lock
+and 5 seconds for short privileged services; a measured fixed-startup Minihost
+empty-view capture of about 5.5 seconds exceeded that short window before identity.
+The policy does not silently extend a window, adopt adaptive startup, or revive
+stock-desktop hands-free scanning. This integration coverage permits explicit
+experimental opt-in; it does not qualify a device, participant group, or population.
+
+## Current evidence, September 8, 2026
+
+The maintained local reports record: 252 earlier paper/screen/video frames with no
+face detections; a separate 396-frame regression with 119/123 detected banner
+frames PAD-refused and four below threshold; twelve live attempts with six banner
+PAD refusals and genuine four candidates/one identity mismatch/one capture failure;
+then two targeted genuine candidates after diagnostic-only error refinement.
+These are observations on an existing person/artifact and a limited hardware set,
+not independent qualification. The earlier capture and identity failures remain in
+the campaign record; successful repeats do not erase them or establish population
+performance. The experimental product option is not a qualification result.

--- a/docs/PAD_SELFTEST.md
+++ b/docs/PAD_SELFTEST.md
@@ -5,6 +5,11 @@ IR liveness gate (`irlume_liveness::LivenessGate`). The shipped deny-only PAD
 models (ViT RGB + FLIR IR, ADR-0013) run alongside this gate on the credential
 path and are out of scope here; see `docs/pad-results/`.
 
+> For the optional IR-only **full diagnostic path**, use
+> [IR-only qualification](IR_ONLY_QUALIFICATION.md). The gate-only measurements
+> below do not include its mandatory model PAD and complete identity decision,
+> and cannot qualify that proposed login mode.
+
 This document defines how irlume's presentation-attack-detection (PAD) gate is
 self-tested against the methodology of **ISO/IEC 30107-3** (*Biometric presentation
 attack detection, Part 3: Testing and reporting*). It is the reference the

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -89,6 +89,45 @@ irlume status for 'you'
 `irlume detect` is a script-friendly probe (exit 0 = ready, 10 = partial,
 20 = absent).
 
+### Optional experimental IR-only policy
+
+Dual RGB+IR authentication remains the default. Irlume also provides an explicit
+machine-owner IR-only policy. It remains experimental and is not a qualification
+claim.
+
+Inspect the installed policy and prerequisites without opening a camera:
+
+```sh
+irlume auth sensor status
+irlume auth sensor preflight
+```
+
+A successful preflight means only that the daemon found the configured IR target,
+its enrolled camera binding, compatible enrollment and recognizer models, and the
+mandatory IR PAD model. It does not prove that capture will finish, that login will
+succeed, or that the configuration is qualified. Older daemons, unknown readiness
+values and missing prerequisites fail closed to the password with an actionable
+message.
+
+The machine owner must opt in explicitly:
+
+```sh
+sudo irlume auth sensor ir-only --yes
+sudo irlume auth sensor dual       # restore the default
+```
+
+This writes the exact setting `face_sensor_policy=ir-only-experimental`. Missing
+settings select dual; malformed or unreadable settings make face authentication
+unavailable until repaired. IR-only opens only the configured, enrollment-bound IR
+image endpoint and its exact optional metadata companion. It does not probe RGB or
+fall back to RGB, and it adds no startup or background camera opens. The currently
+supported scope requires the enrolled isolated USB IR interface and fixed startup,
+with compatible IR templates and mandatory FLIR PAD.
+
+This sensor policy is independent of sequential/concurrent `CaptureMode`, the PAM
+`Method`, and privileged per-attempt consent. It changes none of those controls and
+does not reset retry history. Password fallback remains available.
+
 ### 2. Enroll your face
 
 ```sh
@@ -169,6 +208,14 @@ mistyped password can't be sealed and leave the wallet failing to unlock; the
 password is never stored in plaintext. Re-run it after you change your login
 password. On a fingerprint machine a fingerprint login unseals the wallet the
 same way (see [ADR-0003](adr/0003-fingerprint-keyring-unlock.md)).
+
+For KDE, the CLI or PAM session asks the packaged `irlume-kwallet-init` helper
+to read the fixed-size wallet salt after permanently entering the target account.
+The daemon receives those bytes and performs the existing key derivation; it
+does not open the user's wallet path as root or fall back to doing so. The KDF,
+sealed-envelope format, and wallet files are unchanged, so this needs no wallet
+migration. A failed best-effort reseal after an already valid password login
+does not fail that login.
 
 #### KDE Plasma: what has to be in place for KWallet
 
@@ -332,6 +379,36 @@ word. Do it only if you accept what follows: every
 and one run from a script. Passive PAD still applies, and the password still
 works.
 
+### Choosing privileged face confirmation
+
+Use the same control from the CLI or **TUI Settings > Privileged consent [p]**:
+
+```sh
+irlume auth consent status
+sudo irlume auth consent hands-free --yes  # opt in for configured privileged prompts
+sudo irlume auth consent required         # restore the default confirmation
+```
+
+The TUI explains the scope before enabling hands-free mode. This is a
+machine-wide administrator setting, not a face-profile preference. It affects
+already-configured privileged services, including sudo and polkit; it does not
+wire those services or enable automatic desktop login/lock-screen scanning.
+An app, script or another person can raise a prompt while you are in view.
+Recognizing your face does not establish that you intended that approval.
+Face matching, passive PAD and password fallback remain unchanged.
+
+The commands preserve unrelated settings and apply to subsequent attempts;
+no daemon restart is needed. Status reports the policy visible to this
+process, or an unknown state when it cannot read the file. An environment
+override is shown explicitly and prevents editing through these controls.
+PAM and the daemon may have different environments; a service-level
+`IRLUME_PRIVILEGED_FACE_CONSENT` override still takes precedence there.
+
+Only `0`, `false`, `no` or `off` (case-insensitive, whitespace trimmed)
+waive confirmation. Missing, empty, unreadable or unrecognized values retain
+confirmation. Correct malformed legacy values explicitly instead of relying
+on them to enable hands-free mode.
+
 ## App prompts via polkit (optional)
 
 Desktop apps ask polkit to verify you; Bitwarden's biometric unlock and
@@ -345,7 +422,7 @@ The daemon treats polkit as verify-only (it never releases the TPM-sealed
 credential to it). PAM shows `Type yes to use face authentication` above the
 normal hidden field, unless `privileged_face_consent=0` waives it as described
 above. Type `yes` for one face attempt, or type the ordinary
-password once for the password/fingerprint path. Empty Enter and cancellation
+password once for the password/fingerprint path. With the default confirmation enabled, empty Enter and cancellation
 never open the camera. Automatic passive PAD remains mandatory and separate.
 Full walkthrough, Bitwarden setup, and the security stance:
 [APP-INTEGRATION.md](APP-INTEGRATION.md).
@@ -475,7 +552,7 @@ live in them; sealed envelopes are stored separately (see
 
 | File | Holds | Written by |
 |---|---|---|
-| `/etc/irlume/settings.conf` | `privileged_face_consent=0` is the machine owner's waiver of the literal `yes` on privileged services, so the scan starts when the privileged PAM prompt appears, with no per-attempt word (default on: the confirmation is required, and an unreadable settings file keeps it). `enforce_biopolicy=1` opts into operation-class gating; `forbid_external_cameras=1` restricts face authentication to cameras the kernel reports as `removable: fixed` (internal only; `removable: unknown` fails closed to the password, mirroring Windows ShouldForbidExternalCameras post-CVE-2021-34466); the legacy `third_party_pad` / `third_party_recognizer` keys are ignored with a startup notice (the third-party lane was removed, ADR-0015). Head-gesture settings are retired and ignored; see [migration notes](HEAD-GESTURE-REMOVAL.md) | TUI Settings |
+| `/etc/irlume/settings.conf` | `face_sensor_policy=ir-only-experimental` is the explicit experimental IR-only opt-in; absence selects dual, while malformed or unreadable policy fails closed. `privileged_face_consent=0` is the machine owner's waiver of the literal `yes` on privileged services, so the scan starts when the privileged PAM prompt appears, with no per-attempt word (default on: the confirmation is required, and an unreadable settings file keeps it). `enforce_biopolicy=1` opts into operation-class gating; `forbid_external_cameras=1` restricts face authentication to cameras the kernel reports as `removable: fixed` (internal only; `removable: unknown` fails closed to the password, mirroring Windows ShouldForbidExternalCameras post-CVE-2021-34466); the legacy `third_party_pad` / `third_party_recognizer` keys are ignored with a startup notice (the third-party lane was removed, ADR-0015). Head-gesture settings are retired and ignored; see [migration notes](HEAD-GESTURE-REMOVAL.md) | `sudo irlume auth sensor ...` for the sensor policy; TUI Settings for the other listed settings |
 | `/etc/irlume/cameras.conf` | `rgb=` / `ir=` device nodes of the active camera pair | TUI camera picker, or `sudo irlume set-cameras <rgb> <ir>` |
 | `/etc/irlume/method` | one line: the active auth method (`auto`, `face`, `fingerprint`, or `both` = face OR fingerprint) | `irlume fingerprint enable/disable` |
 | `/var/lib/irlume/ir_emitter.conf` | the UVC extension-unit control that lights the emitter | `irlume ir-setup` |
@@ -587,6 +664,32 @@ recovery management does not attest which authentication factor was used.
 Older clients can use the new daemon with an available authorization agent;
 older daemons, including after a binary rollback, do not enforce this new gate.
 Rollback leaves recovery envelopes and retry records intact.
+
+
+Face retry recovery uses a separate command: `irlume retry status` shows the
+short face cooldown, the separate 50-consecutive-unsuccessful-request ceiling,
+and the independent reset-password budget; `irlume retry reset`
+verifies your current local login password before clearing both. It checks daemon
+support and reset availability before prompting, and never changes your password
+or restores the template key. Root can explicitly override the retry state with
+`sudo irlume retry reset --user <account>`. Ordinary password login does not clear
+these counters and remains available when retry reset is refused.
+Only an admitted face grant that is successfully written and flushed clears the
+face budget. Cancellation, errors and no-face/setup results after reservation
+retain a charge; cooldowns do
+not refill it. Legacy records start a prospective epoch on their first reservation,
+and status labels earlier history unknown. See [retry policy](DISABLE.md#persistent-retry-records).
+
+The initial password verifier supports local Linux passwords through its dedicated
+`pam_unix` service; LDAP, SSSD and systemd-homed are not qualified. Self-service
+reset is unavailable under enforcing AppArmor. Upgrade/restart the daemon and
+install the packaged verifier/service before using this feature; otherwise use
+normal password login and administrator assistance. The reset-password budget
+allows five failed checks before requiring a 30-second delay for each further
+check; 50 failures require administrator reset. Interrupted verification can
+consume an attempt. Existing face cooldown behavior and the cumulative face
+ceiling described above remain enabled. See [retry recovery](DISABLE.md#password-verified-retry-reset)
+for persistence, repair and rollback details.
 
 Install polkit and run a desktop authentication agent. For terminal sessions, register `pkttyagent` for the requesting process/session before enrollment or profile/model removal. Missing authority or agent, denial, cancellation and expired approval refuse the operation. The dialog uses configured OS authentication, which may include an existing face or fingerprint. The shipped policy does not retain approvals; administrator policy overrides remain authoritative.
 

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -10,12 +10,56 @@ formal certification stays optional.
   the threshold from a genuine/impostor ROC; do not port a threshold measured
   on another stack (e.g. buffalo_l's customary 0.60).
   **Measured status:** AuraFace shows a ~10× per-group FAR spread; a single
-  threshold meeting FMR ≤ 1×10⁻⁴ for every group needs ≈0.69. The gap is bounded
-  by a conservative fixed threshold + mandatory fallback, never by relaxing FAR.
+  threshold meeting FMR ≤ 1×10⁻⁴ for every group needs ≈0.69 in that benchmark.
+  These recognizer results do not establish the FMR of the deployed acceptance
+  rule. Password fallback preserves recovery after refusal; it does not bound
+  false matches that already granted.
   See [`FAIRNESS.md`](FAIRNESS.md) for the per-group table and policy.
 - **PAD mandatory**; target **IAPAR < 0.07** (ISO/IEC 30107-3 Clause 13).
 - **Biometric is one MFA factor only**, with a mandatory non-biometric fallback.
 - No network calls in the auth loop; templates/secrets local, root-owned 0600.
+
+## Acceptance-rule evidence limits
+
+The current face matcher has several acceptance arms after the applicable
+capture, liveness, PAD and enrollment-floor checks:
+
+| Assessment path | Identity acceptance arms |
+|---|---|
+| RGB face, non-sequential pair | RGB-primary, then weighted RGB/IR fusion, IR fallback or calibrated IR centroid |
+| RGB face, sequential pair | IR fallback or calibrated IR centroid; RGB-primary and fusion cannot grant |
+| No RGB face, IR face in a scene not conclusively lit | Dark-path liveness/PAD and the stricter IR best-template or centroid threshold |
+
+Purpose-specific consent applies before returning a grant. A below-threshold
+identity result is not presence-retryable; separate requests still need their
+own attempt/rate-limit analysis.
+
+Fusion uses legacy fixed sigmoid coefficients and a brightness-weighted mean.
+Its IR coefficients came from the retired adapter space; current-pipeline
+probability calibration and a full-rule FMR bound have not been established.
+A `prob` value of 0.50 is a score threshold, not a demonstrated 50% probability
+of identity. Adding this arm expands possible acceptance even though the other
+thresholds are unchanged. See [`fusion.rs`](../crates/irlume-core/src/fusion.rs).
+
+An accuracy claim needs evaluation of the complete deployed rule with its actual
+model/calibration spaces, template and profile counts, capture conditions and
+request protocol. Marginal RGB/IR benchmarks or an assumption of independent
+modalities do not establish that combined result. FMR, PAD resistance and
+non-biometric fallback are separate requirements in
+[NIST SP 800-63B-4, section 3.2.3](https://pages.nist.gov/800-63-4/sp800-63b.html#biometric).
+This documents an evidence gap; it does not quantify a new false-accept rate or
+change the runtime decision rule.
+
+Irlume has a separate, explicit experimental IR-only policy. Dual
+remains the default, and malformed or unreadable policy fails closed. The IR-only
+route is limited to the configured canonical IR image endpoint and its exact
+optional metadata companion, requires the enrollment camera binding, compatible IR
+templates and mandatory FLIR PAD, and does not probe or fall back to RGB. The
+sensor policy does not change capture scheduling, PAM method, consent, service
+deadlines, or retry accounting. Its absence of RGB cross-spectrum evidence narrows
+the evidence available to the decision and remains subject to the separate
+[qualification protocol](IR_ONLY_QUALIFICATION.md); local development observations
+do not establish deployment assurance.
 
 ## Known Windows Hello bypass classes → our defenses
 
@@ -328,17 +372,21 @@ with a fabricated print.
   What this gate is for is deliberate INTENT on the credential-release path, and
   the honest limit is that a present, non-consenting user can still satisfy it by
   moving. Tracked in [#101](https://github.com/archledger/irlume/issues/101).
-- **Consecutive-failure throttle.** After a run of failed face attempts (5 by
-  default, `IRLUME_RATE_LIMIT`), the daemon stops starting face capture for a
-  cooldown (30s, `IRLUME_RATE_COOLDOWN_SECS`) and PAM falls
-  straight to the password; a grant resets it, and an empty frame (nobody
-  present) never counts. This satisfies the NIST SP 800-63B-4 §3.2.3 intent
-  (an attacker cannot cheaply grind presentation attacks against the gate)
-  deliberately as a *throttle*, not the standard's hard biometric-disable
-  tier: irlume's password is always the fallback and there is no account
-  lockout, so disabling face until "another factor" would only re-offer the
-  password the throttled user is already typing. State is per-user and
-  in-memory; a daemon restart clears it because the password, not a lockout,
-  is the security floor. Every mainstream authenticator (Face ID, Android,
-  Windows Hello) likewise uses ~5 failures then falls to a non-biometric
-  factor rather than locking the account.
+- **Consecutive unsuccessful request ceiling.** Each account shares a durable
+  50-request budget across face verification and credential release. Reservation
+  precedes engine work; errors, cancellation, no-face results and crashes retain
+  the charge. Internal retries share one request; several template/acceptance
+  arms can run within it. Only an admitted and successfully written face grant,
+  independently verified password reset, or explicit administrator reset clears
+  the budget. Cooldowns and reboot do not replenish it. Short strikes retain
+  their separate default 5/30-second policy; zero cannot disable enforcement.
+  Selecting dual or experimental IR-only never clears or bypasses this history.
+  Migration from legacy records starts a prospective epoch and cannot reconstruct
+  erased history. See [persistent retry records](DISABLE.md#persistent-retry-records).
+  This 50-request ceiling is an enforced operational policy. Its number is not a
+  biometric qualification target or a claim of desktop compliance with
+  [NIST SP 800-63B-4](https://pages.nist.gov/800-63-4/sp800-63b/authenticators/).
+  A false acceptance already defeats the authentication boundary; resetting after
+  genuine success does not establish safety against that case. Root deletion,
+  disk rollback and the ambiguity between socket delivery and durable reset are
+  outside an exactly-once guarantee. Ordinary password login remains available.

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -39,6 +39,60 @@ If a command fails or is interrupted, some changes may already have been
 applied. Review its terminal output and the refreshed status before retrying.
 An unsuccessful daemon-start command does not automatically resume enrollment.
 
+## Preferences
+
+Preferences shows **ON**, **OFF**, or **UNKNOWN** for experimental IR-only,
+hands-free privileged face authentication, and the biopolicy gate. State is
+read from the daemon in the background, so a normal user can inspect root-only
+settings without running the entire TUI as root. A disconnected or older daemon
+is explicitly labeled; any available local observation is not a confirmed
+daemon state. Environment overrides are identified and block misleading toggles.
+
+Click an action or use its key:
+
+- **i** switches IR-only on or restores dual-camera authentication. Enabling
+  experimental IR-only requires the displayed warning to be accepted.
+- **r** checks IR-only prerequisites for the account shown in the header,
+  without opening a camera. Enabled policy and readiness are separate facts.
+- **p** switches hands-free privileged authentication on or restores required
+  confirmation. Enabling hands-free explains its scope and asks first.
+- **b** switches the biopolicy operation-class gate on or off.
+
+Administrator approval is requested by the action itself. State refreshes after
+it returns, including after a failed command. An unknown observation never
+chooses a toggle direction. Login/app wiring and fingerprint enable/disable
+controls remain in their dedicated sections.
+
+F2 includes sensor status, readiness, privileged confirmation status, face retry
+status, password-verified retry reset, and a separately labeled administrator
+retry reset. Password Wallet's Reseal uses the same seal-type handling as the CLI.
+Forget uses the safe password-rekey flow for token or unknown seals; it refuses
+an unsuccessful inspection. Force-forget remains a separate, explicitly warned
+action. No command needs to be typed for these workflows.
+
+## Diagnostics
+
+Select a check with the mouse or arrow keys to read its full, wrapped diagnosis.
+The details panel adapts to terminal height and scrolls with the mouse wheel;
+changing the selection returns to the start of the explanation. Passed,
+warning, failed and unknown checks are counted separately. Pending system
+checks are labeled, and an unavailable automatic fix does not imply a pass.
+
+**Fix Selected Issue** (`f`) starts the appropriate existing workflow. A daemon
+that is loading models or denying this account access is not offered a restart
+from the Cameras row. Access-denied inspection opens the read-only SELinux
+status action. Fingerprint-only wiring repair preserves the selected method.
+Wallet connection and PCR resealing open Password Wallet's guided flows.
+Missing template keys offer Recovery Restore when a recovery backup is present;
+without a backup, the diagnosis explains the need to re-enroll. The CLI's
+status, recovery status and Doctor use the same recovery distinction, and
+Doctor reports a missing template key as a failed check.
+
+Physical actions such as opening a privacy shutter or changing firmware settings
+remain instructions. Recheck, Full Diagnostics, logs, support reports and explicit
+camera tests remain available. The default support report does not capture
+camera data; an IR test or camera probe still requires an explicit action.
+
 ## Several people on one account
 
 A profile represents one person. An account supports up to **three people**;
@@ -118,6 +172,10 @@ scan lists. Rename and Delete confirmations name their exact target.
 | `profiles rename`, `profiles delete` | Faces: select profile/scan, then Rename/Delete; F2 also works without camera navigation |
 | `profiles forget-model`, `profiles eyes-open off` | F2: remove recognizer scans or clear the legacy blocker |
 | `identify` | Overview / Test Recognition |
+| `auth consent status/required/hands-free` | Preferences (`p`); F2 status |
+| `auth sensor status/dual/ir-only` | Preferences (`i`); F2 status |
+| `auth sensor preflight [--user U]` | Preferences (`r`); F2 readiness for the selected account |
+| `retry status/reset`, administrator `retry reset` | F2: status, password-verified reset or administrator reset |
 | `auth test` | F2: Test authentication for this account; JSON `granted` is the verdict |
 | `keyring arm/status/forget`, `reseal` | Password Wallet |
 | `keyring forget --force` | F2: Forget wallet secret without rekeying; review the consequence carefully |

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -9,6 +9,24 @@ this screen's shortcuts. `v` reveals technical sections. **F2 opens More actions
 from any idle screen. Type a task or CLI command to filter the list, use Up/Down
 to select, and Enter to open it. Esc closes the list or cancels a field.
 
+Mouse users can click the sidebar, status rows and action buttons, including
+in-page Wallet, Recovery, Login, Fingerprint, Cameras, Diagnostics, Identify,
+Preferences and completion actions. Each action has a separated row; its label
+and wrapped explanation activate the same keyboard command. Blank space and
+ordinary explanatory text do not activate commands. In More
+actions, click a row to select it and read its description, then click **Open**.
+Dialogs have separate **Continue**, **Confirm**, **Cancel** or **Close** buttons;
+clicking outside a dialog does nothing. Typed confirmations still require the
+exact requested text.
+
+The mouse wheel moves through the list under the pointer (Faces, Cameras,
+Diagnostics or More actions). Over Activity it scrolls the activity history.
+The wheel also scrolls longer information/action panels, including Wallet,
+Recovery and Login. Long dialogs scroll within their own body while the buttons
+remain visible.
+Press `M` to release mouse capture for the terminal's text selection and copy
+controls; press it again to resume mouse navigation.
+
 More actions supplies guided fields for less frequent tasks and shows the
 account, effects, and literal command arguments before asking you to run it.
 Blank optional fields use the CLI default; required fields cannot be blank.

--- a/docs/adr/0018-owner-opt-in-privileged-consent-waiver.md
+++ b/docs/adr/0018-owner-opt-in-privileged-consent-waiver.md
@@ -66,3 +66,19 @@ lockout.
 - `irlume support` and the settings table document the key and its
   default; the TUI does not expose it, matching the posture of the other
   advanced keys.
+
+## Operator controls, 2026-09-07
+
+The policy above remains the default-on, machine-owned privileged exception.
+It is now exposed by `irlume auth consent status|required|hands-free --yes`
+and TUI Settings > Privileged consent [p], superseding the earlier decision to
+leave it without a TUI control. Enabling requires explicit acknowledgment;
+restoring confirmation does not. Both interfaces use the common policy reader,
+display unreadable state honestly, and refuse writes when this process has an
+environment override. The daemon still independently validates every waiver.
+
+Only recognized false values waive confirmation. Previously the reader treated
+any present unrecognized value as false; that could turn a typo into a waiver.
+Unknown, empty and malformed values now retain confirmation. Existing valid
+false spellings and environment precedence remain compatible. The control
+changes neither PAM wiring nor desktop login/lock-screen arming behavior.

--- a/docs/research/2026-08-22-windows-hello-camera-control-dossier.md
+++ b/docs/research/2026-08-22-windows-hello-camera-control-dossier.md
@@ -6,30 +6,41 @@ this session (Microsoft Learn, USB-IF UVC 1.5, Linux kernel docs,
 linux-enable-ir-emitter). Evidence labels: [DOCUMENTED] stated at the cited
 source; [MEASURED] irlume fleet numbers; [INFERENCE] reasoned.
 
-## Headline numbers (Microsoft's own bar)
+## Correction after the ThinkPad study (2026-09-08)
+
+The original August interpretation confused an IR stream's control interface
+with the complete authentication pipeline. Microsoft explicitly documents RGB
+and IR input for Hello anti-spoofing; the September 4 ThinkPad/BRIO trace also
+observed both streams. An IR-specific control does not prove that RGB is unused.
+The corrected conclusions below supersede that interpretation. Irlume's optional
+IR-only proposal therefore needs its own qualification and is not Hello parity.
+[Current Microsoft privacy guidance](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/camera-privacy-controls#shutters-with-multiple-cameras-on-a-panel).
+
+## Published hardware requirements, not local certification results
 
 - Average authentication duration **< 2 s**, re-auth **< 2 s** [FACE-AUTH].
 - Stream **startup < 500 ms** for the face-auth IR stream (HLK gate) [BRINGUP].
 - Sustained **15 fps minimum while strobing** (lit AND ambient), ≥320x320,
-  L8/NV12 [BRINGUP]. (The NexiGo N930W IR at 14.73-14.79 fps measured would
-  fail this outright — it is a below-certification-bar device, which reframes
-  its 0.4% rate-floor margin as a hardware qualification fact, not a tuning
-  nuisance.)
+  L8/NV12 [BRINGUP]. Local NexiGo measurements of 14.73-14.79 fps are
+  measurements on Irlume's Linux path. They do not establish a Windows HLK
+  result or the device's certification status.
 - FAR < 0.001%, TAR > 95% [BIOREQ].
 
-## The core mechanism: firmware-per-frame strobe
+## Documented face-authentication illumination modes
 
-Hello never times the emitter against frames from the host. The driver sets
-ONE mode; the camera alternates the IR strobe every frame at full rate and
-tags every frame lit/unlit in metadata [DDI, MSXU]:
+The documented face-authentication modes support device-controlled alternating
+illumination or background subtraction, with the metadata contract below
+[DDI, MSXU]. This describes the interface; it does not establish every control
+write made by a particular Windows driver during authentication:
 
 - `FACEAUTH_MODE_ALTERNATIVE_FRAME_ILLUMINATION`: "alternate IR strobe on/off
   for each frame captured", illumination flag mandatory on each sample.
 - `FACEAUTH_MODE_BACKGROUND_SUBTRACTION`: camera delivers
   ambient-subtracted frames, no metadata.
 
-No emitter write sits on the per-authentication hot path. This is the single
-biggest structural difference from irlume's D1-write-per-session model.
+The mode contract does not establish that Windows performs no per-attempt
+control writes. Compare actual device traces before attributing a performance
+difference to Irlume's session setup or restore behavior.
 
 ## The Microsoft extension unit (MSXU)
 
@@ -46,44 +57,45 @@ Linux exposure: `V4L2_META_FMT_UVC` ('UVCH') = host ts + USB SOF + payload
 header per frame; `V4L2_META_FMT_UVC_MSXU_1_5` ('UVCM') adds the Microsoft
 metadata including per-frame illumination [K-UVC, K-MSXU].
 
-**Action for irlume (cheap, read-only): probe the fleet for this XU.** If
-present on a camera: SET_CUR face-auth/torch mode moves the strobe into
-firmware (deleting D1 write/restore from the hot path), and the MSXU
-metadata node gives a deterministic per-frame lit bit (replacing
-brightest-of-burst heuristics). Selector 0x02 is a documented manual-exposure
-path. Absent → current path unchanged. Subject to the XU safety guardrails
-(docs/research/2026-08-22-camera-control-safety-dossier.md).
+A descriptor/capability read can establish whether the XU is advertised.
+`SET_CUR` changes device state; it is not a read-only probe. An advertised XU
+alone does not prove working illumination metadata, successful restore, or that
+capture selection can be removed. Validate those behaviors on the particular
+camera before changing Irlume's existing control and frame-selection path.
+See [camera-control safety](2026-08-22-camera-control-safety-dossier.md).
 
-## RGB is not part of Hello auth
+## RGB participates in Hello authentication
 
-The recognition pipeline is described entirely on IR input; the MSXU
-face-auth control cannot even address the RGB interface; illumination
-metadata must never appear on RGB samples [FACE-AUTH, MSXU, META]. Windows
-has no cross-spectrum skew problem because it never pairs spectra. Irlume's
-joint RGB PAD is a deliberate superset (print-species coverage); ADR-0014 is
-what keeps it reachable on sequential hardware.
+An IR face-authentication stream has IR-specific controls and illumination
+metadata. The complete Hello pipeline also uses RGB for anti-spoofing. Its
+proprietary fusion and synchronization rules are not established by these
+public interfaces. Irlume's cross-spectrum timing and PAD policies therefore
+need their own evidence; describing them as a proven superset of Hello was
+unsupported. [Microsoft privacy guidance](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/camera-privacy-controls#shutters-with-multiple-cameras-on-a-panel).
 
-## Startup-latency techniques (documented)
+## Documented startup requirements and interfaces
 
-1. < 500 ms hard budget to first frame.
-2. IR sensor registered as `KSCATEGORY_SENSOR_CAMERA` + enumeration-hiding
-   (`SkipCameraEnumeration`): always-present node, no app contention.
-3. FrameServer-shareable auth pin: brokered, persistent pipeline.
-4. Static INF-declared capabilities (no runtime discovery).
-5. Torch defaults armed before streaming.
+1. Stream startup < 500 ms in the cited HLK test.
+2. IR sensor registration as `KSCATEGORY_SENSOR_CAMERA`; optional
+   `SkipCameraEnumeration` hides it from legacy camera-app enumeration.
+   This does not establish absence of contention.
+3. FrameServer architecture for brokered capture.
+4. INF-declared device capabilities.
+5. The IR Torch interface defines a pre-stream default mode. Actual control
+   writes and latency effects require device traces.
 6. ESS: hypervisor-isolated frame path (not portable).
 
-Linux analogs we can act on: held/pre-armed sessions (the broker model),
-autosuspend management, and MSXU probing. Pre-arm STREAMON-during-RGB-phase
-is the Windows-endorsed direction (broker holds the pipeline warm).
+Possible Linux experiments include session lifetime and startup-cost measurement.
+The cited Windows interfaces do not endorse Irlume keeping streams armed during
+other work. Queue freshness, ownership, cancellation and emitter restoration
+must remain tested requirements for any such optimization.
 
 ## Multi-camera synchronization
 
-No hardware sync, no documented skew tolerance. Pairing is software-only via
-camera profiles (CONCURRENCYINFO hints); geometric correspondence comes from
-MSXU extrinsics/intrinsics per rig [PROFILES, MSXU]. Our paired-window skew
-gate has no Microsoft counterpart to calibrate against; ADR-0014's
-derivation stands on our own measurements.
+The inspected public interfaces describe camera profiles and
+extrinsics/intrinsics [PROFILES, MSXU]; they do not establish the proprietary
+matcher's permitted skew or prove that every rig lacks hardware synchronization.
+Irlume's paired-window skew limit remains grounded in its own measurements.
 
 ## Sources
 

--- a/docs/research/2026-09-08-ir-only-evaluation.md
+++ b/docs/research/2026-09-08-ir-only-evaluation.md
@@ -1,0 +1,185 @@
+# Experimental IR-only evaluation
+
+This developer diagnostic evaluates one IR presentation without authenticating,
+calling PAM, releasing a credential, saving enrollment, or changing persistent camera
+configuration. `candidate_match` is experimental identity/PAD evidence only. It is
+not qualified for login and must not be consumed as authorization.
+
+The diagnostic exists only with the non-default `irlume-auth/ir-only-evaluation`
+Cargo feature and never grants. Irlume also provides an explicit experimental
+IR-only product policy with a separate production authorization path. The
+diagnostic's `candidate_match` is not consumed by that product route. Existing dual
+RGB+IR and sequential/concurrent scheduling remain unchanged.
+
+## Build and invoke
+
+```sh
+cargo build --release -p irlume-auth --features ir-only-evaluation --example ir_only_evaluation
+target/release/examples/ir_only_evaluation --help
+```
+
+Run the executable as real and effective root. Supply the existing detector,
+recognizer and FLIR files explicitly; the example does not download models.
+Pass the installed ONNX Runtime location through `ORT_DYLIB_PATH` when needed.
+It reads the pair through `configured_pair_no_probe`: an explicit process-local
+`IRLUME_RGB_DEVICE`/`IRLUME_IR_DEVICE` pair or the persisted camera configuration.
+No pair means unavailable, with no fallback to discovery. The IR endpoint must
+exist and differ from RGB. Existing IR enrollment binding, physical-device pin,
+lease, emitter authorization and runtime frame provenance remain enforced.
+
+```sh
+sudo env ORT_DYLIB_PATH=/path/to/libonnxruntime.so \
+  IRLUME_RGB_DEVICE=/dev/video0 IRLUME_IR_DEVICE=/dev/video2 \
+  target/release/examples/ir_only_evaluation --preflight USER \
+  /path/to/detector.onnx /path/to/recognizer.onnx /path/to/flir.onnx \
+  --budget-ms 5000
+```
+
+Replace placeholders and verify the pair against current device metadata first.
+`--preflight` loads models and the requested user's current protected enrollment,
+checks readiness and never opens a camera. It may unseal the existing template
+encryption key for an encrypted enrollment; it never unseals a login credential.
+It uses the read-only protected storage loader, including its per-user state lock,
+with no opportunistic envelope reseal or persistent TPM key provisioning.
+An optional `--adapter /absolute/path.onnx` must match the enrolled IR space.
+Missing explicitly supplied model files fail instead of silently omitting them.
+
+Only after an attended start cue, use `--evaluate` instead of `--preflight`.
+For harness cancellation add `--cancel-on-stdin` and keep stdin open; any byte,
+EOF or read error requests cancellation. The executable refuses debug tracing
+and the virtual-camera test override, suppresses dependency stderr before model
+loading, disables process dumpability and core files before biometric/model reads,
+and emits only its fixed JSON record. Do not enable image/debug capture
+around this operation. The external harness must retain only permitted metadata.
+
+## Operation and output
+
+The library entry points are:
+
+```rust,ignore
+Engine::ir_only_evaluation_preflight(&self, enrollment: &Enrollment) -> Category
+Engine::evaluate_ir_only(
+    &mut self,
+    enrollment: &Enrollment,
+    control: &CaptureControl,
+    budget: Duration,
+) -> Report
+```
+
+The operation constructs the configured IR target, which validates the supported
+sysfs topology before capture: one IR image node with at most its exact same-name
+index-1 metadata companion on the isolated interface. It acquires a Diagnostics
+lease for those exact endpoints and calls target-bound one-shot capture with pinned
+emitter authorization. When the companion exists, capture opens that exact metadata
+node for illumination classification; an explicitly absent companion does not
+trigger discovery.
+
+The contributor protocol intentionally narrows this further: its current harness
+requires exactly one IR image node and one metadata companion, with RGB on another
+interface, and rejects every other video open, including failed opens. Treat that
+as the campaign's vetted topology, not evidence for arbitrary devices. The device
+and lease are dropped before detection/inference begins. There is no retry,
+explicit RGB capture, RGB scene substitution, `assess_full` call or authentication call.
+The IR image is replicated into three channels solely for the existing detector,
+FLIR, alignment and embedder input contracts; this is not an RGB camera frame.
+This slice uses the primary detector only, without optional mesh/rescue models.
+
+It checks the existing `evaluate_ir_only` gate, mandatory finite FLIR probability
+in `[0,1]` below the existing IR PAD threshold, and the applicable enrollment
+falloff floor. Identity uses the existing recognizer/IR-space/dimension filters,
+optional adapter or per-profile calibration, best-template count adjustment and
+calibrated-centroid profile-count arm at the existing dark IR thresholds. These
+thresholds are reused for an experiment; their suitability for a new IR-only
+login policy has not been established. Brightness falloff is not measured depth.
+No cross-spectrum or RGB scene evidence is available in this experiment.
+
+Current machine-readable results use schema 4. This abbreviated example omits no
+fields; `capture_stages_ms` contains all fifteen nullable timing labels documented
+by the contributor harness:
+
+```json
+{"schema":4,"operation":"ir_only_evaluation","authentication_granted":false,"category":"candidate_match","identity_acceptance":"both","elapsed_ms":1234,"capture_ms":900,"detection_ms":100,"pad_ms":100,"identity_ms":100,"capture_stages_ms":{"open":1,"session_setup":800,"buffers":10,"metadata":5,"emitter":2,"warmup":300,"rate_fill":250,"frames":100,"session_release":80,"image_stop":70,"metadata_streamoff":1,"metadata_buffers":1,"metadata_format":0,"metadata_close":0,"emitter_restore":1}}
+```
+
+`identity_acceptance` is `best_template`, `centroid`, or `both` only for a final
+`candidate_match`; it is null for every refusal, error, cancellation or expiry.
+It reports which existing finite-score predicates passed and never reports scores
+or identities. Schemas 1, 2 and 3 remain valid historical records and are not
+rewritten. Instrumentation permits empirical arm coverage to be measured, but
+does not itself provide trials or qualification evidence.
+
+Timing values are unsigned integer milliseconds. Unrun stages are `null`.
+`elapsed_ms` covers the library evaluation, including readiness/capture/inference;
+it excludes executable model loading and protected enrollment loading. Capture
+time includes lease acquisition, setup and release. Identity time includes
+alignment, embedding, optional adapter and matching. Millisecond rounding can
+produce zero for a completed fast stage. Times are observations, not hard bounds.
+
+Categories: `ready`, `candidate_match`, `identity_mismatch`, `no_face`,
+`liveness_refused`, `pad_unavailable`, `pad_invalid`, `pad_refused`,
+`incompatible_enrollment`, `invalid_frame`, `inference_failed`,
+`camera_unavailable`, `cancelled`, `deadline_expired`, `invalid_request`,
+`enrollment_unavailable`, `models_unavailable`, and `root_required`.
+
+Capture errors additionally report these fixed labels: `camera_busy`,
+`camera_rate_refused`, `camera_io_failed`, `camera_hardware_failed`,
+`camera_authorization_refused`, `camera_policy_refused`, `camera_capture_failed`,
+`camera_lease_timeout`, and `camera_lease_refused`. These preserve existing typed
+errors; messages and rate-evidence payloads are discarded. `camera_unavailable`
+remains the preflight category for an unavailable/mismatched endpoint. A lease
+acquisition timeout is distinct from the five-second (or caller-specified)
+evaluation deadline; caller cancellation or expiry still takes precedence.
+Generic hardware errors cannot identify provenance, emitter, permission or
+other causes once the lower layer has collapsed them into a string. No text
+matching or automatic retry attempts to infer a more precise cause.
+
+Schema 4 adds only the bounded identity acceptance field and preserves the schema-3
+capture timing map. Consumers must enforce the exact category/acceptance relation.
+Older recorded reports are not reclassified. Camera-free tests exercise error-type
+classification, payload suppression, inference stopping and cancellation priority.
+
+No result contains names, scores, raw errors, images, embeddings or templates.
+Exit status 0 means the diagnostic ran, including a refusal; it never denotes
+successful authentication. Invalid syntax and non-root execution exit 2.
+
+## Bounds and qualification limits
+
+The required budget is 100 through 30,000 milliseconds. Caller cancellation and
+any earlier caller deadline are preserved; the local deadline also bounds
+capture. Checks run before capture, after returned driver calls, between
+inference stages and immediately before publishing the category. Late
+cancellation or expiry overrides a candidate. Kernel/model calls cannot be
+forcibly interrupted by this cooperative contract; a returned report can exceed
+the budget. A supervising harness needs a separate startup/hard watchdog, whose
+forced cleanup must be recorded separately from normal cooperative release.
+
+Camera-free tests cover missing/invalid/spoof PAD, failed liveness, optional
+falloff floor, incompatible templates, identity mismatch and centroid evidence,
+malformed frame dimensions, cancellation/expiry at the injected capture boundary,
+argument bounds, crash-dump disabling in an isolated child, and a metadata-only
+output schema. The real orchestration driver is exercised through typed stages
+that interrupt after capture, detection, PAD, alignment, embedding, adaptation
+and final identity evaluation. These do not establish device
+release timing or the absence of RGB opens in a physical run. The attended
+harness must trace opens/closes and independently verify camera cleanup.
+
+First evaluate an ordinary-light genuine user, an empty frame, cooperative
+cancellation, and available presentation artifacts such as the user's vinyl
+photo banner. Record each result and its coverage separately. Dim-light trials
+remain excluded. An unavailable model/lease or an expired attempt is not an
+identity/PAD accuracy sample. One subject and one artifact do not establish
+false-accept rates, broad presentation-attack resistance, or sensor-injection
+resistance. Optional login support requires held-out full-rule genuine/impostor
+and attack evaluation across both identity acceptance arms and the relevant
+supported camera/model configurations.
+
+## Contributor qualification
+
+Use the [IR-only qualification protocol](../IR_ONLY_QUALIFICATION.md) and its
+[campaign record](ir-only-campaign-template.md) before making deployment claims.
+The current diagnostic is available for evaluation; empirical acceptance-arm
+coverage remains open. A [portable contributor harness](../../scripts/ir-evaluation/README.md)
+now supplies explicit host checks and an attended attempt ledger; qualification
+on additional hosts remains open. Neither
+component replay nor successful developer trials qualify or enable the separate
+experimental product policy on an installed login.

--- a/docs/research/ir-only-campaign-template.md
+++ b/docs/research/ir-only-campaign-template.md
@@ -1,0 +1,101 @@
+# IR-only campaign record
+
+Copy this form for one frozen campaign. Follow the
+[qualification protocol](../IR_ONLY_QUALIFICATION.md). This unfilled form is not
+an accepted plan or evidence of qualification. Do not put personal identifiers,
+biometric payloads or raw errors in any field. A missing required entry makes a
+qualification campaign incomplete.
+
+## Plan, frozen before evaluation
+
+| Required field | Campaign entry |
+|---|---|
+| Campaign ID, date and phase: development / pilot / qualification | |
+| Plan revision and review reference; freeze date | |
+| Code commit, local patch hash and executable hash | |
+| Model/adapter identities and hashes; recognizer space | |
+| Matching, PAD and liveness thresholds; profile/template-count strata | |
+| Hardware model, kernel/driver, backend and vetted image/metadata topology | |
+| Scope: population, sensor configurations, ordinary lighting/pose/distance | |
+| Enrollment procedure and separation from evaluation sessions | |
+| Development/evaluation separation by people, instruments and sessions | |
+| Dataset origin, terms, preprocessing, splits and known training overlap | |
+| Participant consent process and private retention/deletion procedure | |
+| Sampling unit, cluster structure, order, counts and missing-data rules | |
+| Planned genuine and zero-effort impostor attempts by stratum | |
+| Planned attack attempts by species/device; target-identity validity checks | |
+| Untested attack/device/population scope and effect on intended claims | |
+| Independent empirical identity-arm coverage method, or unavailable | |
+| Evaluation budget, startup watchdog, cancellation and release checks | |
+| Reviewed harness revision; exact output/category allowlist | |
+| Protected-state verification and restoration procedure | |
+| Accuracy trials versus separate lifecycle/fault controls | |
+
+## Acceptance targets, reviewed before evaluation
+
+Record project decisions here; do not silently copy standards with different
+metrics. For each row specify numerator/denominator, numerical target, uncertainty
+method/confidence, independent sampling unit and per-stratum sample plan. Explain
+how the sample plan can support the target. Blank or retrospectively chosen
+entries cannot qualify a deployment.
+
+| Required measure | Target, uncertainty and sampling plan |
+|---|---|
+| Attack candidate fraction, each claimed species/configuration | |
+| Zero-effort impostor candidate fraction, each claimed configuration | |
+| Genuine failed-attempt fraction, each claimed configuration | |
+| Capture/infrastructure failure fraction and stage/data adequacy | |
+| Multiple-stratum/cluster treatment and fixed stopping rule | |
+
+Any attack/impostor candidate, grant indication, unexpected device access,
+cleanup/preservation failure is a stop for investigation regardless of these
+numbers. Record the disposition before resuming; never delete the stopped trial.
+
+## Results, append after the frozen plan
+
+| Stratum | Planned | Started | Candidate | No face | Liveness refused | PAD refused | Identity mismatch | Other diagnostic categories | Harness failures |
+|---|---:|---:|---:|---:|---:|---:|---:|---|---:|
+| One row per ground-truth class/species and sensor configuration | | | | | | | | | |
+
+Enumerate every “other” category separately, with counts. Candidate + all refusal
+and error categories + harness failures must equal started. Explain planned but
+not started attempts without claiming outcomes for them. Give aggregate unique
+participant, instrument, session and device counts and cluster sizes without
+identity linkage. Record separate stage-reach counts; these overlap outcomes and
+must not be added to the outcome denominator.
+
+Report both all-started and explicitly defined assessment-only fractions, their
+counts and valid uncertainty bounds. Report non-response/availability details,
+weakest strata, all stop conditions and their disposition. Keep lifecycle controls
+separate. Never provide just a combined headline or treat zero samples as zero risk.
+
+## Lifecycle and integration evidence
+
+| Check | Evidence/reference or not tested |
+|---|---|
+| Camera-free preflight, exact binary/schema identity | |
+| Only vetted IR image/metadata nodes opened; no RGB opens | |
+| All successful opens closed; camera idle afterward | |
+| Cancellation and expiry override late candidates | |
+| Fault/lease/permission/incompatible-enrollment cases, no grant | |
+| Protected state preserved; watchdog or restoration failures | |
+| Empirical coverage of both identity acceptance arms | |
+| Final installed state and operator release from positioning | |
+| Actual login integration review/testing | Not implemented by this diagnostic |
+
+If reporting physical optical shutdown, include its distinct measurement method;
+descriptor timestamps alone do not support that claim.
+
+## Decision
+
+- Outcome: not qualified / inconclusive / evidence meets predeclared targets for stated scope.
+- Supported scope and unresolved exclusions:
+- Comparison against every frozen target and uncertainty requirement:
+- Failed attempts and unresolved findings retained:
+- Independent reviewer disposition and reviewed artifact identities:
+- Configuration/model/code changes that invalidate this result:
+- Next action (no automatic login enablement):
+
+Publish only reviewed aggregate evidence and public code/model identities. Local
+trial-category/timing and video-open metadata may be retained under the protocol;
+remove private host/account paths and participant linkage before sharing.

--- a/docs/superpowers/plans/2026-09-07-active-capture-cancellation.md
+++ b/docs/superpowers/plans/2026-09-07-active-capture-cancellation.md
@@ -1,0 +1,49 @@
+# Active Capture Cancellation Implementation Plan
+
+> **For agentic workers:** Use the established test-first execution and independent review workflow. Continue in the existing isolated worktree and preserve prior uncommitted changes.
+
+**Goal:** Stop an abandoned authentication at returned camera-frame boundaries, release streams and restore controls without completing the remaining capture budget.
+
+**Architecture:** Add an opt-in CaptureControl carrying the existing watchdog callback plus a distinct request-cancellation signal. Preserve Progress and all existing entry points as wrappers with cancellation disabled. Carry control in TrackedStream, check around every returned dequeue, and preserve typed cancellation through camera errors and auth fallback decisions. Existing resource owners remain responsible for stream-off and emitter restoration.
+
+**Tech Stack:** Rust 2021, MSRV 1.88, pinned v4l 0.14, existing scoped worker threads and RAII guards.
+
+**Spec:** User-authorized reduction of the 5.110-second release delay recorded in /home/wisbfime/archledger-gp/artifacts/irlume/2026-09-07-cancellation-live-check/report.md.
+
+## Global Constraints
+
+- Preserve camera rate floors, frame provenance, warm-up retry/dequeue budgets, privacy/lease checks, emitter ordering and existing public entry points.
+- Scheduler yield is distinct from client cancellation. Cancellation must not demote camera qualification, retry hardware, emit partial evidence or mutate retry history.
+- No forced termination of driver calls or inference; returned-call checks are cooperative.
+- No raw biometric evidence, automatic desktop scanning, custom KDE work or publication.
+- Keep the installed build until source/test/review/build gates pass; install with an exact manifest and verified rollback. Coordinate any physical test before its cue.
+
+## Task 1: Camera frame cancellation and cleanup
+
+Files: create crates/irlume-camera/src/capture_control.rs and capture_cancellation_tests.rs; modify lib.rs and sequential_batch.rs; extend sequential_batch_tests.rs.
+
+Interfaces: CaptureControl::new(progress: Progress, cancelled: Arc<dyn Fn() -> bool + Send + Sync>), CaptureControl::with_progress(progress: Progress), check() -> irlume_common::Result<()>. New additive session/capture `_with_control` entry points accept &CaptureControl. Existing `_with_progress` wrappers disable cancellation.
+
+- [x] Add typed marker and control plumbing with checks initially absent, then failing regressions for already-cancelled dequeue, cancellation during a returned frame, rate-fill interruption and preserved next-request operation.
+- [x] Run `cargo test -p irlume-camera --locked capture_cancellation` and record assertion failures, with hardware opt-ins untouched.
+- [x] Check control before/after TrackedStream dequeue and before opening/arming/recovering sessions; map only the typed marker to Error::Preempted. Warm-up must not retry it.
+- [x] Pass control through sequential batch checkpoints, checking after opener/capture and before starting another phase. Regression must show no IR opener after cancelled RGB and owner-drop on failure.
+- [x] Run focused regressions; preserve ordinary warm-up and parallel-fill tests.
+
+## Task 2: Authentication wiring and cancellation classification
+
+Files: crates/irlume-auth/src/lib.rs, grouped_auth.rs, docs/DESKTOP-AUTH.md.
+
+- [x] Add Engine::capture_control() using existing capture_progress() and the request-only cancellation callback; ordinary CLI callers retain disabled cancellation.
+- [x] Route held, concurrent, standalone and grouped authentication captures through the additive control entry points.
+- [x] Preserve Error::Preempted before concurrent setup degradation, in-place recovery and one-shot retry decisions. Check cancellation before inference/materialization where captures have returned.
+- [x] Add regressions proving heartbeat still runs, scheduler yield does not cancel auth frames, request cancellation does, and cancellation does not enter camera fallback/retry.
+- [x] Update documentation with returned-frame semantics and remaining in-flight driver/inference limitation. Record an incremental patch instead of committing unrelated existing work.
+
+## Task 3: Qualify and deploy
+
+- [x] Run camera/auth/daemon ordinary tests, all-target Clippy -D warnings, MSRV1.88 check, fmt, rustdoc -D warnings and release build with CARGO_TARGET_DIR=/home/wisbfime/archledger-gp/irlume/target; inspect every result and real test counts.
+- [x] Independently review cancellation propagation and cleanup; fix findings with regressions and repeat affected checks.
+- [ ] Verify the source manifest, payload hash and dynamic linkage, install the exact daemon/docs/metadata overlay with protected-state checks and rollback.
+- [ ] Reuse the prior attended trial method and cold-after-restart conditions, without a stronger performance claim than the measurements support. Observe cancellation time, FD release and separate emitter restoration events; always remove the temporary logger.
+- [ ] Verify final hashes/service/caps/SELinux/camera-idle/diagnostic cleanup and refresh shared memory with exact resumption state and remaining frontend work.

--- a/docs/superpowers/plans/2026-09-07-auth-deadlines.md
+++ b/docs/superpowers/plans/2026-09-07-auth-deadlines.md
@@ -1,0 +1,26 @@
+# Consented authentication deadlines
+
+**Goal:** Keep the existing consented desktop flow and 15s desktop / 5s privileged defaults, reject expired grants and secrets, and stop collecting at cooperative frame/inference boundaries.
+
+**Architecture:** One monotonic authentication window spans engine setup, attempts and daemon completion. Zero retains legacy one-shot behavior. A scoped engine deadline supplies existing capture and inference checkpoints; a typed expiry is distinct from disconnect and hardware faults. The client also enforces an overall response-read budget so partial replies cannot prolong PAM waiting.
+
+**Tech stack:** Rust workspace, MSRV 1.88, Linux UnixStream, existing synthetic camera and inference fixtures.
+
+**Spec:** User authorized the recommendation in the current task; canonical handoff project-irlume.md and audit artifact 2026-09-07-auth-deadlines.
+
+**Global constraints:** Preserve the 29 existing changes, on-demand PAM wiring, owner opt-in, PAD and matcher thresholds, zeroizing secret owners, retry/fallback policy, stock frontend compatibility. No camera/TPM exercise, install, publish or external messaging during offline validation. Blocking driver/TPM calls cannot be forcibly interrupted; preserve loader ownership and document this limit. Never detach repeated TPM loaders merely to meet a wall-clock claim.
+
+- [x] Reproduce ordinary late grants and capture begun after expiry in auth/src/lib.rs using the production retry loop and injected clock. Cover zero-window one-shot and unchanged denial settlement.
+- [x] Add a shared auth window and scoped engine deadline, typed common expiry and camera control deadline. Gate frame collection, inference, camera recovery and retries without hardware degradation or extra retry strikes. Add meaningful camera/error-routing/scope regressions.
+- [x] Carry the window through daemon verify/unseal completion; reject expiry/disconnect around blocking work and before publishing credentials. Preserve retry-history behavior and test finalization with delayed synthetic operations.
+- [x] Reproduce and fix plain UnixStream response trickle extending a PAM client read budget in common/src/client.rs. Preserve framing, zeroization, cancellation and public default budgets; add real private-socket regressions.
+- [x] Run cargo test -p irlume-common -p irlume-camera -p irlume-auth -p irlume-daemon -p irlume-pam --locked; inspect hardware ignores and run no hardware opt-ins. Run affected all-target Clippy, MSRV1.88 check, release daemon/PAM build, rustdoc warnings-denied, fmt and diff checks.
+- [x] Obtain independent scoped review, fix verified findings and rerun relevant gates. Record exact delta/hash and installed-state preservation, update DESKTOP-AUTH and canonical memory. Prepare reviewable candidate and rollback before any installation; coordinate a separately cued physical timeout test if needed.
+
+## Validation and remaining attended step
+
+Final offline validation: 1177 default tests + 30 explicitly selected userspace PAM wrapper tests passed; 35 existing opt-ins left disabled. Workspace Clippy/MSRV1.88, release daemon/PAM, scoped rustdoc, formatter and diff checks passed. Independent rereview approved all corrections, including active-probe empty-token cleanup. Evidence lives in the task artifact directory.
+
+- [ ] After a fresh user readiness cue, perform a guarded attended timeout trial with the packaged candidate and verified rollback. No camera test or installation was performed during offline validation.
+
+The retained enrollment-loader drain and already-running driver/TPM calls may finish after the window; a camera-off wall-clock guarantee is outside this cooperative correction. The legacy PAM wait loop is not part of the on-demand contract. A retry reset whose atomic write crosses expiry can remain stored despite refused response admission; no rollback transaction is claimed.

--- a/docs/superpowers/plans/2026-09-08-ir-identity-arm-evidence.md
+++ b/docs/superpowers/plans/2026-09-08-ir-identity-arm-evidence.md
@@ -1,0 +1,66 @@
+# IR identity acceptance evidence implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task.
+
+**Goal:** Make both IR identity acceptance rules observable during qualification without disclosing biometric scores.
+
+**Architecture:** Extend the existing non-granting diagnostic and strict Python consumer together. Keep one identity predicate implementation and carry its bounded result through final deadline/cancellation admission.
+
+**Tech Stack:** Existing Rust 1.88 workspace and Python 3 standard-library harness; no new dependencies.
+
+**Spec:** ../specs/2026-09-08-ir-identity-arm-evidence-design.md
+
+## Global Constraints
+
+- Preserve dual-camera authentication, thresholds, PAD, enrollment, retry and credential-release behavior.
+- Schema 4 accepts `identity_acceptance` values `best_template`, `centroid`, `both` for `candidate_match` only; all other categories require null.
+- Preserve exact historical schemas 1, 2 and 3 and all fifteen schema-3 capture timing fields.
+- No scores, names, embeddings, images, free-form errors, extra crates or dependencies.
+- Keep work local and uncommitted; preserve the existing unpublished changes and durable attempt ledgers.
+
+### Task 1: Emit and validate acceptance evidence
+
+**Files:**
+- Modify/test: crates/irlume-auth/src/ir_only_evaluation.rs
+- Modify: scripts/ir-evaluation/harness.py
+- Test: scripts/ir-evaluation/test_harness.py
+- Modify: scripts/ir-evaluation/README.md
+- Modify: docs/IR_ONLY_QUALIFICATION.md
+- Modify: docs/research/2026-09-08-ir-only-evaluation.md
+
+**Interfaces:**
+- Consume existing `IrMatch`, `EvaluationStages::identify`, `Report::to_json`, and `checked_report(record)`.
+- Produce a typed acceptance result from the same `identity_category` predicates; no second independent threshold implementation. Change the private stage interface as needed so acceptance travels with the category. The public report exposes a bounded optional enum, not arbitrary strings.
+
+- [ ] Add Rust regression tests for each truth-table case, both matching thresholds, adapter selection and no compatible templates. Use synthetic `IrMatch` values and actual `scaled_threshold` boundaries. Preserve existing tests.
+
+```rust
+// Test vectors: neither predicate, best only, centroid only, both.
+// Set best to threshold +/- 0.01 and centroid to its separate threshold +/- 0.01.
+// Assert serialized identity_acceptance equals null, best_template, centroid, both.
+// Infinity/NaN never counts as a passing predicate.
+```
+
+- [ ] Add strict Python schema-4 positive/negative tests, including unknown labels, boolean/numeric/list/dict values, missing/extra keys, candidate/null and noncandidate/non-null contradictions; preserve schemas 1/2/3 tests.
+
+```python
+record = dict(schema3_record, schema=4, category="candidate_match", identity_acceptance="centroid")
+assert harness.checked_report(record) == record
+for invalid in (None, "unknown", True, 1, [], {}):
+    with self.assertRaises(ValueError):
+        harness.checked_report(dict(record, identity_acceptance=invalid))
+```
+
+- [ ] Run targeted new tests before implementation and retain expected failure evidence. Implement schema 4 with the exact vocabulary above and clear acceptance evidence on every final interruption/refusal. Extend cancellation/expiry stage tests to verify null evidence after a late match; verify a completed candidate retains its arm.
+- [ ] Run auth feature library/examples tests and Python discovery, Rust 1.88 feature Clippy, rustdoc with warnings denied, formatter, Ruff lint/format and git diff whitespace checks. Use CARGO_BUILD_JOBS=4 and ORT_DYLIB_PATH=/usr/share/irlume/onnxruntime/lib/libonnxruntime.so. Commands execute in the absolute worktree.
+
+```bash
+cargo +1.88.0 test --locked -p irlume-auth --features ir-only-evaluation --lib --examples
+python3 -m unittest discover -s scripts/ir-evaluation -p 'test_*.py'
+cargo +1.88.0 clippy --locked -p irlume-auth -p irlume-camera --features irlume-auth/ir-only-evaluation --all-targets -- -D warnings
+RUSTDOCFLAGS='-D warnings' cargo +1.88.0 doc --locked -p irlume-auth --features ir-only-evaluation --no-deps
+cargo +1.88.0 fmt --all -- --check
+```
+
+- [ ] Update current contributor documentation for schema 4 and explain that instrumenting acceptance enables empirical coverage but does not itself supply it. Correct the stale schema-1 description in the diagnostic research guide while preserving historical evidence.
+- [ ] Self-review necessity and privacy, then deliver exact changed-file hashes, incremental patch against the pre-task files, commands/results and concerns. Parent dispatches independent spec/quality review. Do not commit or run cameras.

--- a/docs/superpowers/plans/2026-09-08-ir-only-evaluation.md
+++ b/docs/superpowers/plans/2026-09-08-ir-only-evaluation.md
@@ -1,0 +1,55 @@
+# IR-only evaluation implementation plan
+
+> **For agentic workers:** Use superpowers:subagent-driven-development for the bounded implementation, then independent review. Preserve all pre-existing work and do not commit or install.
+
+**Goal:** A runnable developer diagnostic that captures only IR and evaluates existing IR PAD and compatible enrolled IR identity without authenticating or releasing credentials.
+
+**Architecture:** A non-default `ir-only-evaluation` Cargo feature exposes a diagnostic module on Engine and a required-feature example. No daemon/PAM/protocol/settings integration. An external attended harness records metadata and verifies camera release and no RGB device use.
+
+**Tech Stack:** Existing Rust workspace, Rust 1.88 floor, existing camera/liveness/vision/core components; Python standard library for the external harness.
+
+**Spec:** /home/wisbfime/archledger-gp/artifacts/irlume/2026-09-08-ir-only-design/assessment.md (diagnostic slice accepted by user September 8).
+
+## Global constraints
+
+- No changes to production authentication acceptance, camera mode configuration, enrolled data or installed binaries.
+- No `Outcome::grant`, authenticate method, PAM client or credential-release call in the diagnostic execution path.
+- Open only the configured bound IR device; no camera discovery/probing or RGB scene substitution.
+- IR PAD mandatory; absent/invalid/failed evidence and incompatible enrollment cannot produce candidate_match.
+- Reuse existing IR liveness and IR matching contracts, including best-template and centroid acceptance; label candidate_match as experimental evidence only.
+- No saved raw camera images, identity embeddings, templates, names or secrets in output/artifacts. Only bounded categories and timings.
+- Cooperatively check cancellation and a bounded deadline before capture, between inference stages and before reporting; release camera before inference when one-shot capture returns. Do not claim a hard wall-clock bound on blocked kernel/inference calls.
+- Hardware trial needs an attended start cue; dim-light trials excluded. Keep consented desktop and legacy greeter behavior.
+
+## Task 1: feature-gated diagnostic and runnable example
+
+Files: crates/irlume-auth/Cargo.toml, crates/irlume-auth/src/lib.rs (module declaration only), new crates/irlume-auth/src/ir_only_evaluation.rs, new crates/irlume-auth/examples/ir_only_evaluation.rs, new docs/research/2026-09-08-ir-only-evaluation.md.
+
+- [ ] Write behavior tests first for diagnostic policy. Missing/failed/nonfinite/out-of-range PAD, no face, failed liveness, incompatible templates, mismatch and late cancellation/expiry cannot return candidate_match. A good synthetic compatible IR candidate can return candidate_match only as a diagnostic category.
+- [ ] Run `cargo test -p irlume-auth --features ir-only-evaluation ir_only_evaluation --lib`, record red evidence for missing behavior before implementation.
+- [ ] Implement the separate feature-gated Engine operation with caller-supplied Enrollment and CaptureControl, a single configured IR endpoint, and categorical result/timing output. Use existing camera lease Diagnostics and ordinary pinned/emitter capture. Reuse detector/alignment/embed/adapter/ir_match and evaluate_ir_only, without calling assess_full or authenticating. Cover injected capture boundary in tests to demonstrate selected endpoint and no RGB call; production boundary remains real capture code.
+- [ ] Add the required-feature example: explicit evaluation invocation, root-only execution, argument/budget validation before loading/capture; load configured pair without probing and supplied existing models/enrollment. Load templates through existing protected storage only; never serialize them. Report fixed categories on errors without raw reason/model values. Help/preflight must not open cameras. Successful process execution never means authentication success.
+- [ ] Run feature-specific tests, auth library tests, example help/invalid input tests, fmt, Clippy all targets with feature, Rust 1.88 check and rustdoc. Record exact counts and ignored hardware limits.
+- [ ] Document developer invocation, categories, no-grant semantics, enrollment/model compatibility, hardware consent/cancellation, limitations and proposed next trial matrix.
+- [ ] Review complete diff independently; correct material findings and rerun affected gates. No commit/install/publication.
+
+## Task 2: external evaluation harness and attended trial
+
+Files under /home/wisbfime/archledger-gp/artifacts/irlume/2026-09-08-ir-only-evaluation only: metadata-only preflight, attended harness, tests, report and manifest.
+
+- [ ] Snapshot source hashes, installed overlay/protected state, selected camera binding and model metadata without camera opening or biometric file contents.
+- [ ] Build the exact diagnostic example and verify its library API is absent in normal feature configuration.
+- [ ] Write and test a bounded harness that launches the non-granting example, records only allowed output categories/timing, observes video-node descriptor use and process cleanup, and never records image/model inference payloads. Use system tracing where available for no-RGB-open evidence rather than claiming sampling proves absence.
+- [ ] Request readiness only when executable and hardware checks are ready; give start cue. One ordinary-light genuine-user trial first, then no-face/cancellation trials based on readiness. Ask what attack props/second consenting participant are available before claiming those evaluations.
+- [ ] Record observed result and camera release limits; compare against dual-camera only with same-condition measured trials. Missing attack coverage stays explicit, no optional login support enabled.
+- [ ] Verify source changes and unchanged installed state; refresh shared handoff/index with exact resumption and rollback.
+
+## Completed execution and approved recorded-data extension
+
+The user supplied seven explicit prior NexiGo IR attack folders during execution. Added a separate required-feature ir_recorded_pad example to process all252PGMframes with the current primary detector and FLIR, retaining aggregate counts only. This is regression data already evaluated in August, not held-out validation. No dataset downloaded. Four parser/accounting tests and three actual failure-invocation checks pass; independent review accepted the strict exit0/exact36/accounting gate. Failed-run counts are discarded entirely, including caught panics.
+
+Task1 completed:17newIRpolicy/orchestration tests +3CLI tests; defaultauth176pass/3ignored,featureauth193pass/3ignored. Readonlyloading correction adds5coretests,core136pass/26existinghardwareignored. No opportunistic template-key upgrades or persistent SRK creation in diagnostic loading. Core/header/source and harness independently reviewed.
+
+Task2 completed for first evaluation pass: camera-free preflight ready withzero videoopens; attended genuine candidate_match, empty no_face, cancellation cancelled, banner pad_refused. Allfourtrials noRGBopens,IRimage+companionmetadata only, release+installed7/66 preservation checks pass. Root13harness tests pass. Frame-level recordedreplay252noface/0failed/0PADevaluated. Alloutputsare non-granting; nooptional loginmode enabled.
+
+Final gates: Clippy/MSRV1.88/rustdoc/fmt/diff and optimizedexamples pass. Normal-feature positive Engine import compiles; diagnostic import refuses E0432. Report/evidence in /home/wisbfime/archledger-gp/artifacts/irlume/2026-09-08-ir-only-evaluation. No commit/install/publication. Broader held-out sensor-matched genuine/attack evaluation remains before optional authentication support.

--- a/docs/superpowers/plans/2026-09-08-verified-retry-recovery.md
+++ b/docs/superpowers/plans/2026-09-08-verified-retry-recovery.md
@@ -1,0 +1,88 @@
+# Verified Retry Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox syntax for tracking.
+
+**Goal:** Provide explicit password-verified reset of existing face retry state, with independent persistent protection against reset-password guessing.
+
+**Architecture:** A root-only, non-setuid PAM helper verifies a local account password through a dedicated service. The daemon reserves reset attempts durably outside its camera worker, binds the result to the live request and serializes the reset with face accounting. The CLI adds status/reset commands. This slice does not enable the new cumulative face ceiling.
+
+**Tech Stack:** Rust 2021/MSRV 1.88, existing libc/serde/zeroize dependencies, Linux-PAM, private Unix channels and the existing atomic retry store.
+
+**Spec:** ../specs/2026-09-08-cumulative-retry-recovery-design.md
+
+## Global Constraints
+
+- Use the current linked worktree; preserve its 38 pre-existing local changes. No commits, publication or installation this turn.
+- No real account password test, camera capture, enrollment access or installed PAM change. Real PAM tests use private synthetic fixtures only.
+- Keep face authentication defaults and version-1 face records unchanged in this slice.
+- Reset-password budget: five failures then 30 seconds before each subsequent verification; 50 failures require administrator reset. Reserve before helper execution, so unknown completion is charged.
+- Helper interface: `irlume-password-verify USER`, raw password bytes on stdin terminated by EOF, maximum 4096 bytes, no NUL/empty input; exit 0 verified, 1 rejected, 2 unavailable/invalid. No stdout or credential-bearing stderr.
+- Helper service: fixed `irlume-retry-reset`; installed executable `/usr/libexec/irlume-password-verify`, root-owned mode 0755, never setuid. Fixed local-password auth/account service; no includes, Irlume, fingerprint, nullok, password changes or sessions.
+- The daemon supplies a cleared environment and fixed executable/service; untrusted request data cannot select either. Bound process execution and kill/reap on failure or cancellation.
+- Proposed protocol: `RetryStatus { user }`, `RetryReset { user, password: SecretBytes }`; response `RetryStatus { failures: u32, cooldown_seconds: u64, recovery_failures: u32, recovery_cooldown_seconds: u64, recovery_required: bool, password_reset_available: bool }`. A valid status response is capability negotiation; legacy daemon errors mean unsupported.
+- Root reset is an explicit admin override; non-root reset always requires independent password verification. Neither generic polkit success nor keyring preflight is proof.
+
+### Task 1: Password verifier and package boundary
+
+**Files:** Create `crates/irlume-password-verify/{Cargo.toml,src/main.rs,tests/pam.rs}`, `packaging/pam/irlume-retry-reset`; modify workspace Cargo manifests/lock and actual package/install/confinement manifests that ship helper binaries.
+
+**Interfaces:** Consumes fixed username argv and bounded password stdin. Produces only exit 0/1/2 as above. Controller will implement daemon invocation; do not edit daemon/common/CLI code.
+
+- [x] Write tests that execute the helper contract: root-only invocation, invalid/missing/extra args, empty/oversized/NUL input, correct and wrong password, auth success plus account refusal, no password echo, and repeated conversation refusal.
+- [x] Run the new tests and retain failing evidence before adding implementation.
+- [x] Implement minimal Rust/libpam bindings, document every unsafe call, free PAM conversation responses correctly and scrub owned secret buffers. Require `pam_authenticate` and `pam_acct_mgmt` success, always call `pam_end`, accept exactly one password prompt. Reject unexpected prompt styles or repeated password requests. Verify final PAM_USER remains the requested identity.
+- [x] Use private PAM wrapper fixtures or a private compiled PAM test module to execute actual libpam paths without installed PAM edits. Tests requiring wrapper prerequisites must be explicitly exercised locally, not merely skipped and claimed.
+- [x] Wire helper and service into the actual package formats, Nix/release/install machinery and confinement. Do not grant the main daemon broad shadow access or ship a helper reachable as a public service.
+- [x] Run helper tests, MSRV check, Clippy, fmt and relevant package parsing/confinement validation. Report exact commands, outcomes and limitations.
+
+Example contract assertion (implementation test must launch the real helper):
+
+```rust
+assert_eq!(run_case("correct-password-account-expired").status.code(), Some(1));
+assert!(run_case("wrong-password").stdout.is_empty());
+```
+
+### Task 2: Persistent recovery gate and daemon dispatch
+
+**Files:** `crates/irlume-daemon/src/retry_throttle.rs`, new `retry_throttle/recovery.rs` and tests, new `retry_recovery.rs`; integrate in `main.rs`, `arbiter.rs` and shared protocol `crates/irlume-common/src/lib.rs`.
+
+**Interfaces:** `retry_recovery::dispatch(&Request, &Peer, &UnixStream) -> Response` handles both requests before engine readiness. Private retry-store operations take the resolved account and a verifier closure, retain a per-account operation guard, reserve a failed check before invoking the closure, and reset the face record only after the closure reports fresh success. No reset capability is serializable or client-provided.
+
+- [x] Write behavioral tests for cross-account refusal before verifier execution; five/30/50 recovery boundaries; crash/reopen retaining charged attempts; no face-state writes on bad verifier; unsafe record refusal; success clearing existing face cooldown; failed reset commit refusal; active face work exclusion; client disappearance/deadline refusal; root override and status without a camera.
+- [x] Run tests red against unimplemented operations.
+- [x] Implement strict separate recovery records beside existing face records. Reuse trusted directory/read/write primitives without changing legacy face semantics. Serialize face check-to-record and recovery reset through one account operation guard. A helper wait must not hold the global directory lock or camera worker.
+- [x] Launch the fixed helper through cleared environment and bounded input. Validate executable/ancestors and the fixed service before reporting available; root-owned non-writable files only. Hold a live peer/process binding and revalidate after helper return and before durable reset. Keep a conservative recovery charge on ambiguous failure; update face first, then clear recovery budget, so a torn reset cannot replenish guessing without password verification.
+- [x] Integrate exhaustive request authorization, operation-class and diagnostic tables. Preserve old wire shapes and prevent direct worker dispatch from bypassing verification. Ensure status/reset are reachable while models are starting.
+- [x] Run guarded daemon/common suites and inherited cancellation/deadline tests, Clippy and MSRV.
+
+Example state-machine expectations:
+
+```rust
+for _ in 0..5 { assert!(attempt_with_wrong_password().is_err()); }
+assert_eq!(verifier_calls_after_immediate_retry(), 5);
+advance_clock(30);
+assert!(attempt_with_wrong_password().is_err());
+assert!(immediate_retry_does_not_invoke_verifier());
+```
+
+### Task 3: CLI, docs and integrated qualification
+
+**Files:** new `crates/irlume-cli/src/retry.rs`, `main.rs`, relevant CLI tests, `docs/DISABLE.md`, `docs/SETUP.md`, completion/help sources discovered from current CLI wiring.
+
+**Interfaces:** `retry::run(sub: Option<&str>, args: &[String]) -> ExitCode`; status probes new daemon support before prompting; non-root own-account reset uses existing no-echo password reader and SecretBytes. Root `--user` reset explicitly describes administrator action.
+
+- [x] Write tests for old-daemon refusal without password prompt, status text/exit results, same-account reset request shape, helper unavailable, typed password not echoed and root override.
+- [x] Run red, then implement CLI routing and concise fallback guidance. Distinguish template-key recovery from retry reset.
+- [x] Run CLI tests plus real userspace PAM helper qualification and package checks. Compare final source hashes against the initial snapshot and inspect the incremental patch.
+- [x] Obtain independent review of the complete added trust boundary and fix actionable findings. Final scoped formatting, Clippy, compiler and tests must be fresh after fixes.
+- [x] Update the canonical handoff/index and artifact report with actual test evidence, limitations and exact resumption state. Leave the installed system unchanged and the cumulative face ceiling inactive.
+
+## Execution decisions
+
+- The user approved implementation of the recommended recovery-first slice. Routine design details are settled within that scope; no repeated permission question is needed.
+- Preserve the dirty worktree and save incremental artifacts. Commit-based review/cleanup instructions from skills do not authorize destroying or publishing this pre-existing work.
+- Where independent failure protection and face reset span two files, write the verified face reset first and recovery-counter reset second. A crash leaves a conservative recovery charge; no unverified password gains a reset. Atomic publication of both fields belongs to the later unified v2 face migration.
+
+## Completion evidence
+
+Completed source implementation and independent review; evidence is retained in `artifacts/irlume/2026-09-08-verified-retry-recovery/` under the canonical shared-memory root. The final workspace run reports 2,086 passing tests; prerequisite-dependent and ignored tests are accounted for in the report. The private helper suite separately exercised 21 synthetic PAM cases, and the CLI administrator override was explicitly exercised as root. Workspace MSRV, Clippy, rustdoc and formatting pass. No installation or cumulative face ceiling was enabled. Distribution backend, installed confinement and real account qualification remain separate follow-up work.

--- a/docs/superpowers/specs/2026-09-08-cumulative-retry-recovery-design.md
+++ b/docs/superpowers/specs/2026-09-08-cumulative-retry-recovery-design.md
@@ -1,0 +1,252 @@
+# Cumulative face-attempt limits and verified recovery
+
+Status: proposed design, ready for review; not implemented or enabled.
+Agent: codex. Date: 2026-09-08.
+Source baseline: `feat/privileged-consent-controls` at
+`fe7339c18bf44a08bc1736b1300c7c04cf9d91fb`, including the existing local
+consented-authentication and fusion-documentation changes.
+
+## Objective and recommendation
+
+Bound unsuccessful face-authentication attempts across cooldowns and daemon
+restarts while keeping ordinary password authentication available. Restore face
+access through an explicit, independently verified password operation. Keep the
+consented on-demand flow and existing greeter compatibility.
+
+Recommended defaults: five failed attempts, then at least 30 seconds before
+each further attempt; at 50 failures, stop face capture and require recovery.
+Cooldown expiry allows another attempt but does not clear the failure count.
+A completed, admissible face success before exhaustion clears the count.
+
+These are proposed product defaults, informed by
+[NIST SP 800-63B-4 sections 3.2.2–3.2.3](https://pages.nist.gov/800-63-4/sp800-63b.html#biometric).
+The biometric section distinguishes consecutive failures, delays after the
+initial allowance, an overall ceiling, and an alternative authentication method.
+Selecting these values does not establish NIST compliance or biometric accuracy.
+
+## Current implementation and gaps
+
+- `crates/irlume-daemon/src/retry_throttle.rs` already persists strict, root-owned
+  UID/name-bound version-1 records with monotonic deadlines and boot identity.
+  It serializes file updates and refuses face on unsafe or unavailable state.
+- `Record::arm` resets strikes to zero. Cooldown expiry also clears strikes.
+  Consequently, the current default permits repeated five-failure batches.
+- `Authenticate` and `do_unseal_password_scoped` share the throttle. They check
+  before capture and record the final outcome afterward. There is no durable
+  reservation before engine work, and errors can bypass terminal recording.
+- The authentication loop retries incomplete presence evidence. Below-threshold
+  identity and hard spoof results are terminal. The proposed counting unit is
+  one admitted authentication request, not a camera frame or template comparison.
+- `operation_authorization.rs` already binds OS approval to the requesting
+  process, account, exact request and freshness window. Its polkit result does
+  not identify the authentication factor used. The existing enrollment spec
+  explicitly permits the configured polkit stack to use Irlume or fingerprint.
+- `password_matches_login` is a keyring preflight, not a recovery verifier: it
+  returns unknown for unsupported accounts and its existing caller can proceed.
+  It also does not perform PAM account management. Do not reuse that contract.
+- Template-key recovery already exists and has its own authorization. Retry
+  recovery must not implicitly replace a passphrase, reseal a key or re-enroll.
+
+## Approaches considered
+
+| Approach | Benefit | Trade-off |
+|---|---|---|
+| Explicit password verification through a dedicated PAM service — recommended | Direct non-biometric proof; independent of the display manager and optional template recovery setup | Requires a bounded helper, packaging and confinement qualification |
+| Verify the existing template recovery passphrase | Reuses a separately held credential | Not configured for every account; coupling retry reset to template-key recovery creates availability and lifecycle complexity |
+| Reset after ordinary login or generic polkit authorization | Convenient when supported | No existing trustworthy password-success event; generic approval can use face; desktop-specific hooks conflict with the chosen product direction |
+
+## Policy and state transitions
+
+Keep face and recovery-verification budgets separate. Neither locks the Linux
+account, changes its password, nor writes a system-wide password lockout counter.
+
+| Event | Face-budget effect |
+|---|---|
+| Unauthorized request, policy refusal or cancellation before reservation | No change; no capture |
+| Admitted request | Durably reserve one slot before engine work |
+| Terminal spoof or below-threshold result | Finalize the reserved failure |
+| Existing chargeable deadline/runtime/other denial | Finalize the reserved failure |
+| Known no-face, uncertain evidence, missing IR face or setup-unavailable result, with no terminal identity/attack decision | Return only this request's reservation; preserve prior history |
+| Clean cancellation proven to precede any terminal identity/attack decision | Return only this request's reservation; preserve prior history |
+| Cancellation/error after a terminal decision, ambiguous interruption, panic or process death | Keep the reservation charged; do not gain a free attempt |
+| Valid completed face grant, including required consent and successful credential preparation when applicable | Clear face history only through durable completion |
+| Cooldown expires | Clear the deadline, retain cumulative failures |
+| Count reaches 50 after a failed/unknown attempt | Enter recovery-required state; further requests do not start capture |
+| Verified explicit recovery | Clear face history and recovery-verification failures atomically |
+
+The 50th reserved request may still succeed: admission is allowed with 49
+previous failures, and refused with 50 settled failures. An unfinished reservation
+consumes capacity; restarting cannot create a 51st opportunity.
+
+Do not infer exemptions from human-readable reason strings or just the final
+error variant. Add an internal accounting result that records whether any
+terminal identity/attack decision occurred. Its state is owned by the engine and
+daemon, never supplied by the socket client. Keep presence-only internal retries
+within the existing time and PAD-vote budgets. Verify that every decisive grant
+or refusal ends the request; a future change permitting another decisive attempt
+inside one request must acquire another budget slot first.
+
+Existing non-chargeable outcomes remain non-chargeable when positively
+established. The deliberate tightening is that unknown completion cannot refund
+an attempt. A normal early cancellation remains free; a killed daemon may leave
+one conservatively charged slot.
+
+Retain the existing `IRLUME_RATE_LIMIT` and `IRLUME_RATE_COOLDOWN_SECS` controls
+for initial allowance and delay. Apply delays after every subsequent failed
+request once the configured initial allowance is reached. The new overall face
+ceiling is fixed at 50 in this first version. Existing `IRLUME_RATE_LIMIT=0`
+continues disabling the legacy delay mechanism, but does not disable the new
+cumulative ceiling. Document that intentional configuration change prominently;
+custom delay settings do not inherit the default-policy assurance claim.
+
+## Durable accounting and races
+
+Extend the private store to version 2 at the existing fixed retry location.
+Retain ownership, mode, link, size, schema, NSS and clock checks. Store only
+account identity, version, generation, failure counts, cooldowns and pending
+reservation metadata. Do not store scores, face data, credentials or PAM replies.
+
+The proposed private API consists of admission/reservation, settlement, status,
+and verified reset. A reservation is a non-cloneable internal capability bound
+to account, store generation and a unique operation identity. Settlement consumes
+it once. Do not expose a reusable reset or reservation token in the protocol.
+
+Under the store lock, admission reads current state, resolves abandoned work,
+checks the ceiling/deadline, and publishes the charged reservation durably.
+Release the file lock before capture or password verification. Permit only one
+active face reservation per account; preserve the existing worker serialization
+and make duplicate admission fail explicitly. Settlement reopens the authoritative
+state and checks reservation identity and generation before changing it.
+
+Retain an OS-held operation lock for the reservation lifetime so another process
+cannot mistake a live reservation for an abandoned one. Reboot/process death
+releases that lock but leaves the durable charge. On recovery of abandoned work,
+settle it as a failed/unknown attempt and arm the applicable cooldown. A reboot
+rearms a stored cooldown conservatively; it never clears failure counts.
+
+Late settlements from before a verified reset cannot modify the new generation.
+Reset is serialized with face admission/settlement and rejects or waits within a
+bounded deadline while live face work exists. A successful password check must
+remain bound to its account, request and reset generation until the commit.
+
+On write/rename/fsync ambiguity, refuse face and treat the visible record as
+authoritative on the next read, as today. Never restore a stale cached count.
+Keep the existing completion/deadline gates and the rule that credential
+preparation must succeed before a grant clears history. Eligibility must be
+checked before and after persistence. Delivery of a successful socket response
+cannot be made atomic with a disk commit: a crash after a verified successful
+decision is distinct from a crash with an unknown decision and must be documented
+and tested as such. No claim of exact response-delivery accounting is made.
+
+## Verified recovery and user experience
+
+Proposed commands, not currently available:
+
+- `irlume retry status`: explain ready, cooling down, recovery required or state
+  unavailable; show own-account counts and wait where appropriate.
+- `irlume retry reset`: prompt for the current account password without echo;
+  verify it independently, then reset only the retry state.
+- Root may reset a named account as an explicit administrative override. This is
+  trusted administrator authority, not proof of a fresh human password check.
+
+Use an additive protocol operation with a zeroizing secret type and root-or-own
+account authorization. A non-root caller cannot select another identity, a PAM
+service, executable, configuration directory or helper environment. Existing PAM
+clients keep their current denial/fallback response shapes; new CLI features use
+capability negotiation and explain when the daemon is too old.
+
+The daemon launches a fixed root-owned helper through a private bounded channel.
+The helper is not setuid and exposes no public service. It uses a fixed dedicated
+PAM service, calls authentication and account management, and requires explicit
+success from both. Locked, expired, password-change-required, unsupported and
+unavailable cases do not reset. It does not open a session or change a password.
+One request permits one bounded password exchange, not an unbounded conversation.
+Passwords never appear in arguments, environment, logs or saved files.
+
+The shipped recovery service must use a reviewed non-biometric password backend;
+it must not include the ordinary desktop/polkit stack, Irlume, fingerprint,
+automatic credential retrieval or a permissive authentication module. For the
+first implementation, qualify local Linux passwords with `pam_unix` and account
+checks on the supported package targets. Do not pretend this supports LDAP,
+SSSD or systemd-homed automatically. Those account backends need separately
+reviewed password-only services; until qualified, self-service reset fails closed
+with administrator guidance. Ordinary login through the existing OS stack stays
+available. Root modifications to PAM remain within the administrator trust
+boundary; no parser can certify arbitrary administrator-authored PAM behavior.
+
+Bound helper runtime and concurrency, cancel on client disappearance, and reap
+the helper on all paths. Run it outside the camera worker and store lock. A new
+internal proof is bound to the exact requesting connection, live process,
+account, operation and generation; consume it once with the existing short
+freshness discipline. Neither a client assertion, a generic polkit grant, nor a
+successful unrelated recovery/keyring operation substitutes for this proof.
+
+The password-verification endpoint also needs persistent guessing protection:
+five failed checks, then a 30-second delay before each further check, and at 50
+failed checks disable self-service retry reset until explicit administrator
+repair. Successful verified recovery clears that dedicated counter. Reserve
+before invoking the verifier so repeated crashes cannot bypass it. Do not reuse
+or modify the system-wide PAM password-failure tally. Reaching this separate
+limit still leaves ordinary password login available.
+
+Before enabling the overall face ceiling on an installed host, qualify the
+recovery helper, package service and confinement rules. Missing/broken recovery
+must be visible in status and installation checks. Never silently relax a face
+limit because the helper becomes unavailable.
+
+## Migration, compatibility and limits
+
+Version-1 records cannot reconstruct failures erased by earlier cooldowns.
+Treat upgrade as the beginning of the cumulative-policy epoch, retain known
+strikes, and preserve any active cooldown. For an active legacy cooldown whose
+strikes were reset to zero, begin the new count at the configured initial
+allowance (at least one); label this a migration seed, not reconstructed history.
+Do not claim the new ceiling retrospectively covers pre-upgrade attempts.
+
+Convert under the store lock with durable publication before new admission.
+Malformed records and UID/name mismatches continue refusing face and require
+administrator repair; the ordinary reset path does not reinterpret corrupt state
+as zero. Missing records follow the existing adoption semantics. Root deletion,
+disk rollback and account-identity reconciliation remain administrative trust
+boundaries, not tamper-proof counter guarantees.
+
+The old binary rejects version 2 because its reader requires version 1. A rollback
+must therefore be coordinated and preserve an explicit password-only fallback;
+do not translate version 2 to version 1 and silently discard cumulative history.
+Test downgrade behavior before deployment. Keep the earlier installed rollback
+separate from any future retry-state migration rollback.
+
+No display-manager hooks, automatic stock-desktop face integration, matcher/PAD
+threshold changes, biometric measurements or dim-light tests belong to this work.
+The optional privileged consent waiver cannot waive retry limits or recovery proof.
+
+## Implementation slices and acceptance evidence
+
+1. Implement and qualify the independently verified recovery boundary, its
+   dedicated guessing protection, protocol/CLI and package/confinement integration.
+   Keep the new overall face ceiling inactive until this route is qualified.
+2. Add version-2 reservations, settlement and migration. Exercise the state machine
+   with injected clocks/writers and real private files/processes.
+3. Connect both verify and credential-release paths, explicit accounting phases,
+   status/fallback wording and configuration migration guidance. Activate the
+   policy only after the combined acceptance tests pass.
+
+Required new checks: failures 4/5/6/49/50; no fresh burst after cooldown; successful
+50th attempt; clean exemptions versus unknown cancellation; one decisive attempt
+per reservation; no cross-account/profile/service bypass; concurrent admission;
+kill/restart/reboot and stale settlement; failed writes before/after rename and
+directory sync; full counter overflow/schema/ownership validation; v1 migration
+and old-binary refusal; expiry during settlement and credential preparation;
+reset proof replay/wrong account/expired peer; missing, compromised or failed
+helper; wrong/locked/expired password; prohibited biometric verifier path;
+independent recovery guessing limits; legacy PAM fallback for both verification
+and unseal; unsupported-account guidance without resetting anything.
+
+Use real PAM wrapper integration for helper contracts, plus package-specific
+password-backend qualification. Do not authenticate the user's real account,
+alter their PAM files or run cameras during unit tests. Hardware installation
+qualification remains a later attended step.
+
+This design was reviewed against current source and the installed Linux-PAM
+1.7.2 headers/man pages. Existing retry and authorization tests provide baseline
+evidence only; they do not validate this unimplemented proposal.

--- a/docs/superpowers/specs/2026-09-08-ir-identity-arm-evidence-design.md
+++ b/docs/superpowers/specs/2026-09-08-ir-identity-arm-evidence-design.md
@@ -1,0 +1,23 @@
+# IR identity acceptance evidence
+
+The optional IR-only login workflow needs empirical coverage of both existing
+identity acceptance rules. The diagnostic currently collapses these into one
+candidate category, so a live campaign cannot establish that coverage.
+
+Add one bounded `identity_acceptance` field to diagnostic schema 4: `best_template`,
+`centroid`, or `both` only when the final category is `candidate_match`; otherwise
+null. Report which predicates actually passed, not which branch happened to run
+first. Preserve the current finite-score checks, thresholds, profile/template
+scaling, enrollment compatibility, capture path and PAD policy. A cancelled or
+expired attempt must clear acceptance evidence even if identity finished.
+
+The wrapper accepts exact schemas 1, 2, 3 and 4. Historical reports remain
+immutable. Schema 4 retains all fifteen capture timing fields and enforces the
+category/acceptance relationship. No score, name, embedding, image, free-form
+error, additional model or dependency is introduced. Diagnostic results never
+authorize authentication or credential release.
+
+This is a prerequisite deliverable, not the IR-only granting integration. The
+broader workflow tracks qualification, opt-in policy integration, Windows Hello
+lessons and unresolved audit findings separately. Dual-camera authentication
+remains the default; stock-desktop experimental hands-free remains retired.

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -211,6 +211,9 @@ in
     # the package is documentation here; THIS line is the operative one on
     # NixOS (nothing scans $out/lib/tmpfiles.d).
     systemd.tmpfiles.rules = [
+      # Private persistent machine state. The mode mask tightens a loose
+      # existing directory without widening one whose owner bits are stricter.
+      "d /var/lib/irlume ~0700 root root -"
       "d /run/lock/irlume 2751 root video -"
     ];
 
@@ -318,6 +321,10 @@ in
 
     # Splice pam_irlume into each opted-in service with its resolved control.
     security.pam.services = lib.mkMerge [
+      # A dedicated fixed local-password stack; defaults must not add biometrics.
+      {
+        irlume-retry-reset.text = lib.mkForce (builtins.readFile ../packaging/pam/irlume-retry-reset);
+      }
       (lib.mapAttrs (_: svc: { rules.auth.irlume = mkAuthRule svc; }) cfg.pam.services)
       # Text-mode greeters are not a graphical session, so pam_kwallet skips
       # itself unless forced. Only meaningful when the service actually enables

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -120,6 +120,10 @@ rustPlatform.buildRustPackage {
   preBuild = ''
     export BINDGEN_EXTRA_CLANG_ARGS="$BINDGEN_EXTRA_CLANG_ARGS -isystem ${linuxHeaders}/include"
 
+    substituteInPlace crates/irlume-daemon/src/retry_recovery.rs \
+      --replace-fail '"/usr/libexec/irlume-password-verify"' \
+        "\"$out/libexec/irlume-password-verify\""
+
     # The compiled-in helper path is an FHS path that does not exist on NixOS,
     # so the PAM module would look for it, not find it, and decline. Nothing
     # sets IRLUME_KWALLET_INIT either, so a KDE-only NixOS user with a wallet-key
@@ -161,6 +165,11 @@ rustPlatform.buildRustPackage {
     install -Dm0755 "$out/bin/irlume-gkr-unlock" \
       "$out/libexec/irlume/irlume-gkr-unlock"
     rm "$out/bin/irlume-gkr-unlock"
+
+    test -x "$out/bin/irlume-password-verify"
+    install -Dm0755 "$out/bin/irlume-password-verify" "$out/libexec/irlume-password-verify"
+    rm "$out/bin/irlume-password-verify"
+    install -Dm0644 packaging/pam/irlume-retry-reset "$out/share/irlume/pam/irlume-retry-reset"
 
     install -d "$out/share/irlume/models"
     install -m0644 ${models}/*.onnx "$out/share/irlume/models/"

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -20,6 +20,14 @@ lane fetches and sha256-verifies them at build time (`scripts/fetch-models.sh`,
 or the Source URLs in the spec / PKGBUILD / flake). An installed package bundles
 the weights, so a running system needs no download.
 
+Wallet-salt routing is one package-level compatibility unit: upgrade the daemon,
+CLI, PAM module, and `irlume-kwallet-init` helper together, then restart the
+running daemon. A new daemon clearly refuses an older client that did not perform
+the account-scoped lookup. A new client talking to an old daemon is not protected
+by the client change alone because the old daemon ignores the additive request
+fields and retains its former path read. Existing sealed envelopes and wallet
+files need no migration.
+
 ## Per-family
 
 - **Fedora** (`fedora/irlume.spec` + `../.packit.yaml`): Packit builds in Copr

--- a/packaging/apparmor/usr.bin.irlumed
+++ b/packaging/apparmor/usr.bin.irlumed
@@ -217,4 +217,18 @@ profile irlumed /usr/bin/irlumed flags=(attach_disconnected) {
   # and proceeds. An explicit deny also stops AppArmor auditing the refusal,
   # which was filling the audit log with about 30 entries per boot.
   deny capability sys_ptrace,
+  # Fixed recovery helper. Shadow access belongs only to this child profile.
+  # With NoNewPrivileges, AppArmor may prevent this privilege transition;
+  # recovery availability therefore refuses enforcing AppArmor pending runtime
+  # qualification. Never grant shadow to the daemon to bypass that refusal.
+  /etc/pam.d/irlume-retry-reset r,
+  /usr/libexec/irlume-password-verify rCx -> password-verify,
+  profile password-verify {
+    include <abstractions/base>
+    /usr/libexec/irlume-password-verify mr,
+    /etc/pam.d/irlume-retry-reset r,
+    /etc/{passwd,group,shadow,nsswitch.conf,login.defs} r,
+    /usr/lib{,64,/*}/security/pam_unix.so mr,
+    capability dac_override,
+  }
 }

--- a/packaging/apparmor/usr.local.bin.irlumed
+++ b/packaging/apparmor/usr.local.bin.irlumed
@@ -176,4 +176,18 @@ profile irlumed /usr/local/bin/irlumed {
   # and proceeds. An explicit deny also stops AppArmor auditing the refusal,
   # which was filling the audit log with about 30 entries per boot.
   deny capability sys_ptrace,
+  # Fixed recovery helper. Shadow access belongs only to this child profile.
+  # With NoNewPrivileges, AppArmor may prevent this privilege transition;
+  # recovery availability therefore refuses enforcing AppArmor pending runtime
+  # qualification. Never grant shadow to the daemon to bypass that refusal.
+  /etc/pam.d/irlume-retry-reset r,
+  /usr/libexec/irlume-password-verify rCx -> password-verify,
+  profile password-verify {
+    include <abstractions/base>
+    /usr/libexec/irlume-password-verify mr,
+    /etc/pam.d/irlume-retry-reset r,
+    /etc/{passwd,group,shadow,nsswitch.conf,login.defs} r,
+    /usr/lib{,64,/*}/security/pam_unix.so mr,
+    capability dac_override,
+  }
 }

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -12,6 +12,7 @@ license=('GPL-3.0-or-later')
 # choose onnxruntime-cpu unless you want GPU execution providers.
 depends=('onnxruntime' 'tpm2-tss' 'pam' 'polkit' 'dbus')
 optdepends=('fprintd: fingerprint companion factor')
+backup=('etc/pam.d/irlume-retry-reset')
 # clang: v4l2-sys-mit generates its V4L2 bindings with bindgen, which needs
 # libclang at build time; without it makepkg fails on a clean system.
 makedepends=('rust' 'cargo' 'gcc' 'clang')
@@ -69,6 +70,8 @@ package() {
     # transaction.
     install -Dm0755 target/release/irlume-kwallet-init "$pkgdir/usr/libexec/irlume/irlume-kwallet-init"
     install -Dm0755 target/release/irlume-gkr-unlock "$pkgdir/usr/libexec/irlume/irlume-gkr-unlock"
+    install -Dm0755 target/release/irlume-password-verify "$pkgdir/usr/libexec/irlume-password-verify"
+    install -Dm0644 packaging/pam/irlume-retry-reset "$pkgdir/etc/pam.d/irlume-retry-reset"
     # One line per model, deliberately not a loop over basenames. The loop that
     # used to be here was keyed on ".onnx", so the mesh model could not join it
     # and was simply forgotten: the unit pointed IRLUME_MESH_MODEL at a file

--- a/packaging/arch/irlume.install
+++ b/packaging/arch/irlume.install
@@ -55,7 +55,9 @@ post_upgrade() {
     # The timer is NEW in 0.7.0; arm it once for upgraders too, recorded by a
     # marker so a later deliberate disable is respected.
     if [ ! -e /var/lib/irlume/.reconcile-timer-armed ]; then
-        mkdir -p /var/lib/irlume
+        # /var/lib is system-owned and already exists; only the leaf is ours.
+        # shellcheck disable=SC2174
+        mkdir -p -m 0700 /var/lib/irlume
         systemctl enable --now irlume-reconcile.timer 2>/dev/null || true
         : > /var/lib/irlume/.reconcile-timer-armed
     fi

--- a/packaging/debian/build-deb.sh
+++ b/packaging/debian/build-deb.sh
@@ -26,7 +26,7 @@ cargo build --release --locked
 # fail the build instead of shipping that.
 declared="$(sed -n 's/^  - libc6 (>= \(.*\))$/\1/p' "$REPO/packaging/debian/nfpm.yaml")"
 [ -n "$declared" ] || { echo "nfpm.yaml no longer declares a libc6 floor"; exit 1; }
-actual="$(objdump -T target/release/irlume target/release/irlumed target/release/libpam_irlume.so \
+actual="$(objdump -T target/release/irlume target/release/irlumed target/release/libpam_irlume.so target/release/irlume-password-verify \
   | grep -o 'GLIBC_[0-9.]*' | sed 's/GLIBC_//' | sort -V | tail -n1)"
 if [ "$(printf '%s\n%s\n' "$actual" "$declared" | sort -V | tail -n1)" != "$declared" ]; then
   echo "binaries need glibc $actual but nfpm.yaml declares libc6 (>= $declared);"

--- a/packaging/debian/nfpm.yaml
+++ b/packaging/debian/nfpm.yaml
@@ -32,6 +32,7 @@ depends:
   - polkitd | policykit-1
   - libdbus-1-3
   - libpam0g
+  - libpam-modules
   - libtss2-esys-3.0.2-0 | libtss2-esys-3.0.2-0t64
   # tctildr is the TCTI loader the binary links directly; it is NOT pulled in
   # by libtss2-esys (esys drags in mu/sys/tcti-device, but not tctildr), so a
@@ -59,6 +60,19 @@ contents:
     dst: /usr/libexec/irlume/irlume-kwallet-init
   - src: ../../target/release/irlume-gkr-unlock
     dst: /usr/libexec/irlume/irlume-gkr-unlock
+  - src: ../../target/release/irlume-password-verify
+    dst: /usr/libexec/irlume-password-verify
+    file_info:
+      mode: 0755
+      owner: root
+      group: root
+  - src: ../pam/irlume-retry-reset
+    dst: /etc/pam.d/irlume-retry-reset
+    type: config|noreplace
+    file_info:
+      mode: 0644
+      owner: root
+      group: root
   # Bundled models (fetched from the models-v1 release by build-deb.sh)
   - src: ../../models/glintr100.onnx
     dst: /usr/share/irlume/models/glintr100.onnx

--- a/packaging/debian/postinstall.sh
+++ b/packaging/debian/postinstall.sh
@@ -44,7 +44,9 @@ fi
 # population the self-heal exists for (issue #93). Arm it ONCE, recorded by a
 # marker, so a later deliberate `systemctl disable` is still respected.
 if [ ! -e /var/lib/irlume/.reconcile-timer-armed ]; then
-    mkdir -p /var/lib/irlume
+    # /var/lib is system-owned and already exists; only the leaf is ours.
+    # shellcheck disable=SC2174
+    mkdir -p -m 0700 /var/lib/irlume
     systemctl enable --now irlume-reconcile.timer 2>/dev/null || true
     : > /var/lib/irlume/.reconcile-timer-armed
 fi

--- a/packaging/fedora/irlume.spec
+++ b/packaging/fedora/irlume.spec
@@ -123,6 +123,8 @@ install -Dm0644 target/release/libpam_irlume.so %{buildroot}%{_libdir}/security/
 # PAM transaction.
 install -Dm0755 target/release/irlume-kwallet-init %{buildroot}%{_libexecdir}/%{name}/irlume-kwallet-init
 install -Dm0755 target/release/irlume-gkr-unlock %{buildroot}%{_libexecdir}/%{name}/irlume-gkr-unlock
+install -Dm0755 target/release/irlume-password-verify %{buildroot}%{_libexecdir}/irlume-password-verify
+install -Dm0644 packaging/pam/irlume-retry-reset %{buildroot}%{_sysconfdir}/pam.d/irlume-retry-reset
 # Bundled models (release assets, verified in %prep) → /usr/share/irlume/models
 install -Dm0644 %{SOURCE2} %{buildroot}%{_datadir}/%{name}/models/glintr100.onnx
 install -Dm0644 %{SOURCE3} %{buildroot}%{_datadir}/%{name}/models/face_detection_yunet_2023mar.onnx
@@ -196,11 +198,13 @@ systemctl start irlume-reconcile.timer &>/dev/null || :
 # the entire /bin/sh scriptlet, which `|| :` cannot catch.
 # The marker simply stays unwritten on ostree, so this block re-runs on
 # every upgrade (the sandboxed `systemctl enable` is inert there);
-# /var/lib/irlume itself is created on demand by the daemon and the
-# reconcile service, so nothing needs it from this scriptlet.
+# The shared tmpfiles rule creates /var/lib/irlume privately on ordinary
+# installs; the mkdir below is the same-mode fallback and stays inert on
+# rpm-ostree's read-only /var.
 if [ ! -e /var/lib/irlume/.reconcile-timer-armed ]; then
     systemctl enable --now irlume-reconcile.timer &>/dev/null || :
-    mkdir -p /var/lib/irlume 2>/dev/null || :
+    # /var/lib is system-owned and already exists; only the leaf is ours.
+    mkdir -p -m 0700 /var/lib/irlume 2>/dev/null || :
     touch /var/lib/irlume/.reconcile-timer-armed 2>/dev/null || :
 fi
 systemctl start irlume-reconcile.service &>/dev/null || :
@@ -254,6 +258,8 @@ restorecon /run/irlume.sock 2>/dev/null || :
 %dir %{_libexecdir}/%{name}
 %{_libexecdir}/%{name}/irlume-kwallet-init
 %{_libexecdir}/%{name}/irlume-gkr-unlock
+%{_libexecdir}/irlume-password-verify
+%config(noreplace) %{_sysconfdir}/pam.d/irlume-retry-reset
 # Own the directories the globs populate (rpmlint: "directory not owned by a
 # package"; also leaves them behind on erase otherwise).
 %dir %{_datadir}/%{name}

--- a/packaging/pam/irlume-retry-reset
+++ b/packaging/pam/irlume-retry-reset
@@ -1,0 +1,4 @@
+# Local passwords only. Never include the ordinary biometric/login stack.
+# No password changes or sessions; password login remains independent.
+auth required pam_unix.so nodelay
+account required pam_unix.so

--- a/packaging/ppa/debian/control
+++ b/packaging/ppa/debian/control
@@ -21,7 +21,7 @@ Rules-Requires-Root: no
 
 Package: irlume
 Architecture: amd64
-Depends: ${shlibs:Depends}, ${misc:Depends}, libpam0g, polkitd | policykit-1
+Depends: ${shlibs:Depends}, ${misc:Depends}, libpam0g, libpam-modules, polkitd | policykit-1
 Recommends: fprintd
 Description: Windows Hello-style face login for Linux
  IR (Windows Hello) cameras get the secure tier: login, sudo, and TPM-sealed

--- a/packaging/ppa/debian/rules
+++ b/packaging/ppa/debian/rules
@@ -45,6 +45,10 @@ override_dh_auto_install:
 		debian/irlume/usr/libexec/irlume/irlume-kwallet-init
 	install -D -m0755 target/release/irlume-gkr-unlock \
 		debian/irlume/usr/libexec/irlume/irlume-gkr-unlock
+	install -D -m0755 target/release/irlume-password-verify \
+		debian/irlume/usr/libexec/irlume-password-verify
+	install -D -m0644 packaging/pam/irlume-retry-reset \
+		debian/irlume/etc/pam.d/irlume-retry-reset
 	install -D -m0644 models/glintr100.onnx \
 		debian/irlume/usr/share/irlume/models/glintr100.onnx
 	install -D -m0644 models/face_detection_yunet_2023mar.onnx \

--- a/packaging/systemd/irlumed.service
+++ b/packaging/systemd/irlumed.service
@@ -23,8 +23,8 @@ Environment="IRLUME_BLAZE_MODEL=/usr/share/irlume/models/blaze_face_short_range.
 Environment="IRLUME_VIT_PAD_MODEL=/usr/share/irlume/models/liveness_vit.onnx"
 Environment="IRLUME_PAD_IR_MODEL=/usr/share/irlume/models/flir.onnx"
 Environment="IRLUME_SOCKET=/run/irlume.sock"
-# State dir is per-user under $HOME/.local/share/irlume; the daemon resolves
-# the target user per request, so no global STATE_DIR is set here.
+# Account state is stored under /var/lib/irlume (irlume_common::STATE_DIR).
+# Each request selects its account within that root; no HOME-derived state path.
 Restart=on-failure
 RestartSec=2
 # Wedged-capture watchdog (issue #141). Cooperative cancellation covers every

--- a/packaging/tmpfiles.d/irlume.conf
+++ b/packaging/tmpfiles.d/irlume.conf
@@ -1,6 +1,12 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright the irlume contributors.
 
+# Private machine state: create at 0700, remove any group/other access from an
+# existing loose directory, and preserve a mode that is already tighter. The
+# non-recursive `d` rule deliberately leaves descendant ownership and modes as
+# their individual writers established them.
+d /var/lib/irlume ~0700 root root -
+
 # Dedicated setgid directory for irlume's IR-emitter exclusion locks (#542).
 #
 # The daemon's systemd unit deliberately excludes CAP_CHOWN (see the

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -74,3 +74,11 @@ document in `docs/pad-results/` or `docs/recognition-results/`, not from here.
 | `compare-blaze-parity.py` | The fail-closed parity gate for the full-range BlazeFace decoder against Google's own runtime. |
 | `mp-face-detector-bench.py` | Runs Google's MediaPipe FaceDetector over the stage-3 corpus, so no hand-rolled decode can flatter itself. |
 | `capture-stage3-segment.sh` | Captures one stage-3 corpus segment: positioning lead-in, then paired RGB and IR frames. |
+
+## `ir-evaluation/`: attended, non-granting IR-only evaluation
+
+The [contributor harness](ir-evaluation/README.md) validates an explicit Linux host
+configuration, performs camera-free preflight and supervises one attended scan.
+It retains categorical outcomes, stage timings and descriptor-release evidence in
+a durable local ledger. It does not enable IR-only login or issue a qualification
+verdict. Its offline tests use synthetic records and harmless subprocesses.

--- a/scripts/check-packaging-parity.sh
+++ b/scripts/check-packaging-parity.sh
@@ -411,6 +411,33 @@ for marker in "${TMPFILES_APPLY_MARKERS[@]}"; do
   fi
 done
 
+echo
+echo "== private state root in every packaging lane =="
+STATE_TMPFILES_RULE="d /var/lib/irlume ~0700 root root -"
+for lane in packaging/tmpfiles.d/irlume.conf nix/module.nix; do
+  if uncommented "$lane" | grep -F -- "$STATE_TMPFILES_RULE" >/dev/null; then
+    printf '  ok    %-34s %s\n' "private state tmpfiles rule" "$lane"
+  else
+    printf '  MISS  %-34s %s\n' "private state tmpfiles rule" "$lane"
+    fail=1
+  fi
+done
+PRIVATE_STATE_MKDIR_MARKERS=(
+  "packaging/arch/irlume.install|mkdir -p -m 0700 /var/lib/irlume"
+  "packaging/debian/postinstall.sh|mkdir -p -m 0700 /var/lib/irlume"
+  "packaging/fedora/irlume.spec|mkdir -p -m 0700 /var/lib/irlume"
+)
+for marker in "${PRIVATE_STATE_MKDIR_MARKERS[@]}"; do
+  lane="${marker%%|*}"
+  needle="${marker#*|}"
+  if uncommented "$lane" | grep -F -- "$needle" >/dev/null; then
+    printf '  ok    %-34s %s\n' "private marker mkdir" "$lane"
+  else
+    printf '  MISS  %-34s %s\n' "private marker mkdir" "$lane"
+    fail=1
+  fi
+done
+
 if [ "$fail" -ne 0 ]; then
   echo "packaging parity: FAILED"
   exit 1

--- a/scripts/ci-bubblewrap.sh
+++ b/scripts/ci-bubblewrap.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright the irlume contributors.
+# Ubuntu 24.04 permits userns creation but denies subsequent namespace
+# capabilities without an application profile. Bubblewrap's loopback setup
+# then fails with RTM_NEWADDR EPERM, before the isolated CLI tests can execute.
+# https://documentation.ubuntu.com/release-notes/24.04/#unprivileged-user-namespace-restrictions
+set -euo pipefail
+
+probe() {
+  # Match the test helper's namespace setup, including namespace-root and an
+  # isolated network. Success must mean a different user and network namespace.
+  local userns netns
+  userns=$(readlink /proc/self/ns/user)
+  netns=$(readlink /proc/self/ns/net)
+  # The expressions in the script are expanded by the isolated child shell.
+  # shellcheck disable=SC2016
+  /usr/bin/bwrap --die-with-parent --unshare-user --uid 0 --gid 0 \
+    --unshare-pid --unshare-net --unshare-ipc --unshare-uts \
+    --unshare-cgroup-try --ro-bind / / --tmpfs /run --dev /dev --proc /proc \
+    -- /bin/sh -eu -c '
+      test "$(id -u)" = 0
+      test "$(readlink /proc/self/ns/user)" != "$1"
+      test "$(readlink /proc/self/ns/net)" != "$2"
+    ' sh "$userns" "$netns"
+}
+
+# Read-only verification is also useful on developer hosts. Profile loading is
+# restricted to disposable GitHub-hosted runners; never change a local host.
+if [[ $# == 1 && $1 == --check ]]; then
+  probe
+  exit 0
+fi
+if [[ $# != 0 || ${GITHUB_ACTIONS:-} != true || ${RUNNER_ENVIRONMENT:-} != github-hosted ]]; then
+  echo 'Usage: ci-bubblewrap.sh [--check]; setup requires a GitHub-hosted runner' >&2
+  exit 2
+fi
+if probe; then
+  exit 0
+fi
+
+restriction=/proc/sys/kernel/apparmor_restrict_unprivileged_userns
+if [[ ! -r $restriction || $(cat "$restriction") != 1 ]]; then
+  echo 'Bubblewrap probe failed without the Ubuntu AppArmor userns restriction' >&2
+  exit 1
+fi
+# Grant userns setup only to the installed sandbox utility. Do not disable
+# AppArmor or its system-wide userns restriction, or remove --unshare-net.
+sudo apparmor_parser -r <<'PROFILE'
+abi <abi/4.0>,
+include <tunables/global>
+profile irlume-ci-bwrap /usr/bin/bwrap flags=(unconfined) {
+  userns,
+}
+PROFILE
+probe

--- a/scripts/install-host.sh
+++ b/scripts/install-host.sh
@@ -15,7 +15,7 @@ done
 [[ -n "$ORT" && -f "$ORT" ]] || { echo "need --ort <libonnxruntime.so> (found: '$ORT')" >&2; exit 2; }
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
-for b in irlumed irlume; do
+for b in irlumed irlume irlume-password-verify; do
     [[ -f "$REPO/target/release/$b" ]] || { echo "missing $REPO/target/release/$b; build first" >&2; exit 1; }
 done
 for m in face_detection_yunet_2023mar.onnx glintr100.onnx face_landmark.onnx blaze_face_short_range.onnx; do
@@ -59,6 +59,12 @@ install -Dm0644 "$REPO/packaging/polkit/org.irlume.recovery-manage.policy" \
   /usr/share/polkit-1/actions/org.irlume.recovery-manage.policy
 printf "%s\n" "Enrollment and recovery management require polkit and a desktop or registered terminal authentication agent."
 install -m 0755 "$REPO/target/release/irlumed" "$REPO/target/release/irlume" /usr/local/bin/
+
+install -Dm0755 "$REPO/target/release/irlume-password-verify" /usr/libexec/irlume-password-verify
+# Preserve administrator-owned recovery policy on subsequent development installs.
+if [[ ! -e /etc/pam.d/irlume-retry-reset ]]; then
+    install -Dm0644 "$REPO/packaging/pam/irlume-retry-reset" /etc/pam.d/irlume-retry-reset
+fi
 
 cat > /etc/systemd/system/irlumed.service <<EOF
 [Unit]

--- a/scripts/ir-evaluation/README.md
+++ b/scripts/ir-evaluation/README.md
@@ -1,0 +1,261 @@
+# Attended IR-only evaluation harness
+
+Developer tooling for the [qualification protocol](../../docs/IR_ONLY_QUALIFICATION.md).
+It runs the existing **non-granting diagnostic**, never PAM or a login command.
+Dual-camera authentication remains the default; optional IR-only login is not
+implemented by this tool. A successful harness result means the recorded attempt
+passed instrumentation and preservation checks, not that a sensor or policy is
+qualified.
+
+## Diagnostic report records
+
+New diagnostic builds emit report schema 4. `identity_acceptance` is
+`best_template`, `centroid`, or `both` when the final category is
+`candidate_match`; every other category requires null. The label records which
+existing finite-score identity predicates passed without exposing a score,
+template, or identity. A final cancellation or expiry clears the label.
+Instrumenting this decision makes empirical acceptance-arm coverage measurable;
+it does not supply that coverage or qualify a device or policy.
+
+`capture_stages_ms` contains the nine
+schema-2 nullable millisecond fields (`open`, `session_setup`, `buffers`, `metadata`,
+`emitter`, `warmup`, `rate_fill`, `frames`, `session_release`) plus six teardown
+fields described below. The wrapper also accepts exact older schemas 1, 2 and 3;
+unknown fields, labels and versions are refused.
+The host configuration and wrapper ledger schemas remain 1.
+
+Timing storage is fixed-size, request-local and enabled by the nondefault
+`irlume-camera/capture-timing` feature, selected by `ir-only-evaluation`. Scope
+timers record on ordinary errors and cancellation as well as success. Null means
+the stage was not entered; zero can mean it completed within one millisecond.
+There are no images, names, error messages, scores or device paths in these fields.
+
+`session_setup` overlaps buffer allocation, metadata setup, emitter control,
+warm-up and rate fill, and includes resource cleanup if setup fails. Do not add
+overlapping times. `rate_fill` includes the subsequent metadata drain.
+`session_release` measures explicit session destruction after a session was
+successfully constructed, even if frame capture failed. On setup failure it
+stays null because cleanup belongs to `session_setup`; it is not evidence that
+cleanup was skipped. The outer `capture_ms` also includes the operation lease,
+camera destruction and other work outside these spans. No individual driver-call
+or optical emitter-off timing is claimed. A killed process may produce no report;
+the external watchdog and trace checks remain necessary.
+
+| Teardown field | Measured operation |
+|---|---|
+| `image_stop` | Release image buffers/stream, then stop the stream's lease state |
+| `metadata_streamoff` | Metadata STREAMOFF call, when streaming |
+| `metadata_buffers` | Unmap metadata buffers and request buffer release |
+| `metadata_format` | Restore metadata format, when a different format was displaced |
+| `metadata_close` | Close the metadata descriptor |
+| `emitter_restore` | Explicit or destructor-triggered emitter backend restore call |
+
+Timing handles attach to successfully constructed owners in the selected IR
+session setup as each becomes available, before frame warm-up. Failed construction
+cleanup before attachment remains inside the existing open/setup spans. Owner
+teardown spans can also occur during privacy refusal or recovery, so they are
+accumulated for the request and need not be contained solely in `session_release`.
+Replacement owners created by an explicit session recovery do not receive these
+handles; the one-shot IR evaluation does not invoke that recovery path.
+Null means no instrumented call was entered, not that a resource was left open.
+Timing a restore call does not establish that restoration succeeded. The emitter
+span excludes subsequent backend destruction, including any backend-specific
+fallback restore; unexplained session-release remainder needs investigation.
+
+The new spans observe existing cleanup in place: they neither reorder owners nor
+skip cleanup on cancellation, expiry or driver failure. They do not issue extra
+camera calls. A timing-only handle does not carry cancellation into teardown.
+
+Freeze the new executable and wrapper hashes in a separate plan and ledger before
+using these records. Keep earlier attempts and their original budget. Investigate
+an unexpected lifecycle category even when the wrapper reports `complete`.
+
+## Supported scope
+
+Linux with systemd, `/proc`, sysfs, Python 3.10+, `strace`, `fuser`, and a running
+`irlumed.service`. The explicit IR image node must have index 0 and exactly one
+index-1 metadata sibling on the same non-virtual interface; RGB must be a distinct
+index-0 interface. Device names must be literal `/dev/videoN` paths. These checks
+verify topology, not infrared spectral response or sensor authenticity: review
+camera models, drivers and the binding before use. Other layouts are refused.
+
+The reviewed diagnostic must use a single process with shared thread descriptor
+tables. Successful process forks, descriptor-table unsharing, bulk closes or
+video descriptor duplication invalidate the trace proof. This is deliberately
+conservative. Do not remove checks to make an unfamiliar host pass; investigate
+and review any extension. No Windows/ThinkPad, non-systemd or new sensor validation
+is implied by offline tests or by this laptop's camera-free preflight.
+
+## Prepare a private host configuration
+
+Follow the protocol to freeze source/patch identity, models, thresholds, sampling,
+normal-light schedule, strata and numerical acceptance targets **before** trials.
+No numerical release targets have been adopted by this harness. Schema 4 records
+which identity acceptance predicates passed for each admitted candidate, but the
+instrumentation does not compute certification or population confidence claims.
+Use a separate ledger per frozen host/configuration
+and stratum, with anonymous attempt IDs mapped to the predeclared schedule. A
+`qualification` label is descriptive and cannot turn pilot results into evidence.
+
+Build the reviewed diagnostic without changing default features:
+
+```sh
+cargo build --release --locked -p irlume-auth \
+  --features ir-only-evaluation --example ir_only_evaluation
+python3 -m unittest discover -s scripts/ir-evaluation -p 'test_*.py'
+```
+
+Review the three Python modules and exact executable/model/runtime hashes before
+root execution. This tool is **not a sandbox for an untrusted executable or model**.
+It pins the selected files; the OS, Python, tracer and transitive shared libraries
+remain trusted dependencies whose versions belong in the campaign record.
+
+Copy the three modules (`runner.py`, `host.py`, `harness.py`) and reviewed diagnostic
+to an administrator-owned directory such as `/opt/irlume-ir-evaluation`, using
+root ownership and modes 0644 for modules / 0500 for the executable. Every component
+and symlink hop in tool, asset, configuration and output paths must be root-owned
+and not group/world-writable. Do not execute a user-writable checkout as root.
+Create a **new** root-owned mode-0700 output directory for this campaign and a
+root-owned mode-0600 JSON configuration. Keep configuration out of shared reports.
+
+Example **shape only**; replace every placeholder and confirm the camera mapping.
+The tool rejects incomplete hashes. Paths and the subject UID are private inputs
+and are not copied into results.
+
+```json
+{
+  "schema": 1,
+  "subject_uid": 1000,
+  "budget_ms": 5000,
+  "watchdog_seconds": 15,
+  "assets": {
+    "binary": {"path": "/opt/irlume-ir-evaluation/diagnostic", "sha256": "REVIEWED_SHA256"},
+    "detector": {"path": "/usr/share/irlume/models/face_detection_yunet_2023mar.onnx", "sha256": "REVIEWED_SHA256"},
+    "recognizer": {"path": "/usr/share/irlume/models/glintr100.onnx", "sha256": "REVIEWED_SHA256"},
+    "flir": {"path": "/usr/share/irlume/models/flir.onnx", "sha256": "REVIEWED_SHA256"},
+    "ort": {"path": "/usr/share/irlume/onnxruntime/lib/libonnxruntime.so", "sha256": "REVIEWED_SHA256"}
+  },
+  "cameras": {"rgb": "/dev/video0", "ir": "/dev/video2", "metadata": "/dev/video3"},
+  "protected_files": ["/usr/bin/irlumed", "/usr/bin/irlume", "/etc/pam.d/irlume-retry-reset"],
+  "service": "irlumed.service"
+}
+```
+
+Add an `adapter` asset with `path` and `sha256` only when the reviewed enrollment
+requires it. Choose the local enrolled account's UID explicitly; 1000 is not a
+discovery rule. Choose the diagnostic budget (100–30000 ms) and a longer startup
+watchdog (at most 120 seconds) during campaign planning, not after a result.
+
+`protected_files` must be the reviewed set of **public installed binaries and
+configuration** whose preservation the campaign claims. The example is not a
+complete system manifest. Include the actual PAM module, service configuration,
+policy and camera configuration where applicable; only existing regular files
+or trusted links to them are supported. Never list enrollment/template stores,
+password files, credentials or recovery data. The tool hashes only this declared
+scope and public assets. Read-only enrollment behavior is a separate audited
+contract of the diagnostic. Service PID/state/restart count, process credentials,
+capabilities, NoNewPrivs, seccomp, LSM context, SELinux enforcement state where
+available, and camera topology are compared in memory before/after. Preservation
+does not prove the initial security configuration is appropriate; review it first.
+
+The host snapshot also compares the active LSM list. A kernel with only
+`capability`, `landlock`, `lockdown`, `yama` and/or `bpf` may report `EINVAL`
+for the process-context read without supplying a process label, as observed on
+the reviewed Minihost configuration. The wrapper records a distinct absent-context
+state in memory only for that restricted module set and exact error. Unknown modules, label providers such as SELinux or
+AppArmor, other read errors, and changes to the list/context still fail the
+preservation check. This is not a claim of SELinux/AppArmor enforcement on a host
+where they are inactive. See the [Linux LSM hook defaults](https://github.com/torvalds/linux/blob/master/include/linux/lsm_hook_defs.h)
+and [LSM framework](https://github.com/torvalds/linux/blob/master/security/security.c).
+
+## Run one scheduled attempt
+
+From a local terminal, using the reviewed root-owned files:
+
+```sh
+sudo /usr/bin/python3 -E -s /opt/irlume-ir-evaluation/runner.py \
+  --config /opt/irlume-ir-evaluation/host.json \
+  --output /var/lib/irlume-ir-evaluation/pilot-01 \
+  --attempt control-01 --campaign pilot --mode preflight
+```
+
+Preflight loads models and reads enrollment but opens no camera. Every subsequent
+invocation also repeats this camera-free check and checks host preservation.
+For a scheduled live attempt, choose `genuine`, `impostor`, `attack`, `empty` or
+`cancel`, and a new anonymous attempt ID. `empty` and `cancel` are lifecycle controls.
+For example, the operator can replace the final line with:
+
+```sh
+  --attempt genuine-01 --campaign pilot --mode genuine
+```
+
+The participant must be ready **now**, other camera apps closed, and only the
+scheduled presentation in view. The tool requires an interactive terminal and
+an explicit `READY` response, then prints `START`. It runs one scan and prints
+`FINISHED`; positioning is no longer required. There is no unattended readiness
+flag and no automatic retry loop. `cancel` sends a cancellation byte after the
+first successful IR image open. Ctrl-C requests supervisor cleanup and records
+an interrupted attempt. No frames or scores are saved.
+
+Exit 0 means instrumentation/preservation completed; the category can still be a
+refusal or an infrastructure error. Exit 1 means stop and review the result.
+Exit 2 means setup or ledger could not complete; inspect for a started record
+before doing anything else. An attack, impostor or empty-view `candidate_match`,
+invalid/granting output, unexpected video access, missing close, watchdog cleanup,
+or changed/unverifiable protected state stops the campaign ledger. There is no
+force-continue option. Preserve the stopped ledger, investigate, and document
+review before starting a separate follow-up ledger. Never delete failed attempts
+to obtain a passing campaign.
+
+## Read the ledger correctly
+
+Each attempt directory is reserved exclusively, then `started.json` is flushed
+before the first diagnostic invocation. `final.json` is written exclusively and
+flushed after cleanup and preservation checks. Incomplete directories, malformed
+final records and stopped outcomes block subsequent invocations in that ledger.
+A host-wide `/run/irlume-ir-evaluation.lock` prevents simultaneous harness runs.
+Root-owned mode-0700 temporary executable stages under `/run` are removed on normal
+completion. The small lock file remains for reuse until reboot.
+
+The ledger retains only fixed categories/flags, public asset hashes, bounded
+stage timings and video open/close metadata. It never retains diagnostic stderr,
+non-video trace paths, account names or raw exceptions. `preflight` and `evaluation`
+are separate fields, **not two accuracy trials**. Count each started accuracy
+invocation once; a preflight error, declined readiness or missing final record
+still needs explicit accounting as a failed/incomplete attempt. Planned attempts
+never invoked are separately not started. A completed `no_face` is not a PAD
+refusal. Follow the protocol's all-started and assessment-only denominators;
+`evaluation: null` means no report was retained and does not prove that capture
+never started; preserve it as failed/unknown. Controls are separate. Stage timings exclude startup; wall time includes tracing
+and model loading but not all host verification/readiness time.
+
+Video opens are paired once with a successful close of the same descriptor and
+device, with no outstanding descriptors, then `fuser` must show all video nodes
+idle. Tracing failures and ambiguous process/descriptor behavior fail the proof.
+Trace timestamps describe syscall entries; descriptor closure is not a measurement
+of the physical emitter switching off. The watchdog performs process-group TERM
+then KILL cleanup. SIGKILL, power loss, an uninterruptible kernel operation or a
+process escaping its group cannot be turned into guaranteed cleanup by Python;
+a missing final record requires review and the idle check must independently pass.
+Only the reviewed diagnostic is supported, not arbitrary programs.
+
+Relevant primary references: [strace descriptor decoding](https://strace.io/),
+[Python subprocess lifecycle and timeout limits](https://docs.python.org/3/library/subprocess.html),
+and [Linux V4L2 device opening/closing](https://docs.kernel.org/userspace-api/media/v4l/open.html).
+
+### Optional syscall timing
+
+Add `--trace-ioctl` to a separately frozen diagnostic campaign to record numeric
+video ioctl request numbers, results, and microsecond durations. This uses
+`strace -T -e raw=ioctl`: argument structures are never decoded, and raw lines,
+pointers, errors, and non-video operations are discarded. Only descriptors
+observed opening a `/dev/videoN` node are associated with these records; closed
+descriptors are removed. Existing trace ambiguity and overflow gates still apply.
+The default trace remains unchanged. No authentication or capture behavior changes.
+
+Interpret request numbers against the measured host's ABI and headers. These
+wall-clock syscall durations include tracing and scheduling effects; they cannot
+prove physical emitter-off timing or distinguish kernel internals. An image-stop
+span also includes unmapping and local bookkeeping, which ioctl tracing does not
+measure. A successful instrumented run is evidence preservation, not an accuracy
+qualification or a guaranteed hard deadline.

--- a/scripts/ir-evaluation/harness.py
+++ b/scripts/ir-evaluation/harness.py
@@ -1,0 +1,512 @@
+"""Attended diagnostic runner; persist categories/timings and video-open metadata only."""
+
+import os
+import re
+import selectors
+import signal
+import subprocess
+import time
+
+from host import strict_json
+
+CATEGORIES = frozenset(
+    {
+        "ready",
+        "candidate_match",
+        "identity_mismatch",
+        "no_face",
+        "liveness_refused",
+        "pad_unavailable",
+        "pad_invalid",
+        "pad_refused",
+        "incompatible_enrollment",
+        "enrollment_unavailable",
+        "models_unavailable",
+        "camera_unavailable",
+        "invalid_frame",
+        "cancelled",
+        "deadline_expired",
+        "invalid_request",
+        "root_required",
+        "inference_failed",
+        "camera_busy",
+        "camera_rate_refused",
+        "camera_lease_timeout",
+        "camera_lease_refused",
+        "camera_io_failed",
+        "camera_hardware_failed",
+        "camera_rate_fill_io_permission_denied",
+        "camera_rate_fill_io_invalid_argument",
+        "camera_rate_fill_io_device",
+        "camera_rate_fill_io_no_space",
+        "camera_rate_fill_io_timeout",
+        "camera_rate_fill_io_other",
+        "camera_rate_fill_buffer_timestamp",
+        "camera_rate_fill_buffer_clock",
+        "camera_rate_fill_buffer_source",
+        "camera_rate_fill_buffer_layout",
+        "camera_rate_fill_timestamp_non_increasing",
+        "camera_rate_fill_timestamp_clock",
+        "camera_rate_fill_timestamp_source",
+        "camera_rate_fill_timestamp_epoch",
+        "camera_rate_fill_sequence",
+        "camera_rate_fill_rate_window",
+        "camera_rate_fill_privacy_boundary",
+        "camera_rate_fill_privacy_engaged",
+        "camera_rate_fill_privacy_read_permission_denied",
+        "camera_rate_fill_privacy_read_device",
+        "camera_rate_fill_privacy_read_timeout",
+        "camera_rate_fill_privacy_read_busy",
+        "camera_rate_fill_privacy_read_other",
+        "camera_rate_fill_lease_boundary",
+        "camera_rate_fill_stream_state",
+        "camera_rate_fill_continuity_alignment",
+        "camera_rate_fill_continuity_accounting",
+        "camera_rate_fill_incomplete_window",
+        "camera_rate_fill_missing_stream",
+        "camera_rate_fill_stopped_stream",
+        "camera_rate_fill_other",
+        "camera_authorization_refused",
+        "camera_policy_refused",
+        "camera_capture_failed",
+    }
+)
+TIMINGS = frozenset(
+    {"elapsed_ms", "capture_ms", "detection_ms", "pad_ms", "identity_ms"}
+)
+
+
+def video_event(line):
+    # Only trace open/close metadata. No other paths or syscall payload survive.
+    match = re.search(
+        r"(?:\b(openat2|openat|open|close)\(|<\.\.\. (openat2|openat|open|close) resumed>)",
+        line,
+    )
+    device = re.search(r'["<](/dev/video[0-9]+)["><]', line)
+    timestamp = re.search(r"(?:^|\s)([0-9]+\.[0-9]+)\s", line)
+    if not match or not device or not timestamp:
+        return None
+    result = re.search(r"\s=\s(-?[0-9]+)", line)
+    operation = match.group(1) or match.group(2)
+    return {
+        "timestamp": float(timestamp.group(1)),
+        "operation": "close" if operation == "close" else "open",
+        "device": device.group(1),
+        "fd": (
+            int(result.group(1))
+            if result and operation != "close"
+            else int(re.search(r"close\(([0-9]+)", line).group(1))
+            if re.search(r"close\(([0-9]+)", line)
+            else None
+        ),
+        "result": int(result.group(1)) if result else None,
+    }
+
+
+def ioctl_event(line, live):
+    """Decode raw ioctl syntax; retain only metadata for a known video fd."""
+    match = re.search(r"\bioctl\((0x[0-9a-f]+|0),", line)
+    if not match:
+        if "ioctl(" in line:
+            raise ValueError("unexpected ioctl syntax")
+        return None
+    fd = int(match.group(1), 16)
+    if fd not in live:
+        return None
+    fields = re.search(
+        r"ioctl\((0x[0-9a-f]+|0), (0x[0-9a-f]+|0), (?:0x[0-9a-f]+|0)\s*\)"
+        r"\s+=\s+(-1|0x[0-9a-f]+|0)(?: [^<>]*)? <([0-9]+)\.([0-9]{6})>$",
+        line.strip(),
+    )
+    timestamp = re.search(r"(?:^|\s)([0-9]+\.[0-9]+)\s", line)
+    if fields is None or timestamp is None:
+        raise ValueError("unexpected video ioctl syntax")
+    duration = int(fields.group(4)) * 1_000_000 + int(fields.group(5))
+    request = int(fields.group(2), 16)
+    if duration > 120_000_000 or request > 0xFFFFFFFF:
+        raise ValueError("invalid ioctl metadata")
+    return {
+        "timestamp": float(timestamp.group(1)),
+        "device": live[fd],
+        "fd": fd,
+        "request": request,
+        "result": int(fields.group(3), 16),
+        "duration_us": duration,
+    }
+
+
+def checked_report(record):
+    required = {
+        "schema",
+        "operation",
+        "authentication_granted",
+        "category",
+        "elapsed_ms",
+    }
+    if not isinstance(record, dict) or "schema" not in record:
+        raise ValueError("unexpected diagnostic output schema")
+    version = record.get("schema")
+    extra = set()
+    if type(version) is int and version in (2, 3, 4):
+        extra.add("capture_stages_ms")
+    if version == 4:
+        extra.add("identity_acceptance")
+    if record.keys() != required | TIMINGS | extra:
+        raise ValueError("unexpected diagnostic output schema")
+    if (
+        type(record["schema"]) is not int
+        or record["schema"] not in (1, 2, 3, 4)
+        or record["operation"] != "ir_only_evaluation"
+        or record["authentication_granted"] is not False
+    ):
+        raise ValueError("not a non-granting diagnostic result")
+    if not isinstance(record["category"], str) or record["category"] not in CATEGORIES:
+        raise ValueError("unknown result category")
+    if version == 4:
+        acceptance = record["identity_acceptance"]
+        if record["category"] == "candidate_match":
+            if type(acceptance) is not str or acceptance not in {
+                "best_template",
+                "centroid",
+                "both",
+            }:
+                raise ValueError("invalid identity acceptance evidence")
+        elif acceptance is not None:
+            raise ValueError("identity acceptance contradicts result category")
+    for key in TIMINGS & record.keys():
+        value = record[key]
+        if value is None and key != "elapsed_ms":
+            continue
+        if type(value) is not int or not 0 <= value <= 3_600_000:
+            raise ValueError("invalid stage timing")
+    if version in (2, 3, 4):
+        stages = record["capture_stages_ms"]
+        labels = {
+            "open",
+            "session_setup",
+            "buffers",
+            "metadata",
+            "emitter",
+            "warmup",
+            "rate_fill",
+            "frames",
+            "session_release",
+        }
+        if version in (3, 4):
+            labels |= {
+                "image_stop",
+                "metadata_streamoff",
+                "metadata_buffers",
+                "metadata_format",
+                "metadata_close",
+                "emitter_restore",
+            }
+        if not isinstance(stages, dict) or stages.keys() != labels:
+            raise ValueError("unexpected capture timing schema")
+        if any(
+            value is not None
+            and (type(value) is not int or not 0 <= value <= 3_600_000)
+            for value in stages.values()
+        ):
+            raise ValueError("invalid capture timing")
+    return record
+
+
+def run_traced(
+    command,
+    *,
+    env=None,
+    cancel_after_ms=None,
+    cancel_on_ir_open=None,
+    timeout=45,
+    tracer="/usr/bin/strace",
+    trace_ioctl=False,
+):
+    """One fixed diagnostic invocation; no raw stderr is retained.
+
+    A selector drains pipes without blocking reader threads. A dead tracer,
+    watchdog, or exception triggers process-group cleanup before returning.
+    `tracer` exists for harmless real-process failure tests; trials use strace.
+    """
+    if timeout <= 0 or timeout > 120:
+        raise ValueError("watchdog must be within (0,120] seconds")
+    events, output, trace_buffer = [], bytearray(), bytearray()
+    flags = {"trace_error": False, "output_overflow": False, "trace_overflow": False}
+    ioctl_events, live = [], {}
+    ir_open = False
+    started = time.monotonic()
+    proc = None
+    selector = None
+    cancelled, watchdog, early_exit = False, False, False
+    exited_at = None
+    stopping_at = None
+    killed = False
+
+    def signal_group(sig):
+        try:
+            if proc is not None:
+                os.killpg(proc.pid, sig)
+        except ProcessLookupError:
+            pass
+
+    pending = {}
+
+    def consume_trace(raw):
+        nonlocal ir_open
+        line = raw.decode("utf-8", errors="replace")
+        if line.startswith("strace:") and "Process " not in line:
+            flags["trace_error"] = True
+        prefix = re.match(r"^(?:\[pid\s+(\d+)\]\s+|(\d+)\s+)?\d+\.\d+\s+", line)
+        thread = (prefix.group(1) or prefix.group(2) or "main") if prefix else None
+        resumed = re.search(r"<\.\.\. (\w+) resumed>", line)
+        if "<unfinished ...>" in line:
+            if (
+                thread is None
+                or thread in pending
+                or len(pending) >= 1024
+                or len(line) > 4096
+            ):
+                flags["trace_error"] = True
+            else:
+                pending[thread] = line.split("<unfinished ...>", 1)[0]
+            return
+        if resumed:
+            original = pending.pop(thread, None)
+            if original is None or not re.search(
+                r"\b" + resumed.group(1) + r"\(", original
+            ):
+                flags["trace_error"] = True
+                return
+            line = original + line[resumed.end() :]
+        # Only a single process with shared thread descriptors is supported.
+        # A successful process fork, descriptor duplication, or bulk close
+        # makes per-fd release evidence ambiguous: fail conservatively.
+        successful = re.search(r"\s=\s([0-9]+)", line)
+        if successful:
+            if re.search(
+                r"\b(clone3?|fork|vfork)\(|<\.\.\. (clone3?|fork|vfork) resumed>", line
+            ) and not ("CLONE_THREAD" in line and "CLONE_FILES" in line):
+                flags["trace_error"] = True
+            if re.search(r"\b(close_range|unshare)\(", line):
+                flags["trace_error"] = True
+            if "/dev/video" in line and re.search(r"\b(dup[23]?|fcntl)\(", line):
+                flags["trace_error"] = True
+        if trace_ioctl:
+            try:
+                measured = ioctl_event(line, live)
+            except ValueError:
+                flags["trace_error"] = True
+            else:
+                if measured:
+                    if len(ioctl_events) < 10000:
+                        ioctl_events.append(measured)
+                    else:
+                        flags["trace_overflow"] = True
+        event = video_event(line)
+        if event:
+            if event["result"] is not None and event["result"] >= 0:
+                if trace_ioctl:
+                    for entry in pending.values():
+                        inflight = re.search(r"\bioctl\((0x[0-9a-f]+|0),", entry)
+                        if inflight and int(inflight.group(1), 16) == event["fd"]:
+                            flags["trace_error"] = True
+                if event["operation"] == "open":
+                    if event["fd"] in live:
+                        flags["trace_error"] = True
+                    live[event["fd"]] = event["device"]
+                elif event["result"] == 0:
+                    live.pop(event["fd"], None)
+            if len(events) < 10000:
+                events.append(event)
+            else:
+                flags["trace_overflow"] = True
+            if (
+                event["device"] == cancel_on_ir_open
+                and event["operation"] == "open"
+                and event["result"] is not None
+                and event["result"] >= 0
+            ):
+                ir_open = True
+
+    try:
+        proc = subprocess.Popen(
+            [
+                tracer,
+                "-q",
+                "-f",
+                "-ttt",
+                "-yy",
+                "-e",
+                "trace=open,openat,openat2,close,clone,clone3,fork,vfork,dup,dup2,dup3,fcntl,close_range,unshare"
+                + (",ioctl" if trace_ioctl else ""),
+                *(["-T", "-e", "raw=ioctl"] if trace_ioctl else []),
+                "--",
+                *command,
+            ],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+            start_new_session=True,
+        )
+        selector = selectors.DefaultSelector()
+        for pipe, name in [(proc.stdout, "output"), (proc.stderr, "trace")]:
+            os.set_blocking(pipe.fileno(), False)
+            selector.register(pipe, selectors.EVENT_READ, name)
+        while selector.get_map() or proc.poll() is None:
+            now = time.monotonic()
+            elapsed = now - started
+            if proc.poll() is not None and exited_at is None:
+                exited_at = now
+            if stopping_at is None:
+                due = (
+                    cancel_after_ms is not None and elapsed * 1000 >= cancel_after_ms
+                ) or ir_open
+                if due and not cancelled and proc.poll() is None:
+                    try:
+                        proc.stdin.write(b"x")
+                        proc.stdin.flush()
+                        cancelled = True
+                    except BrokenPipeError:
+                        pass
+                if elapsed >= timeout:
+                    watchdog = True
+                    stopping_at = now
+                elif (
+                    exited_at is not None
+                    and selector.get_map()
+                    and now - exited_at >= 0.2
+                ):
+                    early_exit = True
+                    stopping_at = now
+                if stopping_at is not None:
+                    signal_group(signal.SIGTERM)
+            if stopping_at is not None:
+                if not killed and now - stopping_at >= 0.2:
+                    signal_group(signal.SIGKILL)
+                    killed = True
+                if now - stopping_at >= 1:
+                    break
+            for key, _ in selector.select(0.01):
+                chunk = os.read(key.fd, 4096)
+                if not chunk:
+                    selector.unregister(key.fileobj)
+                    continue
+                if key.data == "output":
+                    if len(output) + len(chunk) <= 16384:
+                        output.extend(chunk)
+                    else:
+                        flags["output_overflow"] = True
+                else:
+                    trace_buffer.extend(chunk)
+                    while b"\n" in trace_buffer:
+                        raw, _, rest = trace_buffer.partition(b"\n")
+                        trace_buffer[:] = rest
+                        consume_trace(raw)
+                    if len(trace_buffer) > 65536:
+                        trace_buffer.clear()
+                        flags["trace_overflow"] = True
+        if trace_buffer:
+            consume_trace(trace_buffer)
+        if pending:
+            flags["trace_error"] = True
+        complete = not selector.get_map()
+    finally:
+        # Even a tracer that has already exited may have left children alive.
+        signal_group(signal.SIGKILL)
+        try:
+            if proc is not None:
+                proc.wait(timeout=3)
+        finally:
+            if selector is not None:
+                selector.close()
+            if proc is not None:
+                for pipe in (proc.stdin, proc.stdout, proc.stderr):
+                    pipe.close()
+    report = None
+    output_valid = False
+    if not flags["output_overflow"]:
+        try:
+            report = checked_report(strict_json(output))
+            output_valid = True
+        except (ValueError, TypeError):
+            pass
+    return {
+        "returncode": proc.returncode,
+        "report": report,
+        "output_valid": output_valid,
+        "video_events": events,
+        **({"video_ioctl_events": ioctl_events} if trace_ioctl else {}),
+        "cancellation_sent": cancelled,
+        "watchdog_fired": watchdog,
+        "early_tracer_exit": early_exit,
+        "wall_elapsed_ms": round((time.monotonic() - started) * 1000),
+        "readers_completed": complete,
+        **flags,
+    }
+
+
+def release_checks(events, ir_device, metadata_device, *, preflight=False):
+    """Pair each descriptor lifetime once; ambiguous/incomplete traces fail."""
+    live = {}
+    saw_image = False
+    for event in events:
+        if preflight:
+            return False
+        if event["device"] not in {ir_device, metadata_device}:
+            return False
+        fd, result = event.get("fd"), event["result"]
+        if result is None or fd is None:
+            return False
+        if event["operation"] == "open":
+            if result < 0:
+                continue
+            if fd in live:
+                return False
+            live[fd] = event
+            saw_image |= event["device"] == ir_device
+        else:
+            opened = live.pop(fd, None)
+            if (
+                result != 0
+                or opened is None
+                or opened["device"] != event["device"]
+                or event["timestamp"] < opened["timestamp"]
+            ):
+                return False
+    return not live and (preflight or saw_image)
+
+
+def trial_checks(result, mode, ir_device="/dev/video2", metadata_device="/dev/video3"):
+    if (
+        result["returncode"] != 0
+        or not result["output_valid"]
+        or not result["readers_completed"]
+        or not result["installed_unchanged"]
+    ):
+        return False
+    if any(
+        result[k]
+        for k in [
+            "watchdog_fired",
+            "early_tracer_exit",
+            "trace_error",
+            "trace_overflow",
+            "output_overflow",
+        ]
+    ):
+        return False
+    if not release_checks(
+        result["video_events"],
+        ir_device,
+        metadata_device,
+        preflight=mode == "preflight",
+    ):
+        return False
+    if mode == "preflight":
+        return result["report"]["category"] == "ready"
+    if mode == "cancel":
+        return (
+            result["cancellation_sent"] and result["report"]["category"] == "cancelled"
+        )
+    return result["report"]["category"] != "ready"

--- a/scripts/ir-evaluation/host.py
+++ b/scripts/ir-evaluation/host.py
@@ -1,0 +1,343 @@
+"""Linux host checks and an exclusive, durable attempt ledger.
+
+Private host paths and service state stay in memory, never in result records.
+The root operator owns the configuration and reviews its preservation scope.
+"""
+
+import errno
+import hashlib
+import json
+import os
+import re
+import stat
+import subprocess
+from pathlib import Path
+
+ENV = {"PATH": "/usr/sbin:/usr/bin:/sbin:/bin", "LANG": "C.UTF-8"}
+ASSETS = {"binary", "detector", "recognizer", "flir", "ort"}
+
+
+def strict_json(text):
+    def pairs(items):
+        data = {}
+        for key, value in items:
+            if key in data:
+                raise ValueError("duplicate_key")
+            data[key] = value
+        return data
+
+    return json.loads(text, object_pairs_hook=pairs)
+
+
+def validate_config(data):
+    if not isinstance(data, dict) or set(data) != {
+        "schema",
+        "subject_uid",
+        "budget_ms",
+        "watchdog_seconds",
+        "assets",
+        "cameras",
+        "protected_files",
+        "service",
+    }:
+        raise ValueError("invalid_config")
+    if type(data["schema"]) is not int or data["schema"] != 1:
+        raise ValueError("invalid_config")
+    for key, low, high in [
+        ("subject_uid", 1, 2**32 - 2),
+        ("budget_ms", 100, 30000),
+        ("watchdog_seconds", 1, 120),
+    ]:
+        if type(data[key]) is not int or not low <= data[key] <= high:
+            raise ValueError("invalid_config")
+    if data["watchdog_seconds"] * 1000 <= data["budget_ms"]:
+        raise ValueError("invalid_config")
+    assets = data["assets"]
+    if (
+        not isinstance(assets, dict)
+        or not ASSETS <= assets.keys()
+        or assets.keys() - ASSETS - {"adapter"}
+    ):
+        raise ValueError("invalid_config")
+    for asset in assets.values():
+        if (
+            not isinstance(asset, dict)
+            or set(asset) != {"path", "sha256"}
+            or not absolute_path(asset["path"])
+            or not isinstance(asset["sha256"], str)
+            or re.fullmatch("[a-f0-9]{64}", asset["sha256"]) is None
+        ):
+            raise ValueError("invalid_config")
+    cameras = data["cameras"]
+    if not isinstance(cameras, dict) or set(cameras) != {"rgb", "ir", "metadata"}:
+        raise ValueError("invalid_config")
+    if (
+        any(
+            not isinstance(node, str) or re.fullmatch("/dev/video[0-9]+", node) is None
+            for node in cameras.values()
+        )
+        or len(set(cameras.values())) != 3
+    ):
+        raise ValueError("invalid_config")
+    paths = data["protected_files"]
+    if (
+        not isinstance(paths, list)
+        or not 1 <= len(paths) <= 256
+        or not all(absolute_path(path) for path in paths)
+        or len(set(paths)) != len(paths)
+    ):
+        raise ValueError("invalid_config")
+    if data["service"] != "irlumed.service":
+        raise ValueError("invalid_config")
+    return data
+
+
+def absolute_path(value):
+    return (
+        isinstance(value, str)
+        and value.startswith("/")
+        and "\x00" not in value
+        and len(value) <= 4096
+        and ".." not in Path(value).parts
+    )
+
+
+def trusted_path(path):
+    """Validate every component and symlink hop before following it."""
+    path = Path(path)
+    if not path.is_absolute():
+        raise ValueError("untrusted_path")
+    pending = list(path.parts[1:])
+    current = Path("/")
+    hops = 0
+    while True:
+        info = current.lstat()
+        if info.st_uid != 0 or (
+            not stat.S_ISLNK(info.st_mode) and info.st_mode & 0o022
+        ):
+            raise ValueError("untrusted_path")
+        if stat.S_ISLNK(info.st_mode):
+            hops += 1
+            if hops > 40:
+                raise ValueError("symlink_loop")
+            target = Path(os.readlink(current))
+            current = Path("/") if target.is_absolute() else current.parent
+            pending = (
+                list(target.parts[1:] if target.is_absolute() else target.parts)
+                + pending
+            )
+            continue
+        if not pending:
+            return current
+        part = pending.pop(0)
+        current = current.parent if part == ".." else current / part
+
+
+def file_identity(path):
+    canonical = trusted_path(path)
+    info = canonical.stat()
+    if not stat.S_ISREG(info.st_mode):
+        raise ValueError("not_regular_file")
+    digest = hashlib.sha256()
+    with canonical.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+    return (
+        str(canonical),
+        info.st_uid,
+        info.st_gid,
+        stat.S_IMODE(info.st_mode),
+        digest.hexdigest(),
+    )
+
+
+def qualified_topology(nodes, cameras):
+    ir, meta, rgb = (nodes[key] for key in ["ir", "metadata", "rgb"])
+    siblings = {Path(cameras["ir"]).name, Path(cameras["metadata"]).name}
+    return (
+        ir["index"] == rgb["index"] == 0
+        and meta["index"] == 1
+        and ir["interface"] == meta["interface"] != rgb["interface"]
+        and ir["siblings"] == meta["siblings"] == siblings
+        and all("/virtual/" not in node["interface"] for node in nodes.values())
+    )
+
+
+def topology(cameras):
+    nodes = {}
+    for role, device in cameras.items():
+        info = Path(device).lstat()
+        if not stat.S_ISCHR(info.st_mode) or os.major(info.st_rdev) != 81:
+            raise ValueError("unsupported_topology")
+        node = Path("/sys/class/video4linux") / Path(device).name
+        if (
+            node.joinpath("dev").read_text().strip()
+            != f"{os.major(info.st_rdev)}:{os.minor(info.st_rdev)}"
+        ):
+            raise ValueError("unsupported_topology")
+        interface = node.joinpath("device").resolve(strict=True)
+        nodes[role] = {
+            "index": int((node / "index").read_text()),
+            "interface": str(interface),
+            "siblings": {p.name for p in (interface / "video4linux").iterdir()},
+        }
+    if not qualified_topology(nodes, cameras):
+        raise ValueError("unsupported_topology")
+    return nodes
+
+
+def command_output(command):
+    got = subprocess.run(
+        command,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        env=ENV,
+        timeout=5,
+        check=False,
+    )
+    if got.returncode != 0 or len(got.stdout) > 16384:
+        raise ValueError("host_check_failed")
+    return got.stdout.decode("ascii").strip()
+
+
+def idle():
+    devices = sorted(str(path) for path in Path("/dev").glob("video[0-9]*"))
+    if not devices:
+        raise ValueError("camera_idle_unverified")
+    # fuser's status alone also covers operational errors; require no stderr.
+    got = subprocess.run(
+        ["/usr/bin/fuser", *devices],
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        env=ENV,
+        timeout=5,
+        check=False,
+    )
+    if got.returncode != 1 or got.stdout.strip() or got.stderr.strip():
+        raise ValueError("camera_idle_unverified")
+
+
+def security_state(process, lsm_list=Path("/sys/kernel/security/lsm")):
+    """Preserve labels when supported, and distinguish verified absence from errors."""
+    modules = lsm_list.read_text().strip()
+    names = modules.split(",")
+    if not modules or any(re.fullmatch("[a-z0-9_]+", name) is None for name in names):
+        raise ValueError("invalid_lsm_list")
+    try:
+        context = (process / "attr/current").read_text().strip()
+    except OSError as error:
+        # The observed configuration returns getprocattr's EINVAL default
+        # without a process label. Restrict absence to this reviewed module set;
+        # do not generalize to unknown providers, missing files or access denial.
+        reviewed_modules = {"capability", "landlock", "lockdown", "yama", "bpf"}
+        if error.errno != errno.EINVAL or not set(names) <= reviewed_modules:
+            raise
+        context = None
+    return {"modules": modules, "context": context}
+
+
+def snapshot(config):
+    assets = {
+        key: file_identity(asset["path"]) for key, asset in config["assets"].items()
+    }
+    if any(
+        assets[key][-1] != value["sha256"] for key, value in config["assets"].items()
+    ):
+        raise ValueError("asset_hash_mismatch")
+    protected = {path: file_identity(path) for path in config["protected_files"]}
+    nodes = topology(config["cameras"])
+    idle()
+    service = command_output(
+        [
+            "/usr/bin/systemctl",
+            "show",
+            config["service"],
+            "--property=MainPID,ActiveState,SubState,NRestarts",
+        ]
+    )
+    fields = dict(line.split("=", 1) for line in service.splitlines())
+    if fields.get("ActiveState") != "active" or fields.get("SubState") != "running":
+        raise ValueError("service_not_ready")
+    pid = int(fields["MainPID"])
+    if pid <= 1:
+        raise ValueError("service_not_ready")
+    status = Path(f"/proc/{pid}/status").read_text()
+    security = tuple(
+        line
+        for line in status.splitlines()
+        if line.startswith(("Uid:", "Gid:", "Cap", "NoNewPrivs:", "Seccomp:"))
+    )
+    lsm = security_state(Path(f"/proc/{pid}"))
+    enforce = Path("/sys/fs/selinux/enforce")
+    selinux = enforce.read_text().strip() if enforce.exists() else "unavailable"
+    return {
+        "assets": assets,
+        "protected": protected,
+        "nodes": nodes,
+        "service": service,
+        "security": security,
+        "lsm": lsm,
+        "selinux": selinux,
+    }
+
+
+def sync_directory(path):
+    fd = os.open(path, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def write_exclusive(path, data):
+    # A crash can leave incomplete JSON; the ledger then blocks further scans.
+    with open(path, "x", encoding="utf-8") as stream:
+        os.chmod(path, 0o600)
+        json.dump(data, stream, sort_keys=True, indent=2, allow_nan=False)
+        stream.write("\n")
+        stream.flush()
+        os.fsync(stream.fileno())
+    sync_directory(path.parent)
+
+
+class Ledger:
+    def __init__(self, directory):
+        self.directory = Path(directory)
+
+    def reserve(self, label, mode, campaign, identity):
+        if re.fullmatch("[a-z0-9][a-z0-9-]{0,63}", label) is None:
+            raise ValueError("invalid_attempt_id")
+        for old in self.directory.iterdir():
+            if (
+                old.is_symlink()
+                or not old.is_dir()
+                or not (old / "started.json").is_file()
+            ):
+                raise ValueError("ledger_requires_review")
+            try:
+                result = strict_json((old / "final.json").read_text())
+                if (
+                    result.get("stop_required") is not False
+                    or result.get("status") != "complete"
+                ):
+                    raise ValueError("ledger_requires_review")
+            except (OSError, ValueError, AttributeError) as exc:
+                raise ValueError("ledger_requires_review") from exc
+        attempt = self.directory / label
+        attempt.mkdir(mode=0o700)
+        sync_directory(self.directory)
+        write_exclusive(
+            attempt / "started.json",
+            {
+                "schema": 1,
+                "mode": mode,
+                "campaign": campaign,
+                "binary_sha256": identity,
+                "status": "started",
+            },
+        )
+        return attempt
+
+    def finish(self, attempt, result):
+        write_exclusive(attempt / "final.json", result)

--- a/scripts/ir-evaluation/runner.py
+++ b/scripts/ir-evaluation/runner.py
@@ -1,0 +1,244 @@
+"""One attended, non-granting IR experiment. See README.md before root execution."""
+
+import argparse
+import fcntl
+import hashlib
+import json
+import os
+import pwd
+import resource
+import signal
+import sys
+import tempfile
+from pathlib import Path
+
+import harness
+import host
+
+MODES = ["preflight", "genuine", "impostor", "attack", "empty", "cancel"]
+
+
+def attend(mode):
+    if not sys.stdin.isatty() or not sys.stdout.isatty():
+        return False
+    print(
+        f"Prepare the scheduled {mode} presentation in normal lighting; close other camera apps."
+    )
+    print(
+        "Type READY now only if the participant is ready for this one scan: ",
+        end="",
+        flush=True,
+    )
+    if sys.stdin.readline().strip() != "READY":
+        return False
+    print("START: hold the scheduled position until FINISHED.", flush=True)
+    return True
+
+
+def diagnostic_command(config, binary, operation):
+    assets = config["assets"]
+    command = [
+        str(binary),
+        "--" + operation,
+        pwd.getpwuid(config["subject_uid"]).pw_name,
+        *[assets[key]["path"] for key in ["detector", "recognizer", "flir"]],
+        "--budget-ms",
+        str(config["budget_ms"]),
+        "--cancel-on-stdin",
+    ]
+    if "adapter" in assets:
+        command += ["--adapter", assets["adapter"]["path"]]
+    return command
+
+
+def execute(config, directory, label, mode, campaign, binary, *, trace_ioctl=False):
+    ledger = host.Ledger(directory)
+    attempt = ledger.reserve(
+        label, mode, campaign, config["assets"]["binary"]["sha256"]
+    )
+    result = {
+        "schema": 1,
+        "status": "stopped",
+        "stop_required": True,
+        "mode": mode,
+        "campaign": campaign,
+        "budget_ms": config["budget_ms"],
+        "watchdog_seconds": config["watchdog_seconds"],
+        "asset_sha256": {k: v["sha256"] for k, v in config["assets"].items()},
+        "preflight": None,
+        "evaluation": None,
+        "preservation_verified": False,
+        "failure": None,
+    }
+    before = None
+    env = dict(
+        host.ENV,
+        ORT_DYLIB_PATH=config["assets"]["ort"]["path"],
+        IRLUME_RGB_DEVICE=config["cameras"]["rgb"],
+        IRLUME_IR_DEVICE=config["cameras"]["ir"],
+    )
+    try:
+        before = host.snapshot(config)
+        preflight = harness.run_traced(
+            diagnostic_command(config, binary, "preflight"),
+            env=env,
+            timeout=config["watchdog_seconds"],
+            trace_ioctl=trace_ioctl,
+        )
+        result["preflight"] = preflight
+        preflight["installed_unchanged"] = host.snapshot(config) == before
+        if not harness.trial_checks(
+            preflight,
+            "preflight",
+            config["cameras"]["ir"],
+            config["cameras"]["metadata"],
+        ):
+            result["failure"] = "preflight_failed"
+        elif mode == "preflight":
+            result.update(status="complete", stop_required=False)
+        elif not attend(mode):
+            result["failure"] = "readiness_declined"
+        elif host.snapshot(config) != before:
+            result["failure"] = "host_changed_before_capture"
+        else:
+            trial = harness.run_traced(
+                diagnostic_command(config, binary, "evaluate"),
+                env=env,
+                timeout=config["watchdog_seconds"],
+                trace_ioctl=trace_ioctl,
+                cancel_on_ir_open=config["cameras"]["ir"] if mode == "cancel" else None,
+            )
+            result["evaluation"] = trial
+            trial["installed_unchanged"] = host.snapshot(config) == before
+            safe = harness.trial_checks(
+                trial, mode, config["cameras"]["ir"], config["cameras"]["metadata"]
+            )
+            candidate = (
+                trial["report"] is not None
+                and trial["report"]["category"] == "candidate_match"
+            )
+            if safe and not (mode in {"attack", "impostor", "empty"} and candidate):
+                result.update(status="complete", stop_required=False)
+            else:
+                result["failure"] = "trial_requires_review"
+    except KeyboardInterrupt:
+        result["failure"] = "interrupted"
+    except Exception:  # noqa: BLE001 — sanitize all library failures at the report boundary
+        # Never stringify raw exceptions: paths, account names and third-party
+        # error payloads may occur even before diagnostic stderr suppression.
+        result["failure"] = "execution_failed"
+    finally:
+        try:
+            result["preservation_verified"] = (
+                before is not None and host.snapshot(config) == before
+            )
+        except Exception:  # noqa: BLE001 — sanitize all library failures at the report boundary
+            result["preservation_verified"] = False
+        if result["failure"] is not None or not result["preservation_verified"]:
+            result.update(status="stopped", stop_required=True)
+        ledger.finish(attempt, result)
+        if mode != "preflight":
+            print("FINISHED: you may leave the test position.", flush=True)
+    return result
+
+
+class SafeParser(argparse.ArgumentParser):
+    def error(self, message):
+        self.exit(2, "invalid_arguments: see --help\n")
+
+
+def main():
+    parser = SafeParser(description=__doc__)
+    parser.add_argument("--config", required=True, help="root-owned private host JSON")
+    parser.add_argument(
+        "--output", required=True, help="existing root-owned private campaign directory"
+    )
+    parser.add_argument("--attempt", required=True, help="anonymous unique schedule ID")
+    parser.add_argument("--mode", required=True, choices=MODES)
+    parser.add_argument(
+        "--campaign", required=True, choices=["development", "pilot", "qualification"]
+    )
+    parser.add_argument(
+        "--trace-ioctl",
+        action="store_true",
+        help="record numeric video ioctl durations; no payloads",
+    )
+    args = parser.parse_args()
+    if os.getuid() != 0 or os.geteuid() != 0:
+        print("root_required", file=sys.stderr)
+        return 2
+    os.umask(0o077)
+    resource.setrlimit(resource.RLIMIT_CORE, (0, 0))
+
+    # Handle normal terminal/service interruption through cleanup and the ledger.
+    def interrupted(signum, frame):
+        raise KeyboardInterrupt
+
+    signal.signal(signal.SIGTERM, interrupted)
+    try:
+        for name in ["runner.py", "host.py", "harness.py"]:
+            host.trusted_path(Path(__file__).resolve().parent / name)
+        config_path = host.trusted_path(args.config)
+        output = host.trusted_path(args.output)
+        if (
+            not output.is_dir()
+            or output.stat().st_mode & 0o077
+            or config_path.stat().st_mode & 0o077
+            or config_path.stat().st_size > 65536
+        ):
+            raise ValueError("private_paths_required")
+        config = host.validate_config(host.strict_json(config_path.read_text()))
+        for program in ["/usr/bin/strace", "/usr/bin/fuser", "/usr/bin/systemctl"]:
+            host.trusted_path(program)
+        # One host-wide lock, independent of campaign output path.
+        lock = os.open(
+            "/run/irlume-ir-evaluation.lock",
+            os.O_CREAT | os.O_RDWR | os.O_NOFOLLOW,
+            0o600,
+        )
+        with os.fdopen(lock, "w") as stream:
+            info = os.fstat(stream.fileno())
+            if info.st_uid != 0 or info.st_mode & 0o077:
+                raise ValueError("untrusted_lock")
+            fcntl.flock(stream, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            identity = host.file_identity(config["assets"]["binary"]["path"])
+            if identity[-1] != config["assets"]["binary"]["sha256"]:
+                raise ValueError("binary_hash_mismatch")
+            with tempfile.TemporaryDirectory(
+                prefix="irlume-ir-evaluation-", dir="/run"
+            ) as stage:
+                binary = Path(stage) / "diagnostic"
+                # Execute the checked bytes, never a path replaceable by a user.
+                data = Path(config["assets"]["binary"]["path"]).read_bytes()
+                if hashlib.sha256(data).hexdigest() != identity[-1]:
+                    raise ValueError("binary_changed")
+                binary.write_bytes(data)
+                binary.chmod(0o500)
+                result = execute(
+                    config,
+                    output,
+                    args.attempt,
+                    args.mode,
+                    args.campaign,
+                    binary,
+                    trace_ioctl=args.trace_ioctl,
+                )
+                print(
+                    json.dumps(
+                        {
+                            "status": result["status"],
+                            "stop_required": result["stop_required"],
+                        }
+                    )
+                )
+                return 1 if result["stop_required"] else 0
+    except (Exception, KeyboardInterrupt):  # noqa: BLE001 — never print private exception payloads
+        print(
+            "setup_or_ledger_failed: inspect the private campaign ledger before any retry",
+            file=sys.stderr,
+        )
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ir-evaluation/test_harness.py
+++ b/scripts/ir-evaluation/test_harness.py
@@ -1,0 +1,719 @@
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import harness
+
+
+class TraceTests(unittest.TestCase):
+    def test_rate_fill_failures_remain_non_granting_and_payload_free(self):
+        labels = [
+            "io_permission_denied", "io_invalid_argument", "io_device", "io_no_space",
+            "io_timeout", "io_other", "buffer_timestamp", "buffer_clock", "buffer_source",
+            "buffer_layout", "timestamp_non_increasing", "timestamp_clock",
+            "timestamp_source", "timestamp_epoch", "sequence", "rate_window", "other",
+            "privacy_boundary", "privacy_engaged", "privacy_read_permission_denied",
+            "privacy_read_device", "privacy_read_timeout", "privacy_read_busy",
+            "privacy_read_other", "lease_boundary", "stream_state", "continuity_alignment",
+            "continuity_accounting", "incomplete_window", "missing_stream", "stopped_stream",
+        ]
+        base = {
+            "schema": 1,
+            "operation": "ir_only_evaluation",
+            "authentication_granted": False,
+            "category": "camera_hardware_failed",
+            "elapsed_ms": 12,
+            "capture_ms": 11,
+            "detection_ms": None,
+            "pad_ms": None,
+            "identity_ms": None,
+        }
+        for label in labels:
+            record = dict(base, category="camera_rate_fill_" + label)
+            try:
+                accepted = harness.checked_report(record)
+            except ValueError as error:
+                self.fail(str(error))
+            self.assertEqual(accepted, record)
+            for invalid in [
+                dict(record, authentication_granted=True),
+                dict(record, raw_error="private driver payload"),
+                dict(record, category=record["category"] + "_errno_5"),
+            ]:
+                with self.assertRaises(ValueError):
+                    harness.checked_report(invalid)
+
+    def test_rate_fill_category_keeps_all_prior_schema_contracts(self):
+        stage_names = [
+            "open", "session_setup", "buffers", "metadata", "emitter", "warmup",
+            "rate_fill", "frames", "session_release", "image_stop", "metadata_streamoff",
+            "metadata_buffers", "metadata_format", "metadata_close", "emitter_restore",
+        ]
+        for version in (1, 2, 3, 4):
+            record = {
+                "schema": version,
+                "operation": "ir_only_evaluation",
+                "authentication_granted": False,
+                "category": "camera_rate_fill_timestamp_non_increasing",
+                "elapsed_ms": 12,
+                "capture_ms": 11,
+                "detection_ms": None,
+                "pad_ms": None,
+                "identity_ms": None,
+            }
+            if version >= 2:
+                record["capture_stages_ms"] = dict.fromkeys(
+                    stage_names[:9] if version == 2 else stage_names
+                )
+            if version == 4:
+                record["identity_acceptance"] = None
+            self.assertEqual(harness.checked_report(record), record)
+            for old in ["camera_hardware_failed", "cancelled", "deadline_expired"]:
+                legacy = dict(record, category=old)
+                self.assertEqual(harness.checked_report(legacy), legacy)
+            if version == 4:
+                with self.assertRaises(ValueError):
+                    harness.checked_report(dict(record, identity_acceptance="both"))
+
+    def test_ioctl_metadata_is_numeric_and_payload_free(self):
+        line = "123.456 ioctl(0x4, 0x40045613, 0xdeadbeef) = 0 <0.933001>"
+        self.assertEqual(
+            harness.ioctl_event(line, {4: "/dev/video2"}),
+            {
+                "timestamp": 123.456,
+                "device": "/dev/video2",
+                "fd": 4,
+                "request": 0x40045613,
+                "result": 0,
+                "duration_us": 933001,
+            },
+        )
+        self.assertIsNone(harness.ioctl_event(line, {}))
+        for invalid in [
+            line.replace("<0.933001>", ""),
+            line.replace("0x40045613", "VIDIOC_STREAMOFF"),
+            line.replace("<0.933001>", "<121.000000>"),
+            line.replace("0xdeadbeef", "{private_payload}"),
+        ]:
+            with self.assertRaises(ValueError):
+                harness.ioctl_event(invalid, {4: "/dev/video2"})
+
+    def test_ioctl_trace_handles_resumption_and_fd_reuse_without_payloads(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tracer = Path(tmp) / "tracer.py"
+            lines = [
+                '9 123.000 openat(AT_FDCWD, "/dev/video2", O_RDWR) = 4</dev/video2>',
+                "9 123.100 ioctl(0x4, 0x40045613, 0xdeadbeef <unfinished ...>",
+                "9 124.033 <... ioctl resumed>) = 0 <0.933000>",
+                "9 124.034 close(4</dev/video2>) = 0",
+                "9 124.035 ioctl(0x4, 0x40045613, 0xdeadbeef) = -1 ENOTTY (message) <0.000001>",
+            ]
+            tracer.write_text(
+                "#!"
+                + sys.executable
+                + "\nimport sys\n"
+                + "assert '-T' in sys.argv and 'raw=ioctl' in sys.argv\n"
+                + "print("
+                + repr("\n".join(lines))
+                + ",file=sys.stderr)\n"
+            )
+            tracer.chmod(0o700)
+            got = harness.run_traced(
+                ["unused"], timeout=5, tracer=str(tracer), trace_ioctl=True
+            )
+            self.assertFalse(got["trace_error"])
+            self.assertEqual(len(got["video_ioctl_events"]), 1)
+            self.assertEqual(got["video_ioctl_events"][0]["duration_us"], 933000)
+            self.assertNotIn("deadbeef", json.dumps(got))
+            self.assertNotIn("message", json.dumps(got))
+
+    def test_close_during_pending_ioctl_invalidates_measurement(self):
+        for reopen in [False, True]:
+            with self.subTest(reopen=reopen), tempfile.TemporaryDirectory() as tmp:
+                lines = [
+                    '9 123.000 openat(AT_FDCWD, "/dev/video2", O_RDWR) = 4</dev/video2>',
+                    "9 123.100 ioctl(0x4, 0x40045613, 0xdeadbeef <unfinished ...>",
+                    "10 123.200 close(4</dev/video2>) = 0",
+                ]
+                if reopen:
+                    lines.append(
+                        '10 123.300 openat(AT_FDCWD, "/dev/video3", O_RDWR) = 4</dev/video3>'
+                    )
+                lines.append("9 124.033 <... ioctl resumed>) = 0 <0.933000>")
+                tracer = Path(tmp) / "tracer.py"
+                tracer.write_text(
+                    "#!"
+                    + sys.executable
+                    + "\nimport sys\nprint("
+                    + repr("\n".join(lines))
+                    + ",file=sys.stderr)\n"
+                )
+                tracer.chmod(0o700)
+                got = harness.run_traced(
+                    ["unused"], timeout=5, tracer=str(tracer), trace_ioctl=True
+                )
+                self.assertTrue(got["trace_error"])
+
+    def test_pending_nonvideo_ioctl_cannot_become_video_metadata(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            lines = [
+                '9 123.000 openat(AT_FDCWD, "/dev/null", O_RDWR) = 4</dev/null>',
+                "9 123.100 ioctl(0x4, 0x40045613, 0xdeadbeef <unfinished ...>",
+                "10 123.200 close(4</dev/null>) = 0",
+                '10 123.300 openat(AT_FDCWD, "/dev/video2", O_RDWR) = 4</dev/video2>',
+                "9 124.033 <... ioctl resumed>) = 0 <0.933000>",
+                "9 124.034 close(4</dev/video2>) = 0",
+            ]
+            tracer = Path(tmp) / "tracer.py"
+            tracer.write_text(
+                "#!"
+                + sys.executable
+                + "\nimport sys\nprint("
+                + repr("\n".join(lines))
+                + ",file=sys.stderr)\n"
+            )
+            tracer.chmod(0o700)
+            got = harness.run_traced(
+                ["unused"], timeout=5, tracer=str(tracer), trace_ioctl=True
+            )
+            self.assertTrue(got["trace_error"])
+
+    def test_version_three_requires_all_teardown_timings_and_rejects_payloads(self):
+        stages = dict.fromkeys(
+            [
+                "open",
+                "session_setup",
+                "buffers",
+                "metadata",
+                "emitter",
+                "warmup",
+                "rate_fill",
+                "frames",
+                "session_release",
+                "image_stop",
+                "metadata_streamoff",
+                "metadata_buffers",
+                "metadata_format",
+                "metadata_close",
+                "emitter_restore",
+            ]
+        )
+        stages.update(image_stop=950, metadata_close=0)
+        record = {
+            "schema": 3,
+            "operation": "ir_only_evaluation",
+            "authentication_granted": False,
+            "category": "deadline_expired",
+            "elapsed_ms": 5700,
+            "capture_ms": 5699,
+            "detection_ms": None,
+            "pad_ms": None,
+            "identity_ms": None,
+            "capture_stages_ms": stages,
+        }
+        self.assertEqual(harness.checked_report(record), record)
+        for values in [
+            dict(stages, metadata_close=True),
+            dict(stages, image_stop=-1),
+            dict(stages, emitter_restore="private error"),
+            dict(stages, image_stop=3600001),
+            dict(stages, score=0.99),
+            {k: v for k, v in stages.items() if k != "image_stop"},
+        ]:
+            with self.assertRaises(ValueError):
+                harness.checked_report(dict(record, capture_stages_ms=values))
+        for version in [1, 2, 4]:
+            with self.assertRaises(ValueError):
+                harness.checked_report(dict(record, schema=version))
+
+    def test_version_four_requires_bounded_identity_acceptance_evidence(self):
+        stages = dict.fromkeys(
+            [
+                "open",
+                "session_setup",
+                "buffers",
+                "metadata",
+                "emitter",
+                "warmup",
+                "rate_fill",
+                "frames",
+                "session_release",
+                "image_stop",
+                "metadata_streamoff",
+                "metadata_buffers",
+                "metadata_format",
+                "metadata_close",
+                "emitter_restore",
+            ]
+        )
+        base = {
+            "schema": 4,
+            "operation": "ir_only_evaluation",
+            "authentication_granted": False,
+            "category": "candidate_match",
+            "identity_acceptance": "centroid",
+            "elapsed_ms": 5700,
+            "capture_ms": 5699,
+            "detection_ms": 0,
+            "pad_ms": 0,
+            "identity_ms": 1,
+            "capture_stages_ms": stages,
+        }
+        for acceptance in ["best_template", "centroid", "both"]:
+            record = dict(base, identity_acceptance=acceptance)
+            self.assertEqual(harness.checked_report(record), record)
+        for invalid in [None, "unknown", True, 1, [], {}]:
+            with self.assertRaises(ValueError):
+                harness.checked_report(dict(base, identity_acceptance=invalid))
+        with self.assertRaises(ValueError):
+            harness.checked_report(dict(base, category="identity_mismatch"))
+        refusal = dict(base, category="cancelled", identity_acceptance=None)
+        self.assertEqual(harness.checked_report(refusal), refusal)
+        for invalid in [
+            {key: value for key, value in base.items() if key != "identity_acceptance"},
+            dict(base, private_score=0.9),
+        ]:
+            with self.assertRaises(ValueError):
+                harness.checked_report(invalid)
+
+    def test_version_two_capture_timings_are_exact_and_bounded(self):
+        stages = dict.fromkeys(
+            [
+                "open",
+                "session_setup",
+                "buffers",
+                "metadata",
+                "emitter",
+                "warmup",
+                "rate_fill",
+                "frames",
+                "session_release",
+            ]
+        )
+        stages.update(open=120, session_setup=5500, warmup=4200)
+        record = {
+            "schema": 2,
+            "operation": "ir_only_evaluation",
+            "authentication_granted": False,
+            "category": "deadline_expired",
+            "elapsed_ms": 5650,
+            "capture_ms": 5648,
+            "detection_ms": None,
+            "pad_ms": None,
+            "identity_ms": None,
+            "capture_stages_ms": stages,
+        }
+        self.assertEqual(harness.checked_report(record), record)
+        for invalid in [
+            dict(stages, private_score=1),
+            {"open": 1},
+            dict(stages, open=True),
+            dict(stages, open=-1),
+            dict(stages, open=3_600_001),
+            dict(stages, open="120"),
+        ]:
+            with self.assertRaises(ValueError):
+                harness.checked_report(dict(record, capture_stages_ms=invalid))
+        for invalid in [
+            dict(record, schema=1),
+            dict(record, schema=3),
+            dict(record, authentication_granted=True),
+        ]:
+            with self.assertRaises(ValueError):
+                harness.checked_report(invalid)
+
+    def test_capture_failure_categories_accept_only_fixed_metadata(self):
+        for category in [
+            "camera_busy",
+            "camera_rate_refused",
+            "camera_lease_timeout",
+            "camera_lease_refused",
+            "camera_io_failed",
+            "camera_hardware_failed",
+            "camera_authorization_refused",
+            "camera_policy_refused",
+            "camera_capture_failed",
+        ]:
+            record = {
+                "schema": 1,
+                "operation": "ir_only_evaluation",
+                "authentication_granted": False,
+                "category": category,
+                "elapsed_ms": 100,
+                "capture_ms": 99,
+                "detection_ms": None,
+                "pad_ms": None,
+                "identity_ms": None,
+            }
+            self.assertEqual(harness.checked_report(record), record)
+            for extra in [
+                dict(record, message="private"),
+                dict(record, rate_evidence={}),
+                dict(record, category="private error text"),
+                dict(record, authentication_granted=True),
+            ]:
+                with self.assertRaises(ValueError):
+                    harness.checked_report(extra)
+
+    def test_records_successful_ir_open_and_close_without_other_paths(self):
+        lines = [
+            '123.000 openat(AT_FDCWD, "/dev/video2", O_RDWR) = 7</dev/video2>',
+            "123.250 close(7</dev/video2>) = 0",
+            '123.300 openat(AT_FDCWD, "/private/profile.json", O_RDONLY) = 4</private/profile.json>',
+        ]
+        events = [event for line in lines if (event := harness.video_event(line))]
+        self.assertEqual(
+            [(e["operation"], e["device"], e["result"]) for e in events],
+            [("open", "/dev/video2", 7), ("close", "/dev/video2", 0)],
+        )
+        self.assertEqual(events[1]["timestamp"] - events[0]["timestamp"], 0.25)
+
+    def test_character_device_annotations_from_yy_are_recognized(self):
+        for line in [
+            "[pid 200] 123.6 close(6</dev/video2<char 81:2>>) = 0",
+            "[pid 200] 123.6 <... openat resumed>) = 6</dev/video2<char 81:2>>",
+        ]:
+            event = harness.video_event(line)
+            self.assertIsNotNone(event)
+            self.assertEqual(event["device"], "/dev/video2")
+
+    def test_failed_rgb_attempt_remains_visible(self):
+        event = harness.video_event(
+            '[pid 200] 123.5 openat(AT_FDCWD, "/dev/video0", O_RDWR) = -1 EBUSY (Device or resource busy)'
+        )
+        self.assertIsNotNone(event)
+        self.assertEqual(event["result"], -1)
+
+    def test_unfinished_and_resumed_calls_keep_evidence(self):
+        event = harness.video_event(
+            '[pid 200] 123.5 openat(AT_FDCWD, "/dev/video2", O_RDWR <unfinished ...>'
+        )
+        self.assertIsNotNone(event)
+        self.assertEqual(event["operation"], "open")
+        self.assertEqual(
+            harness.video_event(
+                "[pid 200] 123.6 <... openat resumed>) = 6</dev/video2>"
+            )["result"],
+            6,
+        )
+
+    def test_rejects_nonvideo_and_path_prefix_lookalikes(self):
+        for line in [
+            '123 openat(AT_FDCWD, "/dev/video2-secret", O_RDONLY) = 4',
+            "123 close(4</tmp/video2>) = 0",
+            '123 read(4</dev/video2>, "private", 4) = 4',
+        ]:
+            self.assertIsNone(harness.video_event(line))
+
+    def test_output_allows_only_categories_and_bounded_timings(self):
+        record = {
+            "schema": 1,
+            "operation": "ir_only_evaluation",
+            "authentication_granted": False,
+            "category": "candidate_match",
+            "elapsed_ms": 123,
+            "capture_ms": 20,
+            "detection_ms": 30,
+            "pad_ms": 40,
+            "identity_ms": None,
+        }
+        self.assertEqual(harness.checked_report(record), record)
+        for changed in [
+            dict(record, authentication_granted=True),
+            dict(record, embedding=[0.1]),
+            dict(record, category="match Alice"),
+            dict(record, elapsed_ms=-1),
+            dict(record, pad_ms=float("nan")),
+        ]:
+            with self.assertRaises(ValueError):
+                harness.checked_report(changed)
+
+
+class ProcessTests(unittest.TestCase):
+    def test_real_trace_omits_nonvideo_paths_and_stderr_content(self):
+        record = {
+            "schema": 1,
+            "operation": "ir_only_evaluation",
+            "authentication_granted": False,
+            "category": "ready",
+            "elapsed_ms": 1,
+            "capture_ms": None,
+            "detection_ms": None,
+            "pad_ms": None,
+            "identity_ms": None,
+        }
+        code = (
+            "import json,sys; open('/dev/null').close(); print('do not persist me',file=sys.stderr); print("
+            + repr(json.dumps(record))
+            + ")"
+        )
+        got = harness.run_traced([sys.executable, "-c", code], timeout=5)
+        self.assertEqual(got["returncode"], 0)
+        self.assertEqual(got["report"], record)
+        self.assertEqual(got["video_events"], [])
+        self.assertNotIn("do not persist me", json.dumps(got))
+
+    def test_cooperative_stdin_cancellation_is_observed(self):
+        record = {
+            "schema": 1,
+            "operation": "ir_only_evaluation",
+            "authentication_granted": False,
+            "category": "cancelled",
+            "elapsed_ms": 1,
+            "capture_ms": None,
+            "detection_ms": None,
+            "pad_ms": None,
+            "identity_ms": None,
+        }
+        code = (
+            "import sys; sys.stdin.buffer.read(1); print("
+            + repr(json.dumps(record))
+            + ")"
+        )
+        got = harness.run_traced(
+            [sys.executable, "-c", code], cancel_after_ms=30, timeout=5
+        )
+        self.assertTrue(got["cancellation_sent"])
+        self.assertFalse(got["watchdog_fired"])
+        self.assertEqual(got["report"]["category"], "cancelled")
+
+    def test_early_tracer_exit_cleans_descendant_held_pipes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tracer = Path(tmp) / "tracer.py"
+            tracer.write_text(
+                "#!"
+                + sys.executable
+                + '\nimport subprocess,sys\nsubprocess.Popen([sys.executable,"-c","import time; time.sleep(10)"])\n'
+            )
+            tracer.chmod(0o700)
+            got = harness.run_traced(
+                [sys.executable, "-c", "pass"], timeout=2, tracer=str(tracer)
+            )
+            self.assertTrue(got["early_tracer_exit"])
+            self.assertTrue(got["readers_completed"])
+            self.assertLess(got["wall_elapsed_ms"], 1500)
+
+    def test_watchdog_reaps_stuck_child(self):
+        got = harness.run_traced(
+            [sys.executable, "-c", "import time; time.sleep(10)"], timeout=0.1
+        )
+        self.assertTrue(got["watchdog_fired"])
+        self.assertIsNotNone(got["returncode"])
+        self.assertIsNone(got["report"])
+
+
+class TrialGateTests(unittest.TestCase):
+    def result(self):
+        return {
+            "output_valid": True,
+            "readers_completed": True,
+            "watchdog_fired": False,
+            "early_tracer_exit": False,
+            "trace_error": False,
+            "trace_overflow": False,
+            "output_overflow": False,
+            "installed_unchanged": True,
+            "returncode": 0,
+            "cancellation_sent": False,
+            "report": {"category": "candidate_match"},
+            "video_events": [
+                {
+                    "device": "/dev/video2",
+                    "operation": "open",
+                    "result": 6,
+                    "fd": 6,
+                    "timestamp": 1.0,
+                },
+                {
+                    "device": "/dev/video2",
+                    "operation": "close",
+                    "result": 0,
+                    "fd": 6,
+                    "timestamp": 1.1,
+                },
+            ],
+        }
+
+    def test_only_complete_camera_trial_passes(self):
+        result = self.result()
+        self.assertTrue(harness.trial_checks(result, "genuine"))
+        for bad in [
+            dict(result, returncode=-6),
+            dict(result, video_events=[]),
+            dict(result, installed_unchanged=False),
+            dict(result, early_tracer_exit=True),
+        ]:
+            self.assertFalse(harness.trial_checks(bad, "genuine"))
+        result["video_events"].append(
+            {
+                "device": "/dev/video0",
+                "operation": "open",
+                "result": -1,
+                "timestamp": 1.1,
+            }
+        )
+        self.assertFalse(harness.trial_checks(result, "genuine"))
+
+    def test_metadata_is_allowed_and_cancel_requires_cancelled_result(self):
+        result = self.result()
+        result["video_events"].extend(
+            [
+                {
+                    "device": "/dev/video3",
+                    "operation": "open",
+                    "result": 7,
+                    "fd": 7,
+                    "timestamp": 1.1,
+                },
+                {
+                    "device": "/dev/video3",
+                    "operation": "close",
+                    "result": 0,
+                    "fd": 7,
+                    "timestamp": 1.2,
+                },
+            ]
+        )
+        self.assertTrue(harness.trial_checks(result, "genuine"))
+        self.assertFalse(harness.trial_checks(result, "cancel"))
+        result.update(cancellation_sent=True, report={"category": "cancelled"})
+        self.assertTrue(harness.trial_checks(result, "cancel"))
+
+    def test_preflight_requires_ready_and_no_camera_opens(self):
+        result = self.result()
+        self.assertFalse(harness.trial_checks(result, "preflight"))
+        result.update(video_events=[], report={"category": "ready"})
+        self.assertTrue(harness.trial_checks(result, "preflight"))
+        result["report"]["category"] = "enrollment_unavailable"
+        self.assertFalse(harness.trial_checks(result, "preflight"))
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class PortableRegressionTests(unittest.TestCase):
+    def test_missing_stage_fields_is_not_valid_evidence(self):
+        with self.assertRaises(ValueError):
+            harness.checked_report(
+                {
+                    "schema": 1,
+                    "operation": "ir_only_evaluation",
+                    "authentication_granted": False,
+                    "category": "ready",
+                    "elapsed_ms": 1,
+                }
+            )
+
+    def test_one_close_cannot_release_two_open_descriptors(self):
+        result = TrialGateTests().result()
+        result["video_events"].insert(
+            1,
+            {
+                "device": "/dev/video2",
+                "operation": "open",
+                "result": 7,
+                "fd": 7,
+                "timestamp": 1.05,
+            },
+        )
+        self.assertFalse(harness.trial_checks(result, "genuine"))
+
+
+class StrictTraceTests(unittest.TestCase):
+    def test_duplicate_output_keys_are_rejected_without_raw_output(self):
+        raw = '{"schema":1,"operation":"ir_only_evaluation","authentication_granted":true,"authentication_granted":false,"category":"ready","elapsed_ms":1,"capture_ms":null,"detection_ms":null,"pad_ms":null,"identity_ms":null}'
+        got = harness.run_traced(
+            [sys.executable, "-c", "print(" + repr(raw) + ")"], timeout=5
+        )
+        self.assertFalse(got["output_valid"])
+        self.assertIsNone(got["report"])
+
+    def test_shared_fd_lifetimes_are_paired_and_never_reused(self):
+        lines = [
+            '[pid 200] 123.1 openat(AT_FDCWD, "/dev/video10", O_RDWR) = 6</dev/video10<char 81:10>>',
+            "[pid 201] 123.2 close(6</dev/video10<char 81:10>>) = 0",
+        ]
+        events = [harness.video_event(line) for line in lines]
+        self.assertTrue(harness.release_checks(events, "/dev/video10", "/dev/video11"))
+        for tail in [[dict(events[1], fd=7)], [events[1], events[1]], []]:
+            self.assertFalse(
+                harness.release_checks(
+                    [events[0], *tail], "/dev/video10", "/dev/video11"
+                )
+            )
+
+    def test_real_fork_invalidates_shared_fd_assumption(self):
+        code = (
+            "import os; pid=os.fork(); os._exit(0) if pid == 0 else os.waitpid(pid,0)"
+        )
+        got = harness.run_traced([sys.executable, "-c", code], timeout=5)
+        self.assertTrue(got["trace_error"])
+
+
+class ResumedTraceTests(unittest.TestCase):
+    def test_unfinished_calls_preserve_original_fd_and_thread_flags(self):
+        lines = [
+            "[pid 200] 123.0 clone(child_stack=NULL, flags=CLONE_FILES|CLONE_THREAD <unfinished ...>",
+            "[pid 200] 123.1 <... clone resumed>) = 201",
+            '[pid 201] 123.2 openat(AT_FDCWD, "/dev/video10", O_RDWR <unfinished ...>',
+            "[pid 201] 123.3 <... openat resumed>) = 6</dev/video10<char 81:10>>",
+            "[pid 201] 123.4 close(6</dev/video10<char 81:10>> <unfinished ...>",
+            "[pid 201] 123.5 <... close resumed>) = 0",
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            tracer = Path(tmp) / "tracer.py"
+            tracer.write_text(
+                "#!"
+                + sys.executable
+                + "\nimport sys\nfor line in "
+                + repr(lines)
+                + ": print(line,file=sys.stderr)\n"
+            )
+            tracer.chmod(0o700)
+            got = harness.run_traced(["/unused"], timeout=5, tracer=str(tracer))
+        self.assertFalse(got["trace_error"])
+        self.assertTrue(
+            harness.release_checks(got["video_events"], "/dev/video10", "/dev/video11")
+        )
+        self.assertEqual(len(got["video_events"]), 2)
+
+
+class CleanupTests(unittest.TestCase):
+    def test_selector_setup_interrupt_reaps_already_started_child(self):
+        import subprocess
+        from unittest.mock import patch
+
+        children = []
+        original = subprocess.Popen
+
+        def spawned(*args, **kwargs):
+            child = original(*args, **kwargs)
+            children.append(child)
+            return child
+
+        with (
+            patch("harness.subprocess.Popen", side_effect=spawned),
+            patch("harness.selectors.DefaultSelector", side_effect=KeyboardInterrupt()),
+            self.assertRaises(KeyboardInterrupt),
+        ):
+            harness.run_traced(
+                [sys.executable, "-c", "import time; time.sleep(10)"], timeout=5
+            )
+        self.assertIsNotNone(children[0].poll())
+
+
+class DescriptorTableTests(unittest.TestCase):
+    def test_unsharing_fd_table_invalidates_release_proof(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tracer = Path(tmp) / "tracer.py"
+            tracer.write_text(
+                "#!"
+                + sys.executable
+                + '\nimport sys\nprint("[pid 200] 123.0 unshare(CLONE_FILES) = 0",file=sys.stderr)\n'
+            )
+            tracer.chmod(0o700)
+            got = harness.run_traced(["/unused"], timeout=5, tracer=str(tracer))
+        self.assertTrue(got["trace_error"])

--- a/scripts/ir-evaluation/test_host.py
+++ b/scripts/ir-evaluation/test_host.py
@@ -1,0 +1,247 @@
+"""Configuration and persistence failures must fail before camera access."""
+
+import copy
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+import host
+
+
+def config():
+    asset = {"path": "/opt/irlume-eval/file", "sha256": "a" * 64}
+    return {
+        "schema": 1,
+        "subject_uid": 1000,
+        "budget_ms": 5000,
+        "watchdog_seconds": 15,
+        "assets": {
+            key: dict(asset)
+            for key in ["binary", "detector", "recognizer", "flir", "ort"]
+        },
+        "cameras": {
+            "rgb": "/dev/video8",
+            "ir": "/dev/video10",
+            "metadata": "/dev/video11",
+        },
+        "protected_files": ["/etc/pam.d/irlume"],
+        "service": "irlumed.service",
+    }
+
+
+class ConfigTests(unittest.TestCase):
+    def test_explicit_non_default_camera_numbers_are_preserved(self):
+        self.assertEqual(
+            host.validate_config(config())["cameras"]["ir"], "/dev/video10"
+        )
+
+    def test_rejects_ambiguous_or_unpinned_configuration(self):
+        for key, value in [
+            ("budget_ms", True),
+            ("budget_ms", 99),
+            ("watchdog_seconds", 4),
+            ("subject_uid", 0),
+            ("service", "shell; command"),
+            ("extra", "private"),
+        ]:
+            data = config()
+            data[key] = value
+            with self.subTest(key=key), self.assertRaises(ValueError):
+                host.validate_config(data)
+        for edit in ["hash", "node", "duplicate", "model", "protected", "path"]:
+            data = config()
+            if edit == "hash":
+                data["assets"]["binary"]["sha256"] = "auto"
+            if edit == "node":
+                data["cameras"]["ir"] = "/dev/v4l/by-id/private"
+            if edit == "duplicate":
+                data["cameras"]["ir"] = data["cameras"]["rgb"]
+            if edit == "model":
+                del data["assets"]["flir"]
+            if edit == "protected":
+                data["protected_files"] = []
+            if edit == "path":
+                data["assets"]["binary"]["path"] = "relative"
+            with self.subTest(edit=edit), self.assertRaises(ValueError):
+                host.validate_config(data)
+
+    def test_topology_requires_metadata_sibling_and_separate_rgb(self):
+        nodes = {
+            "rgb": {
+                "index": 0,
+                "interface": "/sys/devices/usb1/1-2:1.0",
+                "siblings": {"video8", "video9"},
+            },
+            "ir": {
+                "index": 0,
+                "interface": "/sys/devices/usb1/1-2:1.2",
+                "siblings": {"video10", "video11"},
+            },
+            "metadata": {
+                "index": 1,
+                "interface": "/sys/devices/usb1/1-2:1.2",
+                "siblings": {"video10", "video11"},
+            },
+        }
+        self.assertTrue(host.qualified_topology(nodes, config()["cameras"]))
+        for role, field, value in [
+            ("metadata", "index", 0),
+            ("metadata", "interface", "/wrong"),
+            ("rgb", "interface", "/sys/devices/usb1/1-2:1.2"),
+            ("ir", "siblings", {"video10", "video11", "video12"}),
+            ("ir", "interface", "/sys/devices/virtual/camera"),
+        ]:
+            altered = copy.deepcopy(nodes)
+            altered[role][field] = value
+            self.assertFalse(host.qualified_topology(altered, config()["cameras"]))
+
+    def test_strict_json_rejects_duplicate_keys(self):
+        with self.assertRaises(ValueError):
+            host.strict_json('{"schema": 1, "schema": 1}')
+
+
+class LedgerTests(unittest.TestCase):
+    def test_started_record_survives_failure_without_final(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ledger = host.Ledger(Path(tmp))
+            attempt = ledger.reserve("a01", "genuine", "development", "a" * 64)
+            self.assertEqual(
+                json.loads((attempt / "started.json").read_text())["mode"], "genuine"
+            )
+            with self.assertRaises(ValueError):
+                ledger.reserve("a02", "genuine", "development", "a" * 64)
+            self.assertFalse((attempt / "final.json").exists())
+
+    def test_exclusive_results_and_persistent_stop(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ledger = host.Ledger(Path(tmp))
+            attempt = ledger.reserve("a01", "attack", "pilot", "a" * 64)
+            ledger.finish(attempt, {"status": "stopped", "stop_required": True})
+            self.assertEqual(
+                json.loads((attempt / "final.json").read_text())["status"], "stopped"
+            )
+            with self.assertRaises((ValueError, FileExistsError)):
+                ledger.finish(attempt, {"status": "ok"})
+            with self.assertRaises(ValueError):
+                ledger.reserve("a02", "attack", "pilot", "a" * 64)
+            self.assertEqual((attempt / "final.json").stat().st_mode & 0o777, 0o600)
+
+    def test_symlink_attempt_or_unexpected_ledger_content_blocks(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "a01").symlink_to("/tmp")
+            with self.assertRaises(ValueError):
+                host.Ledger(Path(tmp)).reserve("a02", "genuine", "pilot", "a" * 64)
+
+    def test_successful_attempt_allows_next_but_never_duplicate(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ledger = host.Ledger(Path(tmp))
+            attempt = ledger.reserve("a01", "genuine", "pilot", "a" * 64)
+            ledger.finish(attempt, {"status": "complete", "stop_required": False})
+            self.assertTrue(
+                ledger.reserve("a02", "genuine", "pilot", "a" * 64).exists()
+            )
+            with self.assertRaises((ValueError, FileExistsError)):
+                ledger.reserve("a01", "genuine", "pilot", "a" * 64)
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TrustTests(unittest.TestCase):
+    def test_intermediate_untrusted_symlink_is_not_hidden_by_safe_final_target(self):
+        from unittest.mock import patch
+
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            (base / "file").write_text("fixture")
+            (base / "hop").symlink_to(base / "file")
+            (base / "entry").symlink_to(base / "hop")
+            original = Path.lstat
+
+            def metadata(path, *args, **kwargs):
+                info = list(original(path, *args, **kwargs))
+                info[0] &= ~0o022
+                info[4] = 123 if path == base / "hop" else 0
+                return os.stat_result(info)
+
+            with patch.object(Path, "lstat", metadata), self.assertRaises(ValueError):
+                host.trusted_path(base / "entry")
+
+
+class SecurityContextTests(unittest.TestCase):
+    def test_host_without_context_provider_can_be_preserved(self):
+        import errno
+        from unittest.mock import patch
+
+        process = Path("/proc/123")
+        original = Path.read_text
+        with tempfile.TemporaryDirectory() as tmp:
+            lsm = Path(tmp) / "lsm"
+            lsm.write_text("capability,landlock,lockdown,yama,bpf\n")
+
+            def read(path, *args, **kwargs):
+                if path == process / "attr/current":
+                    raise OSError(errno.EINVAL, "fixture")
+                return original(path, *args, **kwargs)
+
+            with patch.object(Path, "read_text", read):
+                got = host.security_state(process, lsm)
+            self.assertEqual(
+                got,
+                {"modules": "capability,landlock,lockdown,yama,bpf", "context": None},
+            )
+
+    def test_permission_missing_or_unknown_context_support_stays_fatal(self):
+        import errno
+        from unittest.mock import patch
+
+        process = Path("/proc/123")
+        original = Path.read_text
+        with tempfile.TemporaryDirectory() as tmp:
+            lsm = Path(tmp) / "lsm"
+            for modules, error in [
+                ("capability,yama", errno.EACCES),
+                ("capability,yama", errno.ENOENT),
+                ("capability,selinux", errno.EINVAL),
+                ("capability,apparmor", errno.EINVAL),
+                ("capability,future_lsm", errno.EINVAL),
+                ("", errno.EINVAL),
+            ]:
+                lsm.write_text(modules)
+
+                def read(path, *args, failure=error, **kwargs):
+                    if path == process / "attr/current":
+                        raise OSError(failure, "fixture")
+                    return original(path, *args, **kwargs)
+
+                with (
+                    self.subTest(modules=modules, error=error),
+                    patch.object(Path, "read_text", read),
+                    self.assertRaises((OSError, ValueError)),
+                ):
+                    host.security_state(process, lsm)
+
+    def test_available_label_and_module_changes_remain_distinguishable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "attr").mkdir()
+            ctx = root / "attr/current"
+            lsm = root / "lsm"
+            lsm.write_text("capability,selinux")
+            ctx.write_text("system_u:system_r:fixture_t:s0\n")
+            before = host.security_state(root, lsm)
+            self.assertEqual(
+                before,
+                {
+                    "modules": "capability,selinux",
+                    "context": "system_u:system_r:fixture_t:s0",
+                },
+            )
+            ctx.write_text("system_u:system_r:changed_t:s0")
+            self.assertNotEqual(before, host.security_state(root, lsm))
+            ctx.write_text("system_u:system_r:fixture_t:s0")
+            lsm.write_text("capability,yama,selinux")
+            self.assertNotEqual(before, host.security_state(root, lsm))

--- a/scripts/ir-evaluation/test_runner.py
+++ b/scripts/ir-evaluation/test_runner.py
@@ -1,0 +1,134 @@
+"""Real ledger and trace supervision; host/camera boundaries are substituted."""
+
+import contextlib
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import runner
+from test_host import config
+
+
+def result(category="candidate_match"):
+    return {
+        "returncode": 0,
+        "output_valid": True,
+        "readers_completed": True,
+        "watchdog_fired": False,
+        "early_tracer_exit": False,
+        "trace_error": False,
+        "trace_overflow": False,
+        "output_overflow": False,
+        "cancellation_sent": False,
+        "report": {
+            "schema": 1,
+            "operation": "ir_only_evaluation",
+            "authentication_granted": False,
+            "category": category,
+            "elapsed_ms": 23,
+            "capture_ms": 10,
+            "detection_ms": 3,
+            "pad_ms": 5,
+            "identity_ms": 5,
+        },
+        "video_events": [
+            {
+                "device": "/dev/video10",
+                "operation": "open",
+                "result": 7,
+                "fd": 7,
+                "timestamp": 1.0,
+            },
+            {
+                "device": "/dev/video10",
+                "operation": "close",
+                "result": 0,
+                "fd": 7,
+                "timestamp": 1.2,
+            },
+        ],
+        "wall_elapsed_ms": 45,
+    }
+
+
+class RunnerTests(unittest.TestCase):
+    def execute(self, mode="genuine", outcomes=None, snapshots=None, ready=True):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        folder = Path(self.tmp.name)
+        preflight = result("ready")
+        preflight["video_events"] = []
+        with (
+            contextlib.redirect_stdout(io.StringIO()),
+            patch(
+                "runner.pwd.getpwuid", return_value=SimpleNamespace(pw_name="fixture")
+            ),
+            patch("runner.host.snapshot", side_effect=snapshots or [{"x": 1}] * 5),
+            patch(
+                "runner.harness.run_traced",
+                side_effect=outcomes or [preflight, result()],
+            ),
+            patch("runner.attend", return_value=ready),
+        ):
+            runner.execute(config(), folder, "a01", mode, "pilot", "/fixed/binary")
+        return json.loads((folder / "a01/final.json").read_text())
+
+    def test_attack_candidate_stops_and_preserves_categorical_evidence(self):
+        got = self.execute(mode="attack")
+        self.assertEqual(got["status"], "stopped")
+        self.assertTrue(got["stop_required"])
+        self.assertEqual(got["evaluation"]["report"]["category"], "candidate_match")
+
+    def test_no_face_remains_no_face_not_pad_success(self):
+        preflight = result("ready")
+        preflight["video_events"] = []
+        got = self.execute(mode="attack", outcomes=[preflight, result("no_face")])
+        self.assertEqual(got["status"], "complete")
+        self.assertEqual(got["evaluation"]["report"]["category"], "no_face")
+
+    def test_private_exception_is_reduced_to_failure_and_ledger_retained(self):
+        got = self.execute(outcomes=[RuntimeError("/private/name score=0.79")])
+        self.assertEqual(got["failure"], "execution_failed")
+        self.assertTrue(got["stop_required"])
+        self.assertNotIn("private", json.dumps(got))
+
+    def test_keyboard_interrupt_records_attempt_and_checks_preservation(self):
+        got = self.execute(outcomes=[KeyboardInterrupt()])
+        self.assertEqual(got["failure"], "interrupted")
+        self.assertTrue(got["preservation_verified"])
+        self.assertTrue(got["stop_required"])
+
+    def test_unready_terminal_never_reaches_evaluation(self):
+        got = self.execute(ready=False)
+        self.assertIsNone(got["evaluation"])
+        self.assertEqual(got["failure"], "readiness_declined")
+
+    def test_changed_protected_state_cannot_pass(self):
+        got = self.execute(snapshots=[{"x": 1}, {"x": 1}, {"x": 1}, {"x": 1}, {"x": 2}])
+        self.assertEqual(got["status"], "stopped")
+        self.assertFalse(got["preservation_verified"])
+
+    def test_only_expected_device_opens_allowed(self):
+        preflight = result("ready")
+        preflight["video_events"] = []
+        bad = result()
+        bad["video_events"][0]["device"] = "/dev/video8"
+        got = self.execute(outcomes=[preflight, bad])
+        self.assertTrue(got["stop_required"])
+
+    def test_operator_cue_requires_a_terminal_and_explicit_readiness(self):
+        stream = io.StringIO("READY\n")
+        with (
+            patch("sys.stdin", stream),
+            contextlib.redirect_stdout(io.StringIO()) as output,
+        ):
+            self.assertFalse(runner.attend("genuine"))
+        self.assertNotIn("START", output.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/kwallet-handoff-check.sh
+++ b/scripts/kwallet-handoff-check.sh
@@ -102,7 +102,7 @@ for _ in $(seq 12); do sleep 1; [ "$(stat -c %s "$KWL" 2>/dev/null || echo 0)" -
 reap_daemon
 
 # --- 1. the key irlume derives opens it -------------------------------------
-"$DERIVE" "$HOMEDIR" "$PASSWORD" > "$WORK/right.key" || { echo "derive failed"; exit 2; }
+IRLUME_KWALLET_INIT="$HELPER" "$DERIVE" "$TESTUSER" "$PASSWORD" > "$WORK/right.key" || { echo "derive failed"; exit 2; }
 [ "$(stat -c %s "$WORK/right.key")" -eq 56 ] || bad "derived key is not 56 bytes"
 handoff "$WORK/right.key" >/dev/null
 got=$(asuser timeout 20 secret-tool lookup svc handoffcheck 2>/dev/null)
@@ -112,7 +112,7 @@ reap_daemon
 
 # --- 2. a key from the wrong password does not ------------------------------
 # Without this the check above could be passing for some other reason.
-"$DERIVE" "$HOMEDIR" "$WRONG" > "$WORK/wrong.key"
+IRLUME_KWALLET_INIT="$HELPER" "$DERIVE" "$TESTUSER" "$WRONG" > "$WORK/wrong.key"
 handoff "$WORK/wrong.key" >/dev/null
 got=$(asuser timeout 20 secret-tool lookup svc handoffcheck 2>/dev/null)
 if [ -z "$got" ]; then note "PASS: a key from the wrong password was refused"

--- a/scripts/test-password-helper.sh
+++ b/scripts/test-password-helper.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Exercise actual libpam using only private synthetic fixtures, never host PAM.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+test_binary="$(cargo test -p irlume-password-verify --locked --test pam --no-run --message-format=json | python3 -c '
+import json, sys
+paths = [row["executable"] for row in map(json.loads, sys.stdin)
+         if row.get("reason") == "compiler-artifact" and row.get("target", {}).get("name") == "pam" and row.get("executable")]
+assert len(paths) == 1, paths
+print(paths[0])
+')"
+./scripts/run-tests-guarded.sh --min 1 -- "$test_binary" unprivileged_invocation_is_unavailable --exact
+./scripts/run-tests-guarded.sh --min 1 -- sudo -n setpriv --no-new-privs --bounding-set=-all,+dac_override,+fowner "$test_binary" actual_pam_contract --exact --ignored --nocapture


### PR DESCRIPTION
## What & why

Adds optional experimental IR-only authentication and makes its controls available from the TUI. Preferences displays daemon-observed ON/OFF/UNKNOWN state with keyboard and mouse controls. Guided actions cover sensor readiness, consent, retry recovery and wallet operations, so normal operator workflows can be completed without typing CLI commands.

Diagnostics now distinguishes pending or unavailable checks, displays full scrollable explanations, and routes recovery and repairs to the appropriate in-app action. Failed wallet inspection refuses forgetting unless force is explicitly selected. CLI doctor and recovery agree about missing template keys.

The first commit contains the previously local foundation: bounded capture and cancellation, durable retry recovery, wallet handoff changes, optional IR evaluation tooling, packaging and documentation. The second commit isolates the 13-file Preferences/CLI/Diagnostics update. Dual-camera defaults and password fallback remain; IR-only requires explicit owner opt-in and is not broadly hardware-qualified.

## Testing

- [x] `cargo +1.88.0 test --workspace --locked --offline -j 2` passes
- [x] `cargo +1.88.0 clippy --workspace --all-targets --locked --offline -- -D warnings` clean
- [x] `cargo +1.88.0 fmt --all --check` and `git diff --check` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo +1.88.0 doc --workspace --no-deps --locked --offline` clean
- [x] Docs/CHANGELOG updated for user-facing changes
- [ ] Full hardware qualification across supported cameras and PAM environments

The exact final source was independently reviewed, release-built and installed on the ASUS. Post-install checks confirmed a healthy daemon, ready models, idle cameras, SELinux enforcement, all 93 protected state identities unchanged, and all seven rollback backups intact. Ordinary-user preference reads and CLI status commands passed. IR-only and hands-free remained enabled; the biopolicy gate remained off.

Read-only terminal smoke checks exercised Preferences, Diagnostics and the action menu at 120x50 and 80x24. The guarded installer passed 25 isolated rollback tests. Earlier ASUS lock-screen face unlock was user-confirmed; no new biometric trial was performed for this UI update. These observations do not replace the remaining sensor-specific genuine/attack qualification or hosted CI.
