### PR TITLE
deps: update Nix inputs from validated monthly refresh

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785454630,
-        "narHash": "sha256-LQy14TZp77TwbQf40gg1V3jo8FwJG0jGDkAH+zRHqg8=",
+        "lastModified": 1788179007,
+        "narHash": "sha256-hn1oU2rue2SYK8dAr8+WNZWtbsz1S2W5mnHlSEuh3bo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1559d3daa3ecc813a650b79375ea61b6741b8746",
+        "rev": "34ab99075ac4f7e40cf037eef32cb1c360bb85e9",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785562362,
-        "narHash": "sha256-J15aBa3d6B1SUUAQydQ06wFjPzrrcVceb6jkdfwfGls=",
+        "lastModified": 1788248235,
+        "narHash": "sha256-siCQqLbY7AbZ9V3oyc65K8bhNr7QgZTXoqLTws3pv0s=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "5f29c219a7655519f8a9f8c6968064b82c17cc93",
+        "rev": "6a84c41e705533dcc5569ac0731f18406b4cdf86",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What & why

Bring the retained September `deps/update-flake-lock` refresh onto current main. This copies the exact validated lockfile from `0ad7bf14a768829394ae60be29a79f75dff2bc0c` into a signed, DCO-compliant commit based on PR #684's merge.

Only the revision, content hash and timestamp for `nixpkgs` and `rust-overlay` change. The input graph, other pins, application source and Cargo lockfile remain unchanged. The monthly updater branch is preserved for its next scheduled refresh.

## Testing

- [x] Unchanged-main baseline: `nix flake check --no-build --show-trace`.
- [x] Candidate: `nix flake check --no-build --show-trace` (x86_64-linux; other systems excluded by the command).
- [x] `nix build --no-link .#default.cargoDeps .#onnxruntime-bin`.
- [x] Structural lockfile review: exactly two locked inputs change, only their revision/hash/timestamp; candidate byte-identical to the retained refresh.
- [x] `git diff --check`, signed commit and exactly one DCO trailer.

No runtime deployment or hardware testing was performed locally. Normal PR checks must pass before merge.
