### PR TITLE
fix: isolate CI fixtures and disposable TPM coverage

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,4 +1,4 @@
-# Custom labels of the self-hosted runner fleet (archhost), so actionlint can
+# Custom labels of the self-hosted runner fleet (minihost and archhost), so actionlint can
 # validate runs-on lines instead of flagging them as unknown.
 self-hosted-runner:
   labels:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,9 @@ jobs:
 
       # --require names the set rather than counting it: renaming one of these
       # while adding another would leave the total intact and hide the loss.
+      - name: Disposable TPM wrapper lifecycle (no hardware)
+        run: python3 scripts/test-with-swtpm.py
+
       - name: test (TPM-gated, against swtpm)
         env:
           IRLUME_TCTI: swtpm:host=127.0.0.1,port=2321

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,14 +34,15 @@ concurrency:
 
 # Runner routing. irlume is a PUBLIC repo, so GitHub-hosted runners are free
 # and unmetered, and hosted jobs run in PARALLEL rather than queueing behind
-# each other on two machines. The rule is capability, not availability: a job
-# touches the maintainer's hardware only when it needs something that
-# hardware has. Every job in THIS file is hosted, which is what lets it stay
-# pull_request-triggered so fork PRs get the full required gate.
+# each other on two machines. Capability selects eligible runners; an available
+# eligible runner accepts each job. A job touches the maintainer's hardware
+# only when it needs something that hardware has. Every job in THIS file is
+# hosted, which lets it stay pull_request-triggered so fork PRs get the full
+# required gate.
 #
 # The hardware lanes live elsewhere and are push-triggered on purpose:
 #   hardware-checks.yml   real TPM + the pinned TFLite runtime, either machine
-#   hardware-suite.yml    the real IR camera, archhost only
+#   hardware-suite.yml    real IR camera + TPM, either capable machine
 #
 # Self-hosted runners are NOT an outage hedge: they still need the Actions
 # control plane to receive a job, and archhost's lane failed at "Set up job"

--- a/.github/workflows/hardware-suite.yml
+++ b/.github/workflows/hardware-suite.yml
@@ -1,6 +1,6 @@
-# Nightly hardware-in-the-loop suite on the self-hosted runner (archhost:
-# real TPM at /dev/tpmrm0 via the tss group, NexiGo N930W IR camera via the
-# video group). This exists because software fakes have proven blind spots:
+# Nightly hardware-in-the-loop suite on either capable self-hosted runner:
+# minihost or archhost, with a real TPM at /dev/tpmrm0 via the tss group
+# and an IR camera via the video group. Software fakes have proven blind spots:
 # the Tier-1 signed-PCR bug passed swtpm-based CI completely and only failed
 # on a real TPM, and the camera paths excluded from coverage are exactly the
 # ones a loopback device cannot exercise.
@@ -28,10 +28,8 @@ concurrency:
 jobs:
   hardware:
     name: build · test · real-TPM · IR camera
-    # `arch` pins this to archhost deliberately: minihost carries tpm and
-    # ir-camera too, and this suite's camera-absent path exits 0, so without
-    # the pin the ONLY real-IR-camera lane could land on the other machine
-    # and report green having tested no camera at all.
+    # Either available runner may take this lane when it carries every
+    # required capability label. Labels describe capabilities, not priority.
     runs-on: [self-hosted, arch, tpm, ir-camera]
     timeout-minutes: 90
     steps:
@@ -56,14 +54,16 @@ jobs:
       - name: test (hardware-independent set)
         run: ./scripts/run-tests-guarded.sh --min 650 -- cargo test --workspace --locked
 
-      # The same named tests ci.yml runs against swtpm, but with NO IRLUME_TCTI
-      # override, so they hit the real TPM (device:/dev/tpmrm0, the built-in
-      # default). Transient handles + round-trip verification only; validated
-      # non-destructive on this hardware during the seal-ladder campaigns.
+      # Explicitly select the real TPM for this hardware lane, independent
+      # of inherited runner environment. These exercise normal sealing, including creation/reuse of
+      # the dedicated persistent SRK; fixed-NV provisioning fixtures stay on
+      # disposable swtpm state below.
       # The count assertion this step used to carry now lives in the shared
       # guard, which names the set instead of counting it: renaming one of these
       # while adding another would leave the total at 4 and hide the loss.
       - name: test (TPM-gated, against the REAL TPM)
+        env:
+          IRLUME_TCTI: device:/dev/tpmrm0
         run: |
           ./scripts/run-tests-guarded.sh --require seal_unseal_roundtrip_real_tpm,arm_and_unseal_roundtrip,reseal_only_when_stale,tpm_key_and_recovery_lifecycle \
             -- cargo test -p irlume-core --lib --locked -- --ignored \
@@ -297,10 +297,8 @@ jobs:
   coverage:
     name: coverage (hardware-inclusive, nightly floor)
     needs: hardware
-    # `arch` pins this to archhost deliberately: minihost carries tpm and
-    # ir-camera too, and this suite's camera-absent path exits 0, so without
-    # the pin the ONLY real-IR-camera lane could land on the other machine
-    # and report green having tested no camera at all.
+    # Either available runner may take this lane when it carries every
+    # required capability label. Labels describe capabilities, not priority.
     runs-on: [self-hosted, arch, tpm, ir-camera]
     timeout-minutes: 90
     steps:
@@ -333,10 +331,17 @@ jobs:
           # would let the workspace run satisfy the minimum for every filtered
           # lane after it, which is the failure being guarded against.
           ./scripts/run-tests-guarded.sh --min 650 -- cargo llvm-cov --no-report --workspace --locked
-          ./scripts/run-tests-guarded.sh --require seal_unseal_roundtrip_real_tpm,arm_and_unseal_roundtrip,reseal_only_when_stale,tpm_key_and_recovery_lifecycle,tpm_tampered_seal_falls_back_then_recovery_heals,seal_unseal_pcrlock_roundtrip_provisioned_nv \
+          IRLUME_TCTI=device:/dev/tpmrm0 \
+            ./scripts/run-tests-guarded.sh --require seal_unseal_roundtrip_real_tpm,arm_and_unseal_roundtrip,reseal_only_when_stale,tpm_key_and_recovery_lifecycle,tpm_tampered_seal_falls_back_then_recovery_heals \
             -- cargo llvm-cov --no-report -p irlume-core --lib --locked -- --ignored \
             seal_unseal_roundtrip_real_tpm arm_and_unseal_roundtrip reseal_only_when_stale \
-            tpm_key_and_recovery_lifecycle tpm_tampered_seal_falls_back_then_recovery_heals seal_unseal_pcrlock_roundtrip_provisioned_nv --test-threads=1
+            tpm_key_and_recovery_lifecycle tpm_tampered_seal_falls_back_then_recovery_heals --test-threads=1
+          # This fixture replaces a fixed NV index. Preserve its coverage on
+          # disposable TPM state, never the runner's persistent hardware.
+          ./scripts/with-swtpm.sh \
+            ./scripts/run-tests-guarded.sh --require seal_unseal_pcrlock_roundtrip_provisioned_nv \
+            -- cargo llvm-cov --no-report -p irlume-core --lib --locked -- --ignored \
+            seal_unseal_pcrlock_roundtrip_provisioned_nv --test-threads=1
           ./scripts/run-tests-guarded.sh --min 15 -- cargo llvm-cov --no-report -p irlume-camera -p irlume-auth -p irlume-daemon --locked -- --ignored loopback_ --test-threads=1
           ./scripts/run-tests-guarded.sh --min 7 -- cargo llvm-cov --no-report -p irlume-cli --test cli_capture --locked -- --ignored loopback_ --test-threads=1
           ./scripts/run-tests-guarded.sh --min 5 -- cargo llvm-cov --no-report -p irlume-cli --test cli_bench --locked -- --ignored bench_ --test-threads=1

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -11613,6 +11613,9 @@ mod tests {
                 .any(|(_, m)| m.contains("scan added to 'Alice'")),
             "the kept scan must be acknowledged"
         );
+        // The terminal path refreshes daemon state. Finish those workers
+        // before releasing the socket guard to the next test.
+        drain_loads(&mut app);
     }
 
     #[test]
@@ -11655,6 +11658,9 @@ mod tests {
         app.on_key(KeyCode::Esc);
         assert!(app.enroll_merge.is_none(), "Esc declines");
         assert!(app.op.is_none());
+        // The terminal path refreshes daemon state. Finish those workers
+        // before releasing the socket guard to the next test.
+        drain_loads(&mut app);
     }
 
     // ---- enroll worker messages & the enroll key gate ----------------------
@@ -11717,6 +11723,9 @@ mod tests {
         assert!(app.enroll.is_none());
         let err = app.error.as_ref().expect("a failed scan must surface");
         assert_eq!(err, "Enrollment failed: camera busy");
+        // The terminal path refreshes daemon state. Finish those workers
+        // before releasing the socket guard to the next test.
+        drain_loads(&mut app);
     }
 
     /// Regression for #309: a framing guide that stops answering must not
@@ -11834,6 +11843,7 @@ mod tests {
 
     #[test]
     fn enroll_esc_cancels_and_signals_the_worker_to_stop() {
+        let _sock = dead_socket();
         let mut app = test_app();
         let (_tx, enroll) = fake_enroll(0, 4);
         let stop = enroll.stop.clone();
@@ -11853,6 +11863,7 @@ mod tests {
                 .any(|(_, m)| m.contains("enrollment cancelled")),
             "the cancel must be logged"
         );
+        drain_loads(&mut app);
     }
 
     // ---- rendering ---------------------------------------------------------
@@ -14109,6 +14120,7 @@ mod tests {
     /// natural next move.
     #[test]
     fn cancelling_an_enrolment_re_reads_the_profiles() {
+        let _sock = dead_socket();
         let mut app = test_app();
         let (_tx, rx) = mpsc::channel();
         app.enroll = Some(EnrollUi {
@@ -14131,6 +14143,7 @@ mod tests {
             app.profiles_load.is_some(),
             "and asks the daemon what the profile list is now"
         );
+        drain_loads(&mut app);
     }
 
     /// With the daemon down and nothing probed, the Repair tab must say it cannot

--- a/scripts/test-with-swtpm.py
+++ b/scripts/test-with-swtpm.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Exercise disposable TPM lifecycle without touching a hardware TPM."""
+import json
+import os
+from pathlib import Path
+import socket
+import subprocess
+import sys
+import tempfile
+import unittest
+
+SCRIPT = Path(__file__).with_name("with-swtpm.sh").resolve()
+
+
+class DisposableTpmTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory(prefix="irlume-swtpm-test-")
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.env = dict(os.environ, TMPDIR=str(self.root), IRLUME_TCTI="device:/dev/tpmrm0")
+        self.env.pop("IRLUME_SWTPM_PORT", None)
+
+    def run_wrapper(self, command, env=None):
+        return subprocess.run(["/bin/bash", str(SCRIPT), *command], env=env or self.env,
+                              text=True, capture_output=True, timeout=15)
+
+    def assert_clean(self, pid=None):
+        self.assertEqual(list(self.root.iterdir()), [])
+        if pid is not None:
+            with self.assertRaises(ProcessLookupError):
+                os.kill(pid, 0)
+
+    def test_requires_command(self):
+        result = self.run_wrapper([])
+        self.assertEqual(result.returncode, 2, result.stderr)
+        self.assertIn("Usage:", result.stderr)
+        self.assert_clean()
+
+    def test_missing_emulator_never_runs_command(self):
+        result = self.run_wrapper([sys.executable, "-c", "print('UNEXPECTED')"],
+                                  dict(self.env, PATH="/nonexistent"))
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("swtpm", result.stderr)
+        self.assertNotIn("UNEXPECTED", result.stdout)
+        self.assert_clean()
+
+    def test_success_and_failure_preserve_status_and_cleanup(self):
+        for status in (0, 23):
+            with self.subTest(status=status):
+                probe = """import json,os,pathlib,sys
+root=pathlib.Path(os.environ['TMPDIR'])
+states=list(root.glob('irlume-swtpm.*'))
+assert len(states)==1, states
+pid=int((states[0]/'pid').read_text())
+os.kill(pid,0)
+print(json.dumps({'tcti':os.environ['IRLUME_TCTI'],'pid':pid}))
+sys.exit(int(sys.argv[1]))
+"""
+                result = self.run_wrapper([sys.executable, "-c", probe, str(status)])
+                self.assertEqual(result.returncode, status, result.stderr)
+                observation = json.loads(result.stdout)
+                self.assertRegex(observation["tcti"], r"^swtpm:host=127\.0\.0\.1,port=[0-9]+$")
+                self.assert_clean(observation["pid"])
+
+    def test_occupied_port_never_runs_command_or_stops_existing_listener(self):
+        for control_port in (False, True):
+            with self.subTest(control_port=control_port), socket.socket() as listener:
+                listener.bind(("127.0.0.1", 0))
+                listener.listen()
+                occupied = listener.getsockname()[1]
+                port = occupied - 1 if control_port else occupied
+                result = self.run_wrapper([sys.executable, "-c", "print('UNEXPECTED')"],
+                                          dict(self.env, IRLUME_SWTPM_PORT=str(port)))
+                self.assertNotEqual(result.returncode, 0)
+                self.assertNotIn("UNEXPECTED", result.stdout)
+                # Still a functioning listener, not just a surviving descriptor.
+                with socket.create_connection(("127.0.0.1", occupied), timeout=1):
+                    peer, _ = listener.accept()
+                    peer.close()
+                self.assert_clean()
+
+    def test_invalid_port_never_runs_command(self):
+        for value in ("0", "65535", "abc", "2321,host=elsewhere"):
+            with self.subTest(value=value):
+                result = self.run_wrapper([sys.executable, "-c", "print('UNEXPECTED')"],
+                                          dict(self.env, IRLUME_SWTPM_PORT=value))
+                self.assertNotEqual(result.returncode, 0)
+                self.assertNotIn("UNEXPECTED", result.stdout)
+                self.assert_clean()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/with-swtpm.sh
+++ b/scripts/with-swtpm.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Run one command against fresh software TPM state. Never fall back to hardware.
+set -euo pipefail
+if [ "$#" -eq 0 ]; then
+  echo 'Usage: with-swtpm.sh COMMAND [ARG ...]' >&2
+  exit 2
+fi
+command -v swtpm >/dev/null || { echo 'with-swtpm: swtpm is required' >&2; exit 1; }
+port="${IRLUME_SWTPM_PORT:-$((20000 + RANDOM))}"
+if [[ ! "$port" =~ ^[0-9]{1,5}$ ]] || ((10#$port < 1 || 10#$port > 65534)); then
+  echo 'with-swtpm: port must be an integer from 1 to 65534' >&2
+  exit 2
+fi
+port=$((10#$port))
+state=$(mktemp -d "${TMPDIR:-/tmp}/irlume-swtpm.XXXXXXXX")
+swtpm_pid=''
+cleanup() {
+  local status=$?
+  trap - EXIT
+  if [ -n "$swtpm_pid" ]; then
+    kill "$swtpm_pid" 2>/dev/null || true
+    wait "$swtpm_pid" 2>/dev/null || true
+  fi
+  rm -rf -- "$state"
+  exit "$status"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+swtpm socket --tpm2 --tpmstate "dir=$state" \
+  --server "type=tcp,port=$port,bindaddr=127.0.0.1,disconnect" \
+  --ctrl "type=tcp,port=$((port + 1)),bindaddr=127.0.0.1" \
+  --flags not-need-init,startup-clear --pid "file=$state/pid" \
+  >"$state/startup.log" 2>&1 &
+swtpm_pid=$!
+# swtpm writes this marker only after binding BOTH sockets. A pre-existing
+# listener must never count as readiness, and its PID must never be killed.
+ready=false
+for _ in {1..100}; do
+  if [ -f "$state/pid" ] && [ "$(cat "$state/pid")" = "$swtpm_pid" ] && kill -0 "$swtpm_pid" 2>/dev/null; then
+    ready=true
+    break
+  fi
+  kill -0 "$swtpm_pid" 2>/dev/null || break
+  sleep 0.05
+done
+if [ "$ready" != true ]; then
+  cat "$state/startup.log" >&2
+  echo 'with-swtpm: emulator did not acquire its private endpoints' >&2
+  exit 1
+fi
+IRLUME_TCTI="swtpm:host=127.0.0.1,port=$port" "$@"
+# A command that never contacted its TPM must not hide emulator startup failure.
+kill -0 "$swtpm_pid" 2>/dev/null


### PR DESCRIPTION
## What & why

The scheduled hardware suite failed the strict accepted-framing socket assertion. Five other TUI tests could leave background daemon requests running against that mock socket; a controlled reproduction establishes this interference mechanism, although the historical log cannot identify the exact originating test. Keep the socket guard held and drain pending loads in five cancellation/terminal fixtures. A controlled baseline experiment reproduces the same strict socket assertion failure; the assertion and production enrollment behavior remain unchanged.

The nightly coverage lane also selected a fixture that replaces a fixed NV index on the physical TPM. Retain the five normal hardware tests on an explicit device transport and run the provisioning fixture against fresh swtpm state. The wrapper fails closed on startup/port conflicts, preserves command status, and cleans its process/state. Hosted CI exercises its lifecycle tests. All named tests and coverage floors remain required.

Keep capability-based routing shared between minihost and archhost; correct stale comments that described `arch` as an exclusive host label.

## Testing

- [x] `cargo test --workspace --locked --offline`: 2,211 passed, 106 existing opt-in ignores.
- [x] `cargo clippy --workspace --all-targets --locked --offline -- -D warnings`.
- [x] `cargo fmt --all -- --check` and `git diff --check`.
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --locked --offline`.
- Five existing fixture completion assertions failed before correction; final CLI suite: 499 passed. Controlled original cancellation interference causes the original strict framing assertion to fail; uninjected control passes.
- Five software-TPM wrapper tests pass, including occupied data/control ports, missing emulator, invalid port, failure status, and cleanup. Exact `seal_unseal_pcrlock_roundtrip_provisioned_nv` passes through the wrapper and named-test guard.
- Actionlint 1.7.12, zizmor 1.28.0 offline, ShellCheck, Python compilation, and all 52 action pins pass. Independent review found no blocking findings.
- All 16 checks on final head ac49ac3d passed. Normal push hardware checks passed on minihost for the implementation commit and archhost for the final comment-only commit. ASan passed on the implementation commit; the comment-only update did not match its path filter.
- No installed changes or local physical TPM/camera tests. Full nightly physical coverage remains pending the normal scheduled lane. No user-facing product changes.
