### PR TITLE
Qualify 0.12.0 upgrades and fix release integration defects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,11 @@ jobs:
       - name: Disposable TPM wrapper lifecycle (no hardware)
         run: python3 scripts/test-with-swtpm.py
 
+      - name: Upgrade harness regressions (no package or authentication changes)
+        run: |
+          python3 scripts/test-package-upgrade-harness.py
+          python3 scripts/test-check-upgrade-auth.py
+
       - name: test (TPM-gated, against swtpm)
         env:
           IRLUME_TCTI: swtpm:host=127.0.0.1,port=2321

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -14,6 +14,12 @@ upstream_tag_template: "v{version}"
 # Anchored with re.match, so a tag not starting with vN.N.N is not a candidate.
 upstream_tag_include: 'v\d+\.\d+\.\d+$'
 
+# Read the checked-out spec version for PR candidates; git describe otherwise
+# keeps the latest published version even after the workspace version changes.
+actions:
+  get-current-version:
+    - grep -oP '^Version:\s+\K\S+' packaging/fedora/irlume.spec
+
 jobs:
   - job: copr_build
     trigger: release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1015,7 +1015,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-auth"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "irlume-camera",
  "irlume-common",
@@ -1029,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-camera"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "irlume-common",
  "libc",
@@ -1042,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-cli"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "image",
  "irlume-auth",
@@ -1064,7 +1064,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-common"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "libc",
  "serde",
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-core"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-daemon"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "dbus",
  "irlume-auth",
@@ -1113,11 +1113,11 @@ dependencies = [
 
 [[package]]
 name = "irlume-fingerprint"
-version = "0.11.3"
+version = "0.12.0"
 
 [[package]]
 name = "irlume-gkr-unlock"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "irlume-common",
  "libc",
@@ -1125,7 +1125,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-kwallet-init"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "irlume-common",
  "libc",
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-liveness"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "irlume-common",
  "irlume-vision",
@@ -1142,7 +1142,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-pam"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "irlume-common",
  "libc",
@@ -1153,7 +1153,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-password-verify"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "libc",
  "tempfile",
@@ -1162,7 +1162,7 @@ dependencies = [
 
 [[package]]
 name = "irlume-vision"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "edgefirst-tflite",
  "irlume-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.11.3"
+version = "0.12.0"
 edition = "2021"
 rust-version = "1.88"
 license = "GPL-3.0-or-later"

--- a/docs/PLATFORMS.md
+++ b/docs/PLATFORMS.md
@@ -21,6 +21,14 @@ Every lane is x86_64 only today (Copr chroots, PPA, `.deb`, and the AUR
 `arch=` line all say so). No aarch64 build exists yet; the blocker is an
 arm64 onnxruntime + rebuild validation, not anything in the code.
 
+## Release upgrade validation
+
+Package builds and clean-install checks do not establish upgrade or rollback
+behavior. Follow [Package upgrade and rollback validation](UPGRADE-VALIDATION.md)
+for the disposable Debian/Ubuntu, Arch, and Fedora guest procedure, authentication
+checks, recovery steps, and evidence limits. A passing package transaction does
+not extend the hardware or login-manager qualification described below.
+
 ## Validated on real hardware
 
 | Platform | Machine / camera | Tier | What was actually exercised |

--- a/docs/UPGRADE-VALIDATION.md
+++ b/docs/UPGRADE-VALIDATION.md
@@ -1,0 +1,194 @@
+# Package upgrade and rollback validation
+
+[`scripts/test-package-upgrade.py`](../scripts/test-package-upgrade.py) exercises
+four real package transactions in one disposable systemd guest:
+
+1. Install the old package (`old-install`).
+2. Upgrade to the candidate (`candidate-upgrade`).
+3. Restore the complete old package (`old-rollback`).
+4. Upgrade to the candidate again (`candidate-reupgrade`).
+
+The current harness requires upstream versions **0.11.3 → 0.12.0 → 0.11.3 →
+0.12.0**. It checks package metadata and installed CLI versions; renaming an
+artifact does not change its version. For a later release pair, review and
+update the harness's version and state-format assertions before running it.
+This document describes a procedure, not a completed qualification result.
+
+## Prepare an isolated guest
+
+Use a fresh x86_64 QEMU/KVM VM for each package lane. Give it task-owned disks,
+systemd as the running service manager, and no pre-existing Irlume installation.
+Do not attach host cameras, physical TPMs, USB devices, shared folders, host
+credential directories, or an SSH agent. Use an emulated TPM only if needed.
+Transfer public packages and reviewed scripts over the guest's dedicated access
+channel; keep host private keys outside the guest.
+
+The guard requires effective UID 0, `systemd-detect-virt --vm` reporting `qemu`
+or `kvm`, and an exact root-controlled marker. **The marker is the operator's
+attestation; it cannot prove isolation or detect device passthrough.** Inspect
+the VM configuration before creating it. Containers and ordinary host execution
+are refused.
+
+Prepare these prerequisites inside the guest before taking a clean snapshot:
+
+- Python 3.9 or newer; systemd tools, working distribution repositories, and the
+  runtime dependencies of both package versions. The harness does not bootstrap
+  its tools or repair a broken package database.
+- Debian/Ubuntu: `apt-get`, `dpkg-deb`, and `dpkg-query`. Arch: `pacman`, `tar`,
+  and zstd support. Fedora: DNF5, RPM, `getenforce`, and `semodule`, with SELinux
+  **Enforcing** throughout the run.
+- For authentication checks: `pamtester` with the 0.1.2 exit-status contract,
+  `useradd`, `chpasswd`, `sudo`, NSS account/group lookup, and an active
+  `ssh.service` or `sshd.service`. If a distribution does not package pamtester,
+  build an authenticated source archive inside the guest and record its digest.
+  `/usr/local/bin` must exist, be root-owned, and not be group/other-writable;
+  the checker validates its ancestors as well.
+- An independent non-root account named `qualifier`, with its own working SSH
+  login, nonempty `~/.ssh/authorized_keys`, and `sudo -n true` access. Keep that
+  administrative connection available. Do not pre-create the checker's separate
+  `irlume-upgrade-fixture` account or its private files.
+
+Preserve the distribution's service security settings. Do not disable
+AppArmor/SELinux, loosen systemd confinement, or add privileged device access to
+make a failing transaction appear qualified.
+
+## Stage verified inputs
+
+Verify package provenance and digests before staging them. For published Debian
+and Arch release assets, use the repository's
+[`verify-release-assets.py`](../scripts/verify-release-assets.py) with the trusted
+release signing key. Record the candidate source revision, build provenance,
+package metadata, and digests separately from this generic procedure.
+
+For Fedora, obtain **both** `irlume` and `irlume-selinux` RPMs for each version
+and the target Fedora release. The main package must be x86_64 and the policy
+package noarch; each pair must have exactly matching version-release metadata.
+Import the applicable public Copr signing key into the guest only after checking
+its fingerprint against a trusted source; keep that verification receipt.
+Every DNF5 transaction enables `localpkg_gpgcheck=True`. An unsigned RPM or an
+unknown signing key is a failure, not a reason to disable the check.
+
+Run the following **only in a root shell inside the inspected disposable VM**:
+
+```sh
+install -d -m 0755 /var/tmp/irlume-upgrade-input
+install -d -m 0700 /var/tmp/irlume-upgrade-output
+umask 077
+(set -C; printf '%s' 'irlume-upgrade-20260910' > /run/irlume-upgrade-disposable)
+```
+
+The marker has no trailing newline. Copy the reviewed harness and
+[`check-upgrade-auth.py`](../scripts/check-upgrade-auth.py), plus the verified
+packages, into `/var/tmp/irlume-upgrade-input`. Use real files and absolute paths;
+the harness refuses symlink inputs or ancestors. The filenames below are staging
+names: preserve the package extension and use the correct verified contents.
+
+Take a snapshot before the first transaction, while no Irlume or authentication
+fixtures are installed. Include the guest's emulated TPM state in the recovery
+plan if present. `/run` is volatile, so re-create the exact marker after a reboot
+only after rechecking that this is still the intended isolated guest.
+
+## Run one lane
+
+Each command below runs all four stages. Choose one command for the guest's
+distribution; every output filename and its `.log` sibling must be new. The
+output directory must already exist and have no symlink ancestors.
+
+Debian/Ubuntu:
+
+```sh
+python3 /var/tmp/irlume-upgrade-input/test-package-upgrade.py \
+  --old /var/tmp/irlume-upgrade-input/old.deb \
+  --candidate /var/tmp/irlume-upgrade-input/candidate.deb \
+  --stage-check /var/tmp/irlume-upgrade-input/check-upgrade-auth.py \
+  --output /var/tmp/irlume-upgrade-output/debian.json
+```
+
+Arch:
+
+```sh
+python3 /var/tmp/irlume-upgrade-input/test-package-upgrade.py \
+  --old /var/tmp/irlume-upgrade-input/old.pkg.tar.zst \
+  --candidate /var/tmp/irlume-upgrade-input/candidate.pkg.tar.zst \
+  --stage-check /var/tmp/irlume-upgrade-input/check-upgrade-auth.py \
+  --output /var/tmp/irlume-upgrade-output/arch.json
+```
+
+Fedora:
+
+```sh
+python3 /var/tmp/irlume-upgrade-input/test-package-upgrade.py \
+  --old /var/tmp/irlume-upgrade-input/old.rpm \
+  --candidate /var/tmp/irlume-upgrade-input/candidate.rpm \
+  --old-selinux /var/tmp/irlume-upgrade-input/old-selinux.rpm \
+  --candidate-selinux /var/tmp/irlume-upgrade-input/candidate-selinux.rpm \
+  --stage-check /var/tmp/irlume-upgrade-input/check-upgrade-auth.py \
+  --output /var/tmp/irlume-upgrade-output/fedora.json
+```
+
+The harness uses apt with downgrade and conffile-preservation options, pacman
+`-U`, or DNF5 `install`/`upgrade`/`downgrade`/`upgrade` with both RPMs together.
+Package transactions have a 900-second timeout, daemon readiness a 120-second
+budget, and each optional stage checker a 180-second timeout. Omitting
+`--stage-check` omits authentication qualification and is recorded in the JSON.
+
+## Interpret results and recover
+
+Require a zero exit status, top-level `passed: true`, and four passing stage
+receipts. Inspect each stage's authentication result and limitations as well.
+Package-manager success alone is insufficient: the harness checks installed
+versions, a ready daemon Ping response, PID replacement, the running executable's
+digest, required payload modes, and preservation of configuration and synthetic
+state. Old-package files must return byte-for-byte with their original modes and
+owners. Debian's explicitly declared obsolete candidate conffiles may remain;
+they are checked and reported separately. Fedora checks both installed RPMs,
+enforcing mode, and presence of the enabled Irlume policy module.
+Reviewed tmpfiles tightening of the state root's group/other permissions is
+allowed; synthetic descendant metadata must remain unchanged.
+
+The authentication checker creates a throwaway account, a private PAM service,
+and a randomly generated guest-only password. It tests correct and incorrect
+password fallback at every stage, plus candidate retry status and reset behavior
+when available. Passwords travel over stdin and stay inside
+`/var/tmp/irlume-upgrade-private`; never print, copy, or publish that directory.
+
+Export **only the sanitized JSON receipt** for shared evidence. Raw package
+output and service diagnostics remain in the guest's `.log` file. Do not export
+guest journals, account databases, private fixture manifests, or disk snapshots
+as ordinary report attachments. Retain the exact artifact digests and build
+provenance alongside the receipt.
+
+On failure, stop and inspect the guest locally. The harness leaves the failed
+stage's state intact; terminating a timed-out process group cannot undo writes
+already applied by a package transaction. It performs no automatic repair,
+removal, or purge. Recover by restoring the known clean VM snapshot or creating
+a new disposable guest, then run the full sequence with a fresh output path.
+Do not delete individual fixture files or restart the sequence on a partially
+tested installation. Discard only the task-owned guest after preserving the
+sanitized evidence.
+
+## Qualification limits
+
+- Synthetic configuration, state bytes, and retry records establish preservation
+  of those fixtures. They do not establish cryptographic enrollment usability,
+  TPM-sealed credential recovery, camera behavior, liveness, or biometric login.
+- Version 0.11.3 has no retry enforcement. Retaining candidate retry files during
+  rollback does not mean that the old daemon enforces their limits.
+- An enforcing AppArmor installation can intentionally report password-verified
+  retry reset unavailable. Record that limitation; password fallback is tested
+  separately. Do not turn off confinement to change the outcome.
+- The transaction sequence covers the package's enabled, running service path
+  and checks that its enabled state remains unchanged. It does not qualify an
+  administrator-disabled or stopped-service upgrade, a wired graphical greeter,
+  or every login manager. An enabled SELinux module listing does not prove its
+  live byte equivalence or confined greeter access.
+- A separate Nix profile generation rollback is not a NixOS system-generation,
+  module, service, PAM, or hardware qualification. This package harness does not
+  implement a NixOS transaction. See [NIXOS.md](NIXOS.md) for that integration.
+
+Run the local harness regressions without installing any packages:
+
+```sh
+python3 scripts/test-package-upgrade-harness.py
+python3 scripts/test-check-upgrade-auth.py
+```

--- a/docs/UPGRADE-VALIDATION.md
+++ b/docs/UPGRADE-VALIDATION.md
@@ -23,8 +23,9 @@ credential directories, or an SSH agent. Use an emulated TPM only if needed.
 Transfer public packages and reviewed scripts over the guest's dedicated access
 channel; keep host private keys outside the guest.
 
-The guard requires effective UID 0, `systemd-detect-virt --vm` reporting `qemu`
-or `kvm`, and an exact root-controlled marker. **The marker is the operator's
+The guard requires effective UID 0, unfiltered `systemd-detect-virt` reporting
+`qemu` or `kvm` as the innermost environment, and an exact root-controlled marker.
+**The marker is the operator's
 attestation; it cannot prove isolation or detect device passthrough.** Inspect
 the VM configuration before creating it. Containers and ordinary host execution
 are refused.

--- a/flake.nix
+++ b/flake.nix
@@ -129,6 +129,12 @@
           assert authCtl "swaylock" == "sufficient";
           assert authCtl "hyprlock" == "sufficient";
           assert sys.config.systemd.services.irlumed.environment.IRLUME_SOCKET == "/run/irlume.sock";
+          # These shipped PAD cues default to /etc/irlume in the daemon.
+          # A NixOS service must resolve them from its selected package too.
+          assert (sys.config.systemd.services.irlumed.environment.IRLUME_VIT_PAD_MODEL or null)
+            == "${sys.config.services.irlume.package}/share/irlume/models/liveness_vit.onnx";
+          assert (sys.config.systemd.services.irlumed.environment.IRLUME_PAD_IR_MODEL or null)
+            == "${sys.config.services.irlume.package}/share/irlume/models/flir.onnx";
           pkgs.runCommand "irlume-module-checks-ok" { } "echo 'irlume module PAM decision table verified' > $out";
 
         devShells.default = pkgs.mkShell {

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -308,6 +308,9 @@ in
         # native default.
         IRLUME_MESH_MODEL = "${models}/face_landmark.onnx";
         IRLUME_BLAZE_MODEL = "${models}/blaze_face_short_range.onnx";
+        # PAD cues are shipped in the package, not the daemon's /etc defaults.
+        IRLUME_VIT_PAD_MODEL = "${models}/liveness_vit.onnx";
+        IRLUME_PAD_IR_MODEL = "${models}/flir.onnx";
         IRLUME_SOCKET = "/run/irlume.sock";
         IRLUME_RGB_DEVICE = cfg.rgbDevice;
         IRLUME_IR_DEVICE = cfg.irDevice;

--- a/packaging/apparmor/usr.bin.irlumed
+++ b/packaging/apparmor/usr.bin.irlumed
@@ -174,6 +174,9 @@ profile irlumed /usr/bin/irlumed flags=(attach_disconnected) {
   /var/lib/ r,
   /proc/sys/kernel/random/boot_id r,
   /var/lib/irlume/retry/ rwk,
+  # Per-account operation locks serialize face requests and retry recovery;
+  # the directory lock above does not grant flock on these regular files.
+  /var/lib/irlume/retry/*.operation rwk,
   /var/lib/irlume/ rw,
   /var/lib/irlume/** rw,
 

--- a/packaging/apparmor/usr.local.bin.irlumed
+++ b/packaging/apparmor/usr.local.bin.irlumed
@@ -136,6 +136,9 @@ profile irlumed /usr/local/bin/irlumed {
   /var/lib/ r,
   /proc/sys/kernel/random/boot_id r,
   /var/lib/irlume/retry/ rwk,
+  # Per-account operation locks serialize face requests and retry recovery;
+  # the directory lock above does not grant flock on these regular files.
+  /var/lib/irlume/retry/*.operation rwk,
   /var/lib/irlume/ rw,
   /var/lib/irlume/** rw,
 

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: archledger <archledger236@gmail.com>
 pkgname=irlume
-pkgver=0.11.3
+pkgver=0.12.0
 pkgrel=1
 pkgdesc="Windows Hello-style face login for Linux: IR cameras, consent-gated, photo-spoofing resistant, TPM-sealed, password always works"
 arch=('x86_64')

--- a/packaging/debian/nfpm.yaml
+++ b/packaging/debian/nfpm.yaml
@@ -6,7 +6,7 @@
 name: irlume
 arch: amd64
 platform: linux
-version: 0.11.3
+version: 0.12.0
 section: admin
 priority: optional
 maintainer: archledger <archledger236@gmail.com>

--- a/packaging/fedora/irlume.spec
+++ b/packaging/fedora/irlume.spec
@@ -2,7 +2,7 @@
 %global ort_ver 1.28.1
 
 Name:           irlume
-Version:        0.11.3
+Version:        0.12.0
 Release:        1%{?dist}
 Summary:        Windows Hello-style face login for Linux
 

--- a/scripts/check-packaging-parity.sh
+++ b/scripts/check-packaging-parity.sh
@@ -402,6 +402,8 @@ APPARMOR_RUNTIME_RULES=(
   "/var/lib/irlume/ir-emitter-stream/*.lock rwk,"
   "/etc/irlume/*.lock rwk,"
   "/var/lib/irlume/capture-qualifications/*.lock rwk,"
+  "/var/lib/irlume/retry/ rwk,"
+  "/var/lib/irlume/retry/*.operation rwk,"
 )
 for profile in "${APPARMOR_PROFILES[@]}"; do
   for rule in "${APPARMOR_RUNTIME_RULES[@]}"; do

--- a/scripts/check-packaging-parity.sh
+++ b/scripts/check-packaging-parity.sh
@@ -240,6 +240,13 @@ for v in "$spec_v" "$arch_v" "$nfpm_v"; do
     fail=1
   fi
 done
+# Packit otherwise uses the latest release tag and silently relabels a newer
+# candidate as that old version. Require the documented spec-version action;
+# the spec/Cargo comparison above then covers the value Packit consumes.
+if ! grep -Fq "    - grep -oP '^Version:\\s+\\K\\S+' packaging/fedora/irlume.spec" .packit.yaml; then
+  echo "  ERROR: Packit must obtain its candidate version from the specfile"
+  fail=1
+fi
 # The PPA and Nix derive their version from Cargo.toml rather than repeating it,
 # which is why they are not compared here. Assert that, so a future edit that
 # hardcodes one starts being checked instead of silently drifting.

--- a/scripts/check-upgrade-auth.py
+++ b/scripts/check-upgrade-auth.py
@@ -70,7 +70,9 @@ def command(argv, *, input_text=None, capture=True, account=None):
 
 def admit_guest():
     require(os.geteuid() == 0, "root-required")
-    code, kind = command(["systemd-detect-virt", "--vm"])
+    # Unfiltered detection reports the innermost environment. --vm would hide
+    # a container inside QEMU and incorrectly admit its shared-kernel boundary.
+    code, kind = command(["systemd-detect-virt"])
     kind = kind.strip()
     require(code == 0 and kind in ("qemu", "kvm"), "qemu-kvm-required")
     try:

--- a/scripts/check-upgrade-auth.py
+++ b/scripts/check-upgrade-auth.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Bounded authentication checks for the marked disposable upgrade guests only.
+
+Never invoke this on an installed host. The guard runs before any mutation.
+No enrollment, biometric template, recovery envelope or physical device is used.
+
+Source contract at candidate bf323a7e:
+* crates/irlume-daemon/src/retry_throttle.rs: Record v2, FaceBudget, Store::path.
+* crates/irlume-daemon/src/retry_throttle/recovery.rs: Attempts v1, status/reset.
+* crates/irlume-cli/src/retry.rs and main.rs::read_password: CLI and stdin.
+* crates/irlume-daemon/src/retry_recovery.rs: packaged password-helper gate.
+The v0.11.3 tree has no retry_throttle/retry_recovery or retry CLI. Synthetic
+counter preservation does not establish enforcement by that old release, nor
+biometric enrollment usability. Counter fixtures deliberately avoid cooldowns
+and pending operations, which status can legitimately settle or rewrite.
+"""
+import fcntl
+import hashlib
+import json
+import os
+from pathlib import Path
+import pwd
+import re
+import resource
+import secrets
+import shutil
+import stat
+import subprocess
+import sys
+
+STAGES = ("old-install", "candidate-upgrade", "old-rollback", "candidate-reupgrade")
+MARKER = Path("/run/irlume-upgrade-disposable")
+MARKER_BYTES = b"irlume-upgrade-20260910"
+PRIVATE = Path("/var/tmp/irlume-upgrade-private")
+USER = "irlume-upgrade-fixture"
+ADMIN = "qualifier"
+SERVICE = "irlume-upgrade-fallback"
+PAM = Path("/etc/pam.d") / SERVICE
+RETRY = Path("/var/lib/irlume/retry")
+ENV = {"PATH": "/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "LANG": "C", "LC_ALL": "C", "HOME": "/"}
+
+
+class Failure(Exception):
+    """Only fixed, non-sensitive assertion identifiers may be reported."""
+
+
+def require(condition, code):
+    if not condition:
+        raise Failure(code)
+
+
+def command(argv, *, input_text=None, capture=True, account=None):
+    options = {}
+    if account is not None:
+        options = {"user": account.pw_uid, "group": account.pw_gid,
+                   "extra_groups": os.getgrouplist(account.pw_name, account.pw_gid)}
+    try:
+        result = subprocess.run(
+            argv, input=input_text, text=True, env=ENV, cwd="/", timeout=45,
+            stdout=subprocess.PIPE if capture else subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL, **options,
+        )
+    except subprocess.TimeoutExpired:
+        raise Failure("command-timeout") from None
+    except OSError:
+        raise Failure("command-unavailable") from None
+    return result.returncode, result.stdout if capture else ""
+
+
+def admit_guest():
+    require(os.geteuid() == 0, "root-required")
+    code, kind = command(["systemd-detect-virt", "--vm"])
+    kind = kind.strip()
+    require(code == 0 and kind in ("qemu", "kvm"), "qemu-kvm-required")
+    try:
+        fd = os.open(MARKER, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
+        with os.fdopen(fd, "rb") as stream:
+            meta = os.fstat(stream.fileno())
+            require(stat.S_ISREG(meta.st_mode), "marker-not-regular")
+            require(meta.st_uid == 0 and meta.st_mode & 0o022 == 0, "marker-owner-or-mode")
+            marker = stream.read(len(MARKER_BYTES) + 1)
+    except OSError:
+        raise Failure("marker-unreadable-or-symlink") from None
+    require(marker == MARKER_BYTES, "marker-mismatch")
+    return kind
+
+
+def trusted_directory(path, mode=None):
+    # Check every ancestor; /var/tmp is the sole intentionally world-writable
+    # ancestor. The private child is created exclusively and must remain 0700.
+    for item in (path, *path.parents):
+        meta = item.lstat()
+        require(stat.S_ISDIR(meta.st_mode) and meta.st_uid == 0,
+                "directory-owner-or-type")
+        if item == Path("/var/tmp"):
+            require(bool(meta.st_mode & stat.S_ISVTX), "private-parent-not-sticky")
+        else:
+            require(meta.st_mode & 0o022 == 0, "directory-writable")
+    if mode is not None:
+        require(path.stat().st_mode & 0o7777 == mode, "directory-mode")
+
+
+def create_private(path, payload):
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600)
+    with os.fdopen(fd, "wb") as stream:
+        stream.write(payload)
+        stream.flush()
+        os.fsync(stream.fileno())
+
+
+def read_private(path):
+    fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
+    with os.fdopen(fd, "rb") as stream:
+        meta = os.fstat(stream.fileno())
+        require(stat.S_ISREG(meta.st_mode) and meta.st_uid == 0
+                and meta.st_mode & 0o7777 == 0o600 and meta.st_nlink == 1
+                and meta.st_size <= 65536, "private-file-metadata")
+        return stream.read(65537)
+
+
+def save_manifest(manifest):
+    target = PRIVATE / "manifest.json"
+    temp = PRIVATE / ("manifest-" + secrets.token_hex(8))
+    create_private(temp, json.dumps(manifest, sort_keys=True).encode())
+    os.replace(temp, target)
+
+
+def check_stage(stage, previous):
+    index = STAGES.index(stage)
+    expected = STAGES[index - 1] if index else None
+    require(previous == expected, "stage-order")
+
+
+def admin_identity():
+    account = pwd.getpwnam(ADMIN)
+    require(account.pw_uid != 0 and account.pw_name != USER, "independent-admin-required")
+    require(command(["sudo", "-n", "true"], capture=False, account=account)[0] == 0,
+            "independent-admin-sudo-failed")
+    require(any(command(["systemctl", "is-active", "--quiet", service], capture=False)[0] == 0
+                for service in ("ssh.service", "sshd.service")), "admin-ssh-service-inactive")
+    # The parent's live SSH session remains the access qualification. Check the
+    # account and authorized keys remain the same without emitting their content.
+    keys = Path(account.pw_dir) / ".ssh/authorized_keys"
+    require(keys.is_file() and keys.stat().st_size > 0, "admin-ssh-key-missing")
+    return {"uid": account.pw_uid, "gid": account.pw_gid,
+            "home": account.pw_dir, "shell": account.pw_shell,
+            "groups": sorted(os.getgrouplist(ADMIN, account.pw_gid)),
+            "keys_sha256": hashlib.sha256(keys.read_bytes()).hexdigest()}
+
+
+def packaged_module():
+    if shutil.which("dpkg-query", path=ENV["PATH"]):
+        code, files = command(["dpkg-query", "-L", "irlume"])
+    elif shutil.which("pacman", path=ENV["PATH"]):
+        code, files = command(["pacman", "-Qlq", "irlume"])
+    elif shutil.which("rpm", path=ENV["PATH"]):
+        code, files = command(["rpm", "-ql", "irlume"])
+    else:
+        raise Failure("unsupported-package-manager")
+    require(code == 0, "installed-package-query-failed")
+    paths = [Path(line) for line in files.splitlines()
+             if line.startswith("/") and line.endswith("/security/pam_irlume.so")]
+    require(len(paths) == 1, "packaged-pam-module-ambiguous")
+    module = paths[0]
+    require(module.is_file() and module.stat().st_size > 0, "packaged-pam-module-missing")
+    require(module.stat().st_uid == 0 and module.stat().st_mode & 0o022 == 0,
+            "packaged-pam-module-permissions")
+    return module
+
+
+def pam_contents(module):
+    return (f"auth sufficient {module}\nauth required pam_unix.so\n"
+            "account required pam_unix.so\n").encode()
+
+
+def pam_checks(password):
+    results = []
+    # pamtester 0.1.2 app.c:273-275,462 maps PAM rejection to exit 1;
+    # pamtester.c:238-243 returns it unchanged. Signals/other exits are not
+    # evidence of password rejection, even after the positive control passed.
+    for supplied, expected in ((password, 0), ("wrong-" + password, 1)):
+        code, _ = command(["pamtester", SERVICE, USER, "authenticate", "acct_mgmt"],
+                          input_text=supplied + "\n", capture=False)
+        require(code == expected,
+                "pam-correct-password-refused" if expected == 0
+                else "pam-wrong-password-rejection-unconfirmed")
+        results.append(code)
+    return {"correct_password_exit": results[0], "wrong_password_exit": results[1]}
+
+
+def retry_records(uid):
+    return {
+        f"{uid}.json": {"version": 2, "uid": uid, "account": USER, "strikes": 2,
+                        "cooldown": None,
+                        "budget": {"unsuccessful_requests": 7, "pending": False}},
+        f"{uid}.reset.json": {"version": 1, "uid": uid, "account": USER,
+                              "failures": 0, "pending": False, "cooldown": None},
+    }
+
+
+def retry_fingerprints(uid):
+    result = {}
+    for name in retry_records(uid):
+        payload = read_private(RETRY / name)
+        result[name] = hashlib.sha256(payload).hexdigest()
+    return result
+
+
+def seed_retry(uid):
+    trusted_directory(RETRY.parent)
+    if not RETRY.exists():
+        RETRY.mkdir(mode=0o700)
+    trusted_directory(RETRY, 0o700)
+    # Same directory flock as the daemon's Store::lock. Only nonexistent files
+    # for this newly created account are written, never a pre-existing record.
+    fd = os.open(RETRY, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        records = retry_records(uid)
+        require(all(not (RETRY / name).exists() and not (RETRY / name).is_symlink()
+                    for name in records), "retry-record-already-exists")
+        for name, record in records.items():
+            create_private(RETRY / name, json.dumps(record, separators=(",", ":")).encode())
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+    return retry_fingerprints(uid)
+
+
+def check_status(output, strikes, budget, recovery):
+    # Full lines distinguish prospective/unknown history from measured counts.
+    pattern = (
+        rf"Face retry state for '{re.escape(USER)}': {strikes} recorded failures, 0s cooldown\.\n"
+        rf"Cumulative face requests: {budget}/50 consecutive unsuccessful; available after any cooldown\.\n"
+        rf"Password-verified retry reset: (available for supported local accounts|unavailable on this installation); "
+        rf"{recovery} failed checks, 0s cooldown\.\nOrdinary password login remains available\.\n?"
+    )
+    match = re.fullmatch(pattern, output)
+    require(match is not None, "retry-status-mismatch")
+    return match.group(1) == "available for supported local accounts"
+
+
+def status(account, strikes=2, budget=7, recovery=1):
+    code, output = command(["irlume", "retry", "status", "--user", USER], account=account)
+    require(code == 0, "retry-status-command-failed")
+    return check_status(output, strikes, budget, recovery)
+
+
+def run_stage(stage, report):
+    # All subprocesses inherit this no-core policy after admission, so accidental
+    # child failure cannot leave a password-bearing core in exported evidence.
+    resource.setrlimit(resource.RLIMIT_CORE, (0, 0))
+    os.umask(0o077)
+    require(not list(Path("/dev").glob("video*")), "camera-device-present")
+    trusted_directory(Path("/usr/local/bin"))
+    for name in ("pamtester", "useradd", "chpasswd", "irlume", "sudo", "systemctl"):
+        require(shutil.which(name, path=ENV["PATH"]) is not None, "guest-dependency-missing")
+    admin = admin_identity()
+    module = packaged_module()
+    trusted_directory(PAM.parent)
+    expected_pam = pam_contents(module)
+    if stage == "old-install":
+        require(not PRIVATE.exists() and not PRIVATE.is_symlink(), "fixture-already-exists")
+        require(not PAM.exists() and not PAM.is_symlink(), "pam-fixture-already-exists")
+        try:
+            pwd.getpwnam(USER)
+        except KeyError:
+            pass
+        else:
+            raise Failure("fixture-account-already-exists")
+        trusted_directory(PRIVATE.parent)
+        PRIVATE.mkdir(mode=0o700)
+        trusted_directory(PRIVATE, 0o700)
+        password = secrets.token_urlsafe(36)
+        create_private(PRIVATE / "password", password.encode())
+        require(command(["useradd", "--no-create-home", "--shell", "/bin/sh", "--", USER],
+                        capture=False)[0] == 0, "fixture-account-create-failed")
+        require(command(["chpasswd"], input_text=f"{USER}:{password}\n", capture=False)[0] == 0,
+                "fixture-password-setup-failed")
+        create_private(PAM, expected_pam)
+        # PAM configuration need not be private, but keeping this fixture 0600
+        # is sufficient because these pamtester transactions execute as root.
+        account = pwd.getpwnam(USER)
+        manifest = {"stage": None, "uid": account.pw_uid, "gid": account.pw_gid, "admin": admin}
+    else:
+        trusted_directory(PRIVATE, 0o700)
+        manifest = json.loads(read_private(PRIVATE / "manifest.json"))
+        check_stage(stage, manifest["stage"])
+        password = read_private(PRIVATE / "password").decode("ascii")
+        account = pwd.getpwnam(USER)
+        require(account.pw_uid == manifest["uid"] and account.pw_gid == manifest["gid"],
+                "fixture-account-changed")
+        require(admin == manifest["admin"], "independent-admin-changed")
+        require(read_private(PAM) == expected_pam, "pam-fixture-changed")
+    require(account.pw_uid != admin["uid"] and account.pw_uid != 0,
+            "fixture-account-not-independent")
+    check_stage(stage, manifest["stage"])
+    report["pam"] = pam_checks(password)
+    report["packaged_pam_module"] = str(module)
+    report["camera_devices_absent"] = True
+    if stage == "candidate-upgrade":
+        manifest["retry"] = seed_retry(account.pw_uid)
+        available = status(account, recovery=0)
+        require(retry_fingerprints(account.pw_uid) == manifest["retry"], "retry-status-altered-fixture")
+        # Exercise a real password verification failure when the packaged backend
+        # is available, then preserve the daemon-written recovery record. Face
+        # counters remain synthetic because no enrollment/capture is performed.
+        recovery_failures = 0
+        if available:
+            wrong, _ = command(["irlume", "retry", "reset", "--user", USER],
+                               input_text="wrong-" + password + "\n", capture=False, account=account)
+            require(wrong != 0, "retry-wrong-password-accepted")
+            status(account, recovery=1)
+            recovery_failures = 1
+        manifest["recovery_failures"] = recovery_failures
+        manifest["retry"] = retry_fingerprints(account.pw_uid)
+        report["retry"] = {"face_fixture": "source-validated-synthetic-metadata",
+                           "face_failures": 2, "cumulative_face_requests": 7,
+                           "recovery_failures": recovery_failures,
+                           "recovery_failure_created_by_cli": available,
+                           "candidate_status_verified": True,
+                           "password_reset_available": available}
+    elif stage in ("old-rollback", "candidate-reupgrade"):
+        trusted_directory(RETRY, 0o700)
+        require(retry_fingerprints(account.pw_uid) == manifest["retry"], "retry-preservation-failed")
+        report["retry"] = {"bytes_and_private_modes_preserved": True,
+                           "old_version_retry_enforcement": "absent-in-v0.11.3"}
+        if stage == "candidate-reupgrade":
+            available = status(account, recovery=manifest["recovery_failures"])
+            report["retry"]["candidate_status_verified"] = True
+            require(retry_fingerprints(account.pw_uid) == manifest["retry"], "retry-status-altered-fixture")
+            if available:
+                reset = ["irlume", "retry", "reset", "--user", USER]
+                wrong, _ = command(reset, input_text="wrong-" + password + "\n",
+                                   capture=False, account=account)
+                require(wrong != 0, "retry-wrong-password-accepted")
+                status(account, recovery=manifest["recovery_failures"] + 1)
+                correct, _ = command(reset, input_text=password + "\n",
+                                     capture=False, account=account)
+                require(correct == 0, "retry-correct-password-refused")
+                status(account, strikes=0, budget=0, recovery=0)
+                report["retry"]["password_verified_reset"] = "passed-wrong-then-correct"
+                report["retry"]["reset_counts_verified_zero"] = True
+            else:
+                report["retry"]["password_verified_reset"] = "not-available-on-installation"
+                report["limitations"].append("candidate-daemon-reports-password-reset-unavailable")
+    else:
+        report["retry"] = {"old_version_retry_enforcement": "absent-in-v0.11.3"}
+    require(admin_identity() == manifest["admin"], "independent-admin-changed")
+    report["independent_admin_preserved"] = True
+    manifest["stage"] = stage
+    save_manifest(manifest)
+
+
+def main(argv=None):
+    args = sys.argv[1:] if argv is None else argv
+    report = {"passed": False, "limitations": [
+        "synthetic-retry-metadata-is-not-biometric-enrollment-usability",
+        "old-release-byte-preservation-is-not-retry-enforcement",
+    ]}
+    try:
+        require(len(args) == 1 and args[0] in STAGES, "invalid-stage")
+        report["stage"] = args[0]
+        report["virtualization"] = admit_guest()
+        run_stage(args[0], report)
+        report["passed"] = True
+    except Failure as error:
+        report["error"] = str(error)
+    except Exception:
+        # Do not serialize exceptions, subprocess output, account databases,
+        # private file content, passwords, or environment into the receipt.
+        report["error"] = "internal-check-failed"
+    print(json.dumps(report, sort_keys=True))
+    return 0 if report["passed"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test-check-upgrade-auth.py
+++ b/scripts/test-check-upgrade-auth.py
@@ -35,11 +35,30 @@ class AuthCheckerTests(unittest.TestCase):
         for kind in ("none", "docker", "lxc", "vmware", ""):
             with self.subTest(kind=kind), \
                     patch.object(auth.os, "geteuid", return_value=0), \
-                    patch.object(auth, "command", return_value=(0, kind)), \
+                    patch.object(auth, "command", return_value=(0, kind)) as command, \
                     patch.object(auth.os, "open") as read:
                 with self.assertRaisesRegex(auth.Failure, "qemu-kvm-required"):
                     auth.admit_guest()
                 read.assert_not_called()
+                command.assert_called_once_with(["systemd-detect-virt"])
+
+    def test_container_inside_qemu_refused_before_marker_or_mutation(self):
+        # Match real systemd behavior: --vm selects the outer VM even when
+        # unfiltered detection identifies the innermost container.
+        def detect(argv):
+            return 0, "qemu" if "--vm" in argv else "docker"
+
+        with patch.object(auth.os, "geteuid", return_value=0), \
+                patch.object(auth, "command", side_effect=detect) as command, \
+                patch.object(auth.os, "open") as marker_open, \
+                patch.object(auth, "run_stage") as run_stage:
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                self.assertEqual(auth.main(["old-install"]), 1)
+            self.assertEqual(json.loads(output.getvalue())["error"], "qemu-kvm-required")
+            command.assert_called_once_with(["systemd-detect-virt"])
+            marker_open.assert_not_called()
+            run_stage.assert_not_called()
 
     def test_marker_must_be_exact_and_cannot_be_symlink(self):
         with tempfile.TemporaryDirectory() as temp:

--- a/scripts/test-check-upgrade-auth.py
+++ b/scripts/test-check-upgrade-auth.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Pure and refusal regressions: never run PAM, accounts, or guest checks."""
+import contextlib
+import importlib.util
+import io
+import json
+import os
+import stat
+from types import SimpleNamespace
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+SPEC = importlib.util.spec_from_file_location(
+    "upgrade_auth", Path(__file__).with_name("check-upgrade-auth.py")
+)
+auth = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(auth)
+
+
+class AuthCheckerTests(unittest.TestCase):
+    def test_nonroot_refused_before_command_or_mutation(self):
+        with patch.object(auth.os, "geteuid", return_value=1000), \
+                patch.object(auth, "command") as command, \
+                patch.object(auth, "run_stage") as run_stage:
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                self.assertEqual(auth.main(["old-install"]), 1)
+            self.assertEqual(json.loads(output.getvalue())["error"], "root-required")
+            command.assert_not_called()
+            run_stage.assert_not_called()
+
+    def test_host_or_container_refused_before_marker_access(self):
+        for kind in ("none", "docker", "lxc", "vmware", ""):
+            with self.subTest(kind=kind), \
+                    patch.object(auth.os, "geteuid", return_value=0), \
+                    patch.object(auth, "command", return_value=(0, kind)), \
+                    patch.object(auth.os, "open") as read:
+                with self.assertRaisesRegex(auth.Failure, "qemu-kvm-required"):
+                    auth.admit_guest()
+                read.assert_not_called()
+
+    def test_marker_must_be_exact_and_cannot_be_symlink(self):
+        with tempfile.TemporaryDirectory() as temp:
+            marker = Path(temp) / "marker"
+            with patch.object(auth, "MARKER", marker), \
+                    patch.object(auth.os, "geteuid", return_value=0), \
+                    patch.object(auth, "command", return_value=(0, "kvm")), \
+                    patch.object(auth.os, "fstat", return_value=SimpleNamespace(
+                        st_mode=stat.S_IFREG | 0o644, st_uid=0)):
+                for value in (b"", auth.MARKER_BYTES + b"\n", b"other"):
+                    marker.write_bytes(value)
+                    with self.assertRaisesRegex(auth.Failure, "marker-mismatch"):
+                        auth.admit_guest()
+                marker.write_bytes(auth.MARKER_BYTES)
+                self.assertEqual(auth.admit_guest(), "kvm")
+                marker.unlink()
+                marker.symlink_to(Path(temp) / "other")
+                with self.assertRaises(auth.Failure):
+                    auth.admit_guest()
+
+    def test_marker_owner_and_writable_modes_refuse_before_stage(self):
+        with tempfile.TemporaryDirectory() as temp:
+            marker = Path(temp) / "marker"
+            marker.write_bytes(auth.MARKER_BYTES)
+            for uid, mode in ((1000, 0o644), (0, 0o664), (0, 0o646), (0, 0o666)):
+                with self.subTest(uid=uid, mode=oct(mode)), \
+                        patch.object(auth, "MARKER", marker), \
+                        patch.object(auth.os, "geteuid", return_value=0), \
+                        patch.object(auth, "command", return_value=(0, "kvm")), \
+                        patch.object(auth.os, "fstat", return_value=SimpleNamespace(
+                            st_mode=stat.S_IFREG | mode, st_uid=uid)), \
+                        patch.object(auth, "run_stage") as run_stage:
+                    output = io.StringIO()
+                    with contextlib.redirect_stdout(output):
+                        self.assertEqual(auth.main(["old-install"]), 1)
+                    self.assertEqual(json.loads(output.getvalue())["error"],
+                                     "marker-owner-or-mode")
+                    run_stage.assert_not_called()
+
+    def test_invalid_stage_has_no_commands_or_mutations(self):
+        with patch.object(auth, "command") as command, \
+                patch.object(auth, "run_stage") as run_stage:
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                self.assertEqual(auth.main(["wrong-stage"]), 1)
+            self.assertEqual(json.loads(output.getvalue())["error"], "invalid-stage")
+            command.assert_not_called()
+            run_stage.assert_not_called()
+
+    def test_sequencing_rejects_skips_and_repeated_first_stage(self):
+        auth.check_stage("candidate-upgrade", "old-install")
+        auth.check_stage("old-rollback", "candidate-upgrade")
+        auth.check_stage("candidate-reupgrade", "old-rollback")
+        for stage, previous in (("old-rollback", "old-install"),
+                                ("old-install", "old-install"),
+                                ("candidate-upgrade", None)):
+            with self.assertRaisesRegex(auth.Failure, "stage-order"):
+                auth.check_stage(stage, previous)
+
+    def test_status_parser_checks_all_counters_and_cooldowns(self):
+        text = (
+            "Face retry state for 'irlume-upgrade-fixture': 2 recorded failures, 0s cooldown.\n"
+            "Cumulative face requests: 7/50 consecutive unsuccessful; available after any cooldown.\n"
+            "Password-verified retry reset: available for supported local accounts; 1 failed checks, 0s cooldown.\n"
+            "Ordinary password login remains available.\n"
+        )
+        self.assertTrue(auth.check_status(text, 2, 7, 1))
+        for changed in (text.replace("7/50", "0/50"),
+                        text.replace("2 recorded", "0 recorded"),
+                        text.replace("1 failed", "0 failed"),
+                        text.replace("0s cooldown", "30s cooldown"),
+                        text.replace("7/50", "7/500")):
+            with self.assertRaisesRegex(auth.Failure, "retry-status-mismatch"):
+                auth.check_status(changed, 2, 7, 1)
+        self.assertFalse(auth.check_status(text.replace(
+            "available for supported local accounts", "unavailable on this installation"), 2, 7, 1))
+
+    def test_private_file_creation_never_overwrites_or_follows_symlink(self):
+        with tempfile.TemporaryDirectory() as temp:
+            file = Path(temp) / "private"
+            auth.create_private(file, b"fixture")
+            self.assertEqual(file.stat().st_mode & 0o777, 0o600)
+            with self.assertRaises(FileExistsError):
+                auth.create_private(file, b"replacement")
+            self.assertEqual(file.read_bytes(), b"fixture")
+            alias = Path(temp) / "alias"
+            alias.symlink_to(file)
+            with self.assertRaises(FileExistsError):
+                auth.create_private(alias, b"replacement")
+
+    def test_command_uses_stdin_and_never_inherits_environment(self):
+        secret = "synthetic-password-only"
+        with patch.object(auth.subprocess, "run") as run:
+            run.return_value.returncode = 0
+            run.return_value.stdout = "discarded"
+            auth.command(["pamtester", "service", "fixture", "authenticate"],
+                         input_text=secret, capture=False)
+            args, kwargs = run.call_args
+            self.assertNotIn(secret, args[0])
+            self.assertEqual(kwargs["input"], secret)
+            self.assertNotIn("shell", kwargs)
+            self.assertEqual(kwargs["stdout"], auth.subprocess.DEVNULL)
+            self.assertEqual(kwargs["stderr"], auth.subprocess.DEVNULL)
+            self.assertNotIn("LD_PRELOAD", kwargs["env"])
+            self.assertLessEqual(kwargs["timeout"], 45)
+
+    def test_packaged_module_discovers_all_distribution_layouts(self):
+        cases = (
+            ("dpkg-query", ["dpkg-query", "-L", "irlume"],
+             "/usr/lib/x86_64-linux-gnu/security/pam_irlume.so"),
+            ("pacman", ["pacman", "-Qlq", "irlume"],
+             "/usr/lib/security/pam_irlume.so"),
+            ("rpm", ["rpm", "-ql", "irlume"],
+             "/usr/lib64/security/pam_irlume.so"),
+        )
+        for manager, query, module in cases:
+            with self.subTest(manager=manager), \
+                    patch.object(auth.shutil, "which", side_effect=(
+                        lambda name, **kwargs: name if name == manager else None)), \
+                    patch.object(auth, "command", return_value=(0, module + "\n")) as command, \
+                    patch.object(Path, "is_file", return_value=True), \
+                    patch.object(Path, "stat", return_value=SimpleNamespace(
+                        st_size=1, st_uid=0, st_mode=stat.S_IFREG | 0o644)):
+                self.assertEqual(auth.packaged_module(), Path(module))
+                command.assert_called_once_with(query)
+
+    def test_pam_wrong_password_requires_normal_rejection_exit(self):
+        import signal
+        for exit_code in (-signal.SIGSEGV, -signal.SIGKILL, 2, 126, 127, 255):
+            with self.subTest(exit_code=exit_code), \
+                    patch.object(auth, "command", side_effect=[(0, ""), (exit_code, "")]):
+                with self.assertRaises(auth.Failure):
+                    auth.pam_checks("synthetic-password-only")
+
+    def test_pam_normal_success_and_rejection_are_reported(self):
+        with patch.object(auth, "command", side_effect=[(0, ""), (1, "")]):
+            self.assertEqual(auth.pam_checks("synthetic-password-only"),
+                             {"correct_password_exit": 0, "wrong_password_exit": 1})
+
+    def test_pam_wrong_password_success_is_rejected(self):
+        with patch.object(auth, "command", side_effect=[(0, ""), (0, "")]):
+            with self.assertRaises(auth.Failure):
+                auth.pam_checks("synthetic-password-only")
+
+    def test_credential_drop_uses_nss_supplementary_groups(self):
+        from types import SimpleNamespace
+        account = SimpleNamespace(pw_name="fixture", pw_uid=1234, pw_gid=1235)
+        with patch.object(auth.os, "getgrouplist", return_value=[1235, 2345]) as groups, \
+                patch.object(auth.subprocess, "run") as run:
+            run.return_value.returncode = 0
+            run.return_value.stdout = ""
+            auth.command(["irlume", "retry", "status"], account=account)
+            groups.assert_called_once_with("fixture", 1235)
+            self.assertEqual(run.call_args.kwargs["user"], 1234)
+            self.assertEqual(run.call_args.kwargs["group"], 1235)
+            self.assertEqual(run.call_args.kwargs["extra_groups"], [1235, 2345])
+
+    def test_private_read_refuses_wide_modes_and_symlink(self):
+        with tempfile.TemporaryDirectory() as temp:
+            file = Path(temp) / "private"
+            file.write_bytes(b"synthetic")
+            os.chmod(file, 0o644)
+            with self.assertRaisesRegex(auth.Failure, "private-file-metadata"):
+                auth.read_private(file)
+            alias = Path(temp) / "alias"
+            alias.symlink_to(file)
+            with self.assertRaises(OSError):
+                auth.read_private(alias)
+
+    def test_unexpected_error_never_emits_exception_payload(self):
+        with patch.object(auth, "admit_guest", return_value="kvm"), \
+                patch.object(auth, "run_stage", side_effect=ValueError("secret payload")):
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                self.assertEqual(auth.main(["old-install"]), 1)
+            result = json.loads(output.getvalue())
+            self.assertEqual(result["error"], "internal-check-failed")
+            self.assertNotIn("secret", output.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test-package-upgrade-harness.py
+++ b/scripts/test-package-upgrade-harness.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Local regressions for the disposable-guest harness; never install packages."""
+import importlib.util
+import io
+import json
+import os
+import signal
+import sys
+from pathlib import Path
+import tempfile
+import time
+import unittest
+from unittest.mock import Mock, patch
+
+SPEC = importlib.util.spec_from_file_location(
+    "package_upgrade", Path(__file__).with_name("test-package-upgrade.py")
+)
+upgrade = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(upgrade)
+
+
+class HarnessTests(unittest.TestCase):
+    def test_rpm_metadata_checks_upstream_name_epoch_and_architecture(self):
+        good = "irlume\t(none)\t0.12.0\t1.20260910.fc44\tx86_64"
+        with patch.object(upgrade, "read_command", return_value=good):
+            self.assertEqual(upgrade.package_metadata(Path("/candidate.rpm"), "rpm", "0.12.0"),
+                             "0.12.0-1.20260910.fc44")
+        for bad in (good.replace("0.12.0", "0.12.01"), good.replace("(none)", "1"),
+                    good.replace("x86_64", "aarch64"), good.replace("irlume\t", "other\t")):
+            with patch.object(upgrade, "read_command", return_value=bad):
+                with self.assertRaisesRegex(upgrade.Failure, "rpm-package-metadata"):
+                    upgrade.package_metadata(Path("/candidate.rpm"), "rpm", "0.12.0")
+
+    def test_rpm_transactions_move_matched_pair_in_each_direction(self):
+        with tempfile.TemporaryFile() as log:
+            runner = upgrade.Runner(log)
+            for label, action in (("old-install", "install"), ("candidate-upgrade", "upgrade"),
+                                  ("old-rollback", "downgrade"), ("candidate-reupgrade", "upgrade")):
+                with patch.object(runner, "command") as command:
+                    runner.install("rpm", Path("/main.rpm"), label, Path("/selinux.rpm"))
+                    self.assertEqual(command.call_args.args[0],
+                                     ["dnf5", "-y", "--setopt=localpkg_gpgcheck=True",
+                                      action, "/main.rpm", "/selinux.rpm"])
+                    self.assertEqual(command.call_args.kwargs, {"timeout": 900, "capture": False})
+
+    def test_rpm_missing_or_mismatched_policy_pair_refused(self):
+        with self.assertRaisesRegex(upgrade.Failure, "rpm-selinux-pair-required"):
+            upgrade.rpm_companions(None, None, ("0.11.3-1.fc44", "0.12.0-1.fc44"))
+        with patch.object(upgrade, "package_path", side_effect=[Path("/old.rpm"), Path("/new.rpm")]), \
+             patch.object(upgrade, "package_metadata", side_effect=["0.11.3-1.fc44", "0.12.0-2.fc44"]):
+            with self.assertRaisesRegex(upgrade.Failure, "rpm-main-policy-version-mismatch"):
+                upgrade.rpm_companions("/old.rpm", "/new.rpm", ("0.11.3-1.fc44", "0.12.0-1.fc44"))
+
+    def test_fedora_candidate_requires_lib64_pam_and_selinux_payload(self):
+        paths = {
+            "/usr/libexec/irlume-password-verify": 0o755,
+            "/usr/libexec/irlume/irlume-kwallet-init": 0o755,
+            "/usr/libexec/irlume/irlume-gkr-unlock": 0o755,
+            "/etc/pam.d/irlume-retry-reset": 0o644,
+            "/usr/share/polkit-1/actions/org.irlume.enroll.policy": 0o644,
+            "/usr/share/polkit-1/actions/org.irlume.recovery-manage.policy": 0o644,
+            "/usr/lib64/security/pam_irlume.so": 0o644,
+            "/usr/share/selinux/packages/irlume.pp": 0o644,
+        }
+        payload = {path: {"type": "file", "mode": mode, "uid": 0, "gid": 0}
+                   for path, mode in paths.items()}
+        upgrade.check_candidate_payload(payload, "rpm")
+        del payload["/usr/share/selinux/packages/irlume.pp"]
+        with self.assertRaisesRegex(upgrade.Failure, "candidate-required-payload"):
+            upgrade.check_candidate_payload(payload, "rpm")
+
+    def test_rpm_selinux_check_refuses_permissive_or_missing_policy(self):
+        with tempfile.TemporaryFile() as log:
+            runner = upgrade.Runner(log)
+            with patch.object(runner, "command", return_value="Permissive"):
+                with self.assertRaisesRegex(upgrade.Failure, "selinux-not-enforcing"):
+                    runner.selinux()
+            for listing in ("base", "base\nirlume disabled"):
+                with patch.object(runner, "command", side_effect=["Enforcing", listing]):
+                    with self.assertRaisesRegex(upgrade.Failure, "selinux-module-not-enabled"):
+                        runner.selinux()
+            with patch.object(runner, "command", side_effect=["Enforcing", "base\nirlume"]):
+                self.assertTrue(runner.selinux()["irlume_module_enabled"])
+
+    def test_obsolete_conffile_requires_explicit_metadata_flag(self):
+        md5 = "a" * 32
+        output = f"/etc/regular {md5}\n /etc/obsolete {md5} obsolete\n"
+        self.assertEqual(upgrade.obsolete_conffiles(output), {"/etc/obsolete"})
+        with self.assertRaisesRegex(upgrade.Failure, "invalid-conffile-metadata"):
+            upgrade.obsolete_conffiles("/etc/obsolete invalid-hash obsolete")
+
+    def test_rollback_accepts_only_declared_obsolete_candidate_conffile(self):
+        baseline = {"/usr/bin/irlume": {"sha256": "old"}}
+        config = "/etc/pam.d/irlume-retry-reset"
+        candidate = {"/usr/bin/irlume": {"sha256": "new"}, config: {"sha256": "config"}}
+        residual = {config: candidate[config]}
+        current = baseline | residual
+        self.assertEqual(upgrade.check_rollback_payload(
+            baseline, candidate, current, residual, {config}), residual)
+        for obsolete in (set(), {"/etc/other"}):
+            with self.assertRaisesRegex(upgrade.Failure, "candidate-payload-left"):
+                upgrade.check_rollback_payload(baseline, candidate, current, residual, obsolete)
+        with self.assertRaisesRegex(upgrade.Failure, "complete-old-payload"):
+            upgrade.check_rollback_payload(baseline, candidate, candidate, residual, {config})
+        binary = "/usr/bin/extra"
+        with self.assertRaisesRegex(upgrade.Failure, "candidate-payload-left"):
+            upgrade.check_rollback_payload(baseline, candidate | {binary: {}}, baseline | {binary: {}},
+                                           {binary: {}}, {binary})
+
+    def test_package_timeout_kills_surviving_group_after_leader_exits(self):
+        with tempfile.TemporaryFile() as log, \
+             patch.object(upgrade.subprocess, "Popen") as popen, \
+             patch.object(upgrade.os, "killpg") as killpg, \
+             patch.object(upgrade.time, "monotonic", side_effect=[0, 6]), \
+             patch.object(upgrade.time, "sleep"):
+            process = popen.return_value
+            process.pid = 424242
+            process.communicate.side_effect = [upgrade.subprocess.TimeoutExpired("fixture", 1),
+                                               (None, None), (None, None)]
+            with self.assertRaisesRegex(upgrade.Failure, "command-timeout"):
+                upgrade.Runner(log).command(["fixture-only"], timeout=1, capture=False)
+            self.assertIn(((424242, signal.SIGKILL), {}), killpg.call_args_list)
+
+    def test_real_timeout_stops_term_ignoring_descendant(self):
+        # Harmless Python processes only. The leader dies on TERM; its child
+        # ignores TERM and has no inherited stdout pipe to keep communicate
+        # waiting. This reproduces the package-log (capture=False) failure.
+        with tempfile.TemporaryDirectory() as temp, tempfile.TemporaryFile() as log:
+            pid_file = Path(temp) / "child.pid"
+            child = ("import os, signal, time\nfrom pathlib import Path\n"
+                     "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+                     f"Path({str(pid_file)!r}).write_text(str(os.getpid()))\n"
+                     "while True: time.sleep(60)\n")
+            leader = ("import subprocess, sys, time\n"
+                      f"subprocess.Popen([sys.executable, '-c', {child!r}])\n"
+                      "while True: time.sleep(60)\n")
+            try:
+                with self.assertRaisesRegex(upgrade.Failure, "command-timeout"):
+                    upgrade.Runner(log).command([sys.executable, "-c", leader], timeout=1, capture=False)
+                self.assertTrue(pid_file.is_file(), "child must start before timeout")
+                pid = int(pid_file.read_text())
+                state = Path(f"/proc/{pid}/stat")
+                # The orphan may remain a zombie until the host's init reaps it.
+                # Signal delivery is asynchronous even after killpg returns.
+                deadline = time.monotonic() + 1
+                while state.exists():
+                    try:
+                        status = state.read_text().split(")", 1)[1].split()[0]
+                    except FileNotFoundError:
+                        break
+                    if status in {"Z", "X"}:
+                        break
+                    self.assertLess(time.monotonic(), deadline, "descendant survived SIGKILL")
+                    time.sleep(0.01)
+            finally:
+                if pid_file.exists():
+                    try:
+                        os.kill(int(pid_file.read_text()), signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
+
+    def test_unsafe_main_creates_no_output(self):
+        with tempfile.TemporaryDirectory() as temp:
+            output = Path(temp) / "result.json"
+            with patch.object(upgrade.os, "geteuid", return_value=1000), \
+                 patch.object(upgrade.subprocess, "Popen") as command, \
+                 patch.object(upgrade.sys, "stderr", io.StringIO()):
+                self.assertEqual(upgrade.main(["--old", "/bad.deb", "--candidate", "/new.deb",
+                                               "--output", str(output)]), 2)
+                command.assert_not_called()
+            self.assertEqual(list(Path(temp).iterdir()), [])
+
+    def test_non_root_refused_before_commands(self):
+        with patch.object(upgrade.os, "geteuid", return_value=1000), \
+             patch.object(upgrade, "read_command") as command:
+            with self.assertRaisesRegex(upgrade.Failure, "root-required"):
+                upgrade.admit_guest()
+            command.assert_not_called()
+
+    def test_host_and_container_refused_before_marker_read(self):
+        for kind in ("none", "docker", "lxc", "vmware", ""):
+            with self.subTest(kind=kind), \
+                 patch.object(upgrade.os, "geteuid", return_value=0), \
+                 patch.object(upgrade, "read_command", return_value=kind), \
+                 patch.object(Path, "read_bytes") as read:
+                with self.assertRaisesRegex(upgrade.Failure, "qemu-kvm-required"):
+                    upgrade.admit_guest()
+                read.assert_not_called()
+
+    def test_marker_is_exact_and_not_a_symlink(self):
+        with tempfile.TemporaryDirectory() as temp:
+            marker = Path(temp) / "marker"
+            real_stat = Path.stat
+
+            def root_marker_stat(path, *args, **kwargs):
+                result = real_stat(path, *args, **kwargs)
+                if path == marker:
+                    fields = list(result)
+                    fields[4] = 0
+                    return os.stat_result(fields)
+                return result
+
+            with patch.object(upgrade, "MARKER", marker), \
+                 patch.object(upgrade.os, "geteuid", return_value=0), \
+                 patch.object(Path, "stat", autospec=True, side_effect=root_marker_stat), \
+                 patch.object(upgrade, "read_command", return_value="kvm"):
+                for content in (b"", upgrade.MARKER_BYTES + b"\n"):
+                    marker.write_bytes(content)
+                    with self.assertRaisesRegex(upgrade.Failure, "marker-mismatch"):
+                        upgrade.admit_guest()
+                marker.write_bytes(upgrade.MARKER_BYTES)
+                self.assertEqual(upgrade.admit_guest(), "kvm")
+                target = Path(temp) / "target"
+                marker.rename(target)
+                marker.symlink_to(target)
+                with self.assertRaisesRegex(upgrade.Failure, "symlink"):
+                    upgrade.admit_guest()
+
+    def test_input_path_rejects_escape_and_symlink_ancestor(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp) / "input"
+            root.mkdir()
+            package = root / "old.deb"
+            package.write_bytes(b"fixture")
+            with patch.object(upgrade, "INPUT_ROOT", root):
+                self.assertEqual(upgrade.package_path(str(package)), package)
+                with self.assertRaisesRegex(upgrade.Failure, "input-location"):
+                    upgrade.package_path(str(Path(temp) / "outside.deb"))
+                (root / "alias").symlink_to(root, target_is_directory=True)
+                with self.assertRaisesRegex(upgrade.Failure, "symlink"):
+                    upgrade.package_path(str(root / "alias/old.deb"))
+
+    def test_wrong_package_version_and_name_refused(self):
+        for fields in (("irlume", "0.11.30"), ("other", "0.11.3")):
+            with patch.object(upgrade, "read_command", side_effect=fields):
+                with self.assertRaisesRegex(upgrade.Failure, "package-metadata"):
+                    upgrade.package_metadata(Path("/old.deb"), "deb", "0.11.3")
+
+    def test_arch_release_suffix_is_not_cli_version(self):
+        with patch.object(upgrade, "read_command", return_value=(
+            "pkgname = irlume\npkgver = 0.11.3-2\n")):
+            self.assertEqual(upgrade.package_metadata(
+                Path("/old.pkg.tar.zst"), "arch", "0.11.3"), "0.11.3-2")
+
+    def test_preservation_detects_contents_modes_and_tree_changes(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            child = root / "synthetic"
+            child.write_bytes(b"synthetic only")
+            os.chmod(child, 0o600)
+            before = upgrade.snapshot_tree(root)
+            child.write_bytes(b"changed")
+            self.assertNotEqual(before, upgrade.snapshot_tree(root))
+            child.write_bytes(b"synthetic only")
+            os.chmod(child, 0o644)
+            self.assertNotEqual(before, upgrade.snapshot_tree(root))
+            os.chmod(child, 0o600)
+            (root / "unexpected").mkdir()
+            self.assertNotEqual(before, upgrade.snapshot_tree(root))
+
+    def test_root_mode_tightening_is_allowed_but_widening_fails(self):
+        upgrade.check_root_state({"mode": 0o755, "uid": 0, "gid": 0},
+                                 {"mode": 0o700, "uid": 0, "gid": 0})
+        with self.assertRaisesRegex(upgrade.Failure, "state-root-permissions"):
+            upgrade.check_root_state({"mode": 0o700, "uid": 0, "gid": 0},
+                                     {"mode": 0o755, "uid": 0, "gid": 0})
+
+    def test_live_daemon_must_restart_and_match_installed_executable(self):
+        with self.assertRaisesRegex(upgrade.Failure, "daemon-not-restarted"):
+            upgrade.check_daemon_identity(42, "abc", "abc", 42)
+        with self.assertRaisesRegex(upgrade.Failure, "daemon-executable-mismatch"):
+            upgrade.check_daemon_identity(43, "old", "new", 42)
+        upgrade.check_daemon_identity(43, "new", "new", 42)
+
+    def test_cli_version_match_is_exact(self):
+        for text in ("irlume 0.11.30", "irlume 0.12.0", ""):
+            with self.assertRaisesRegex(upgrade.Failure, "cli-version-mismatch"):
+                upgrade.check_cli_version(text, "0.11.3")
+        upgrade.check_cli_version("irlume 0.11.3\n", "0.11.3")
+
+    def test_stage_checker_nonzero_or_non_json_fails(self):
+        with tempfile.TemporaryFile() as log:
+            runner = upgrade.Runner(log)
+            with patch.object(upgrade.subprocess, "Popen") as popen:
+                popen.return_value.communicate.return_value = (b'{"passed":false}', None)
+                popen.return_value.returncode = 1
+                with self.assertRaisesRegex(upgrade.Failure, "command-failed"):
+                    runner.stage_check(Path("/checker.py"), "old-install")
+                popen.return_value.returncode = 0
+                for output in (b"not JSON", b"[]", b'{"passed":false}'):
+                    popen.return_value.communicate.return_value = (output, None)
+                    with self.assertRaises(upgrade.Failure):
+                        runner.stage_check(Path("/checker.py"), "old-install")
+
+    def test_failed_package_transaction_persists_failure_without_raw_output(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            old, candidate = root / "old.deb", root / "candidate.deb"
+            old.write_bytes(b"old synthetic package")
+            candidate.write_bytes(b"candidate synthetic package")
+            output = root / "result.json"
+            processes = []
+            for data in (b"", b"PRIVATE GUEST DIAGNOSTIC", b"", b""):
+                process = Mock(returncode=1)
+                process.communicate.return_value = (data, None)
+                processes.append(process)
+            with patch.object(upgrade, "INPUT_ROOT", root), \
+                 patch.object(upgrade, "admit_guest", return_value="kvm"), \
+                 patch.object(upgrade, "read_command", side_effect=["irlume", "0.11.3", "irlume", "0.12.0"]), \
+                 patch.object(upgrade.subprocess, "Popen", side_effect=processes) as command, \
+                 patch.object(upgrade.sys, "stdout", io.StringIO()):
+                self.assertEqual(upgrade.main(["--old", str(old), "--candidate", str(candidate),
+                                               "--output", str(output)]), 1)
+            receipt = json.loads(output.read_text())
+            self.assertFalse(receipt["passed"])
+            self.assertEqual(receipt["steps"], [{"step": "old-install", "passed": False}])
+            self.assertEqual(receipt["failure"], "command-failed")
+            self.assertNotIn("PRIVATE GUEST DIAGNOSTIC", output.read_text())
+            self.assertIn("PRIVATE GUEST DIAGNOSTIC", output.with_name(output.name + ".log").read_text())
+            self.assertEqual(command.call_args_list[1].args[0][0], "apt-get")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test-package-upgrade-harness.py
+++ b/scripts/test-package-upgrade-harness.py
@@ -181,11 +181,32 @@ class HarnessTests(unittest.TestCase):
         for kind in ("none", "docker", "lxc", "vmware", ""):
             with self.subTest(kind=kind), \
                  patch.object(upgrade.os, "geteuid", return_value=0), \
-                 patch.object(upgrade, "read_command", return_value=kind), \
+                 patch.object(upgrade, "read_command", return_value=kind) as command, \
                  patch.object(Path, "read_bytes") as read:
                 with self.assertRaisesRegex(upgrade.Failure, "qemu-kvm-required"):
                     upgrade.admit_guest()
                 read.assert_not_called()
+                command.assert_called_once_with(["systemd-detect-virt"])
+
+    def test_container_inside_qemu_refused_before_marker_or_mutation(self):
+        # --vm hides this container and reports the outer QEMU machine.
+        def detect(argv):
+            return "qemu" if "--vm" in argv else "docker"
+
+        with tempfile.TemporaryDirectory() as temp, \
+             patch.object(upgrade.os, "geteuid", return_value=0), \
+             patch.object(upgrade, "read_command", side_effect=detect) as command, \
+             patch.object(upgrade, "no_symlinks") as marker_check, \
+             patch.object(upgrade, "execute") as execute, \
+             patch.object(upgrade.sys, "stderr", io.StringIO()) as stderr:
+            output = Path(temp) / "result.json"
+            self.assertEqual(upgrade.main(["--old", "/old.deb", "--candidate", "/candidate.deb",
+                                           "--output", str(output)]), 2)
+            self.assertIn("qemu-kvm-required", stderr.getvalue())
+            command.assert_called_once_with(["systemd-detect-virt"])
+            marker_check.assert_not_called()
+            execute.assert_not_called()
+            self.assertEqual(list(Path(temp).iterdir()), [])
 
     def test_marker_is_exact_and_not_a_symlink(self):
         with tempfile.TemporaryDirectory() as temp:

--- a/scripts/test-package-upgrade.py
+++ b/scripts/test-package-upgrade.py
@@ -1,0 +1,555 @@
+#!/usr/bin/env python3
+"""Strict 0.11.3 -> 0.12.0 -> 0.11.3 -> 0.12.0 disposable QEMU test.
+
+Run inside a fresh root-owned guest only. Prepare dependencies/package inputs
+separately; this script does not alter service security settings. The marker is
+an explicit operator attestation, not proof that a VM has no device passthrough.
+--output names a NEW JSON file in an existing directory; its sibling .log keeps
+raw package-manager and service diagnostics in the guest. Export JSON only.
+Failure leaves the current transaction/state intact for inspection; no automatic
+removal or repair is attempted. Terminating a timed-out process group cannot
+roll back package changes already applied. Synthetic bytes prove preservation, not usable
+enrollment, cryptographic rollback, password fallback, or camera functionality.
+RPM qualification targets x86_64 Fedora with DNF5 and enforcing SELinux; supply
+both --old-selinux and --candidate-selinux for the matching policy packages.
+"""
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import signal
+import socket
+import stat
+import subprocess
+import sys
+import time
+
+MARKER = Path("/run/irlume-upgrade-disposable")
+MARKER_BYTES = b"irlume-upgrade-20260910"
+INPUT_ROOT = Path("/var/tmp/irlume-upgrade-input")
+CONFIG_ROOT = Path("/etc/irlume")
+STATE_ROOT = Path("/var/lib/irlume")
+SYNTHETIC_ROOT = STATE_ROOT / "upgrade-validation"
+ENV = {"PATH": "/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin", "LANG": "C", "LC_ALL": "C",
+       "DEBIAN_FRONTEND": "noninteractive", "SYSTEMD_PAGER": "cat"}
+RPM_QUERY = "%{NAME}\t%{EPOCH}\t%{VERSION}\t%{RELEASE}\t%{ARCH}\\n"
+
+
+class Failure(Exception):
+    """Fixed diagnostic codes only: never embed command output or file bytes."""
+
+
+def require(condition, code):
+    if not condition:
+        raise Failure(code)
+
+
+def read_command(argv, timeout=30):
+    try:
+        result = subprocess.run(argv, env=ENV, stdin=subprocess.DEVNULL,
+                                capture_output=True, text=True, timeout=timeout)
+    except (OSError, subprocess.TimeoutExpired):
+        raise Failure("preflight-command-unavailable-or-timeout") from None
+    require(result.returncode == 0, "preflight-command-failed")
+    return result.stdout.strip()
+
+
+def no_symlinks(path):
+    require(path.is_absolute() and ".." not in path.parts, "absolute-path-required")
+    for item in (*reversed(path.parents), path):
+        require(not item.is_symlink(), "symlink-refused")
+
+
+def admit_guest():
+    require(os.geteuid() == 0, "root-required")
+    kind = read_command(["systemd-detect-virt", "--vm"])
+    require(kind in {"qemu", "kvm"}, "qemu-kvm-required")
+    no_symlinks(MARKER)
+    require(MARKER.is_file(), "marker-missing")
+    require(MARKER.read_bytes() == MARKER_BYTES, "marker-mismatch")
+    info = MARKER.stat()
+    require(info.st_uid == 0 and not info.st_mode & 0o022, "marker-not-root-controlled")
+    return kind
+
+
+def package_path(value):
+    path = Path(value)
+    require(path.is_absolute() and path.is_relative_to(INPUT_ROOT), "input-location")
+    no_symlinks(path)
+    require(path.is_file(), "package-not-regular")
+    return path
+
+
+def package_format(path):
+    if path.name.endswith(".deb"):
+        return "deb"
+    if path.name.endswith(".pkg.tar.zst"):
+        return "arch"
+    if path.name.endswith(".rpm"):
+        return "rpm"
+    raise Failure("unsupported-package-format")
+
+
+def parse_rpm_metadata(text, package, expected=None):
+    fields = text.strip().split("\t")
+    require(len(fields) == 5, "rpm-package-metadata")
+    name, epoch, version, release, arch = fields
+    require(name == package and epoch in {"(none)", "0"}
+            and re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", version)
+            and (expected is None or version == expected)
+            and re.fullmatch(r"[0-9][A-Za-z0-9._+~^]*", release)
+            and arch == ("noarch" if package == "irlume-selinux" else "x86_64"),
+            "rpm-package-metadata")
+    return version + "-" + release
+
+
+def package_metadata(path, kind, expected, package="irlume"):
+    if kind == "rpm":
+        return parse_rpm_metadata(read_command(["rpm", "-qp", "--qf", RPM_QUERY, str(path)]),
+                                  package, expected)
+    if kind == "deb":
+        name = read_command(["dpkg-deb", "-f", str(path), "Package"])
+        version = read_command(["dpkg-deb", "-f", str(path), "Version"])
+        valid = version == expected or re.fullmatch(re.escape(expected) + r"-[0-9]+", version)
+    else:
+        text = read_command(["tar", "--zstd", "-xOf", str(path), ".PKGINFO"])
+        names = re.findall(r"^pkgname = (.+)$", text, re.M)
+        versions = re.findall(r"^pkgver = (.+)$", text, re.M)
+        require(len(names) == len(versions) == 1, "package-metadata")
+        name, version = names[0], versions[0]
+        valid = re.fullmatch(re.escape(expected) + r"-[0-9]+", version)
+    require(name == "irlume" and valid, "package-metadata")
+    return version
+
+
+def rpm_companions(old_value, candidate_value, versions):
+    require(old_value is not None and candidate_value is not None, "rpm-selinux-pair-required")
+    paths = (package_path(old_value), package_path(candidate_value))
+    require(all(package_format(path) == "rpm" for path in paths), "mixed-package-formats")
+    policy_versions = tuple(package_metadata(path, "rpm", expected, "irlume-selinux")
+                            for path, expected in zip(paths, ("0.11.3", "0.12.0")))
+    require(policy_versions == versions, "rpm-main-policy-version-mismatch")
+    return paths
+
+
+def digest(path):
+    hashed = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            hashed.update(block)
+    return hashed.hexdigest()
+
+
+def file_record(path):
+    info = path.lstat()
+    row = {"mode": stat.S_IMODE(info.st_mode), "uid": info.st_uid, "gid": info.st_gid}
+    if stat.S_ISREG(info.st_mode):
+        row.update(type="file", sha256=digest(path))
+    elif stat.S_ISLNK(info.st_mode):
+        row.update(type="symlink", sha256=hashlib.sha256(os.fsencode(os.readlink(path))).hexdigest())
+    elif stat.S_ISDIR(info.st_mode):
+        row["type"] = "directory"
+    else:
+        raise Failure("unexpected-file-type")
+    return row
+
+
+def snapshot_tree(root):
+    no_symlinks(root)
+    require(root.is_dir(), "preserved-directory-missing")
+    return {str(path.relative_to(root)): file_record(path)
+            for path in (root, *sorted(root.rglob("*")))}
+
+
+def check_root_state(before, after):
+    # tmpfiles intentionally strips group/other access non-recursively. Allow
+    # only that change, retaining owner bits, special bits, and ownership.
+    require(after["uid"] == before["uid"] and after["gid"] == before["gid"]
+            and after["mode"] & ~0o077 == before["mode"] & ~0o077
+            and after["mode"] & 0o077 & ~(before["mode"] & 0o077) == 0,
+            "state-root-permissions")
+
+
+def check_cli_version(text, expected):
+    require(text.strip() == "irlume " + expected, "cli-version-mismatch")
+
+
+def check_daemon_identity(pid, running_digest, installed_digest, previous_pid):
+    require(pid > 0, "daemon-no-main-pid")
+    require(pid != previous_pid, "daemon-not-restarted")
+    require(running_digest == installed_digest, "daemon-executable-mismatch")
+
+
+def check_rollback_payload(baseline, candidate, current, residual, obsolete):
+    require(all(path in current and current[path] == row for path, row in baseline.items()),
+            "complete-old-payload-rollback-failed")
+    require(current.keys() - baseline.keys() <= residual.keys(), "candidate-payload-left-after-rollback")
+    for path, row in residual.items():
+        require(path in obsolete and path in candidate and path not in baseline
+                and Path(path).is_relative_to("/etc") and row == candidate[path],
+                "candidate-payload-left-after-rollback")
+    return residual
+
+
+def obsolete_conffiles(text):
+    # dpkg-query ${Conffiles}: path, MD5, optional flags. Only an explicit
+    # obsolete flag permits an extra retained candidate file after rollback.
+    paths = set()
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        match = re.fullmatch(r"\s*(/.*?) ([0-9a-f]{32})(?: (.*))?", line)
+        require(match is not None, "invalid-conffile-metadata")
+        if match[3] == "obsolete":
+            paths.add(match[1])
+    return paths
+
+
+def terminate_group(process, grace=5):
+    """Bound teardown by group survival, independently of leader termination."""
+    deadline = time.monotonic() + grace
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    while True:
+        process.poll()  # Reap our leader so its zombie cannot keep the group alive.
+        try:
+            os.killpg(process.pid, 0)
+        except ProcessLookupError:
+            break
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            break
+        time.sleep(min(0.1, remaining))
+    try:
+        process.communicate(timeout=5)
+    except subprocess.TimeoutExpired:
+        raise Failure("command-teardown-timeout") from None
+
+
+def ping_ready(timeout):
+    # Request::Ping and Response::Pong are serde unit variants, newline framed.
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as peer:
+        end = time.monotonic() + timeout
+        peer.settimeout(timeout)
+        peer.connect("/run/irlume.sock")
+        peer.sendall(b'"Ping"\n')
+        response = bytearray()
+        while b"\n" not in response and len(response) < 256:
+            remaining = end - time.monotonic()
+            if remaining <= 0:
+                return False
+            peer.settimeout(remaining)
+            block = peer.recv(256 - len(response))
+            if not block:
+                break
+            response.extend(block)
+        return bytes(response).strip() == b'"Pong"'
+
+
+class Runner:
+    def __init__(self, log):
+        self.log = log
+
+    def command(self, argv, timeout=30, capture=True, check=True):
+        self.log.write(("\nCOMMAND " + json.dumps(argv) + "\n").encode())
+        self.log.flush()
+        try:
+            process = subprocess.Popen(
+                argv, env=ENV, stdin=subprocess.DEVNULL, start_new_session=True,
+                stdout=subprocess.PIPE if capture else self.log, stderr=self.log)
+        except OSError:
+            raise Failure("command-unavailable") from None
+        try:
+            output, _ = process.communicate(timeout=timeout)
+        except (subprocess.TimeoutExpired, KeyboardInterrupt) as error:
+            # Also terminate package-manager descendants; never leave an
+            # unobserved transaction running after the harness reports failure.
+            terminate_group(process)
+            if isinstance(error, KeyboardInterrupt):
+                raise
+            raise Failure("command-timeout") from None
+        if output:
+            self.log.write(output)
+        self.log.write(("\nEXIT " + str(process.returncode) + "\n").encode())
+        self.log.flush()
+        require(not check or process.returncode == 0, "command-failed")
+        return (output or b"").decode("utf-8", errors="replace").strip()
+
+    def install(self, kind, path, stage=None, policy=None):
+        if kind == "deb":
+            argv = ["apt-get", "-y", "--allow-downgrades", "--no-remove",
+                    "-o", "Dpkg::Options::=--force-confdef",
+                    "-o", "Dpkg::Options::=--force-confold", "install", str(path)]
+        elif kind == "rpm":
+            require(policy is not None, "rpm-selinux-pair-required")
+            actions = {"old-install": "install", "candidate-upgrade": "upgrade",
+                       "old-rollback": "downgrade", "candidate-reupgrade": "upgrade"}
+            require(stage in actions, "invalid-rpm-transaction-stage")
+            # DNF5 defaults localpkg_gpgcheck to false, independently of the
+            # repository signature policy. Require signatures on task inputs.
+            argv = ["dnf5", "-y", "--setopt=localpkg_gpgcheck=True",
+                    actions[stage], str(path), str(policy)]
+        else:
+            argv = ["pacman", "-U", "--noconfirm", str(path)]
+        self.command(argv, timeout=900, capture=False)
+
+    def stage_check(self, path, label):
+        output = self.command([sys.executable, str(path), label], timeout=180)
+        try:
+            value = json.loads(output)
+        except ValueError:
+            raise Failure("stage-check-invalid-json") from None
+        require(isinstance(value, dict), "stage-check-invalid-json")
+        require(value.get("passed") is True, "stage-check-not-passed")
+        return value
+
+    def installed_version(self, kind, package="irlume"):
+        if kind == "rpm":
+            return parse_rpm_metadata(self.command(["rpm", "-q", "--qf", RPM_QUERY, package]), package)
+        if kind == "deb":
+            text = self.command(["dpkg-query", "-W", "-f=${Status}\t${Version}", "irlume"])
+            require(text.startswith("install ok installed\t"), "package-not-configured")
+            return text.split("\t", 1)[1]
+        text = self.command(["pacman", "-Q", "irlume"])
+        require(text.startswith("irlume "), "package-not-installed")
+        return text.split(" ", 1)[1]
+
+    def payload(self, kind):
+        argv = {"deb": ["dpkg-query", "-L", "irlume"],
+                "arch": ["pacman", "-Qlq", "irlume"],
+                "rpm": ["rpm", "-ql", "irlume", "irlume-selinux"]}[kind]
+        paths = self.command(argv).splitlines()
+        rows = {}
+        for value in paths:
+            path = Path(value)
+            require(path.is_absolute() and ".." not in path.parts, "invalid-package-file-list")
+            info = path.lstat()
+            if not stat.S_ISDIR(info.st_mode):
+                rows[str(path)] = file_record(path)
+        require("/usr/bin/irlume" in rows and "/usr/bin/irlumed" in rows, "package-payload-missing")
+        return rows
+
+    def selinux(self):
+        require(self.command(["getenforce"]) == "Enforcing", "selinux-not-enforcing")
+        modules = self.command(["semodule", "--list-modules"]).splitlines()
+        require(any(line.split() == ["irlume"] for line in modules), "selinux-module-not-enabled")
+        return {"mode": "Enforcing", "irlume_module_enabled": True}
+
+    def daemon(self, previous_pid, timeout=120):
+        installed = digest(Path("/usr/bin/irlumed"))
+        end = time.monotonic() + timeout
+        last = "daemon-not-ready"
+        while time.monotonic() < end:
+            try:
+                text = self.command(["systemctl", "show", "irlumed.service",
+                                     "-p", "ActiveState", "-p", "SubState", "-p", "MainPID"],
+                                    timeout=min(5, max(0.1, end - time.monotonic())))
+                fields = dict(line.split("=", 1) for line in text.splitlines() if "=" in line)
+                require(fields.get("ActiveState") == "active" and fields.get("SubState") == "running",
+                        "daemon-not-active")
+                pid = int(fields.get("MainPID", "0"))
+                running = digest(Path(f"/proc/{pid}/exe"))
+                check_daemon_identity(pid, running, installed, previous_pid)
+                require(ping_ready(min(2, max(0.1, end - time.monotonic()))), "daemon-not-ready")
+                # Confirm Ping did not race a restart or executable replacement.
+                current = self.command(["systemctl", "show", "irlumed.service", "-p", "MainPID", "--value"], timeout=5)
+                require(current == str(pid) and digest(Path(f"/proc/{pid}/exe")) == installed,
+                        "daemon-changed-during-readiness")
+                return {"pid": pid, "running_sha256": running, "installed_sha256": installed, "ready": True}
+            except (Failure, OSError, ValueError) as error:
+                last = str(error) if isinstance(error, Failure) else "daemon-observation-failed"
+            time.sleep(min(1, max(0, end - time.monotonic())))
+        raise Failure(last)
+
+    def diagnostics(self):
+        for argv in (["systemctl", "status", "irlumed.service", "irlumed.socket", "--no-pager", "--full"],
+                     ["journalctl", "-u", "irlumed.service", "-n", "150", "--no-pager"]):
+            try:
+                self.command(argv, capture=False, check=False)
+            except Failure:
+                self.log.write(b"\nDiagnostics command failed.\n")
+
+
+def seed_synthetic():
+    for root in (CONFIG_ROOT, STATE_ROOT):
+        no_symlinks(root)
+        require(root.is_dir(), "package-state-directory-missing")
+    config = CONFIG_ROOT / "upgrade-validation.conf"
+    require(not config.exists() and not config.is_symlink() and not SYNTHETIC_ROOT.exists()
+            and not SYNTHETIC_ROOT.is_symlink(), "synthetic-state-already-exists")
+    with config.open("xb") as stream:
+        stream.write(b"# Synthetic package upgrade validation; no product settings.\n")
+    os.chmod(config, 0o600)
+    os.chown(config, 0, 0)
+    SYNTHETIC_ROOT.mkdir(mode=0o700)
+    nested = SYNTHETIC_ROOT / "nested"
+    nested.mkdir(mode=0o700)
+    for directory in (SYNTHETIC_ROOT, nested):
+        os.chown(directory, 0, 0)
+    for path in (SYNTHETIC_ROOT / "synthetic-state.bin", nested / "synthetic-retry.bin"):
+        with path.open("xb") as stream:
+            stream.write(b"IRLUME SYNTHETIC VALIDATION ONLY\x00" + os.urandom(96))
+        os.chmod(path, 0o600)
+        os.chown(path, 0, 0)
+
+
+def check_candidate_payload(payload, kind):
+    pam = {"deb": "/usr/lib/x86_64-linux-gnu/security/pam_irlume.so",
+           "arch": "/usr/lib/security/pam_irlume.so",
+           "rpm": "/usr/lib64/security/pam_irlume.so"}[kind]
+    modes = {"/usr/libexec/irlume-password-verify": 0o755,
+             "/usr/libexec/irlume/irlume-kwallet-init": 0o755,
+             "/usr/libexec/irlume/irlume-gkr-unlock": 0o755,
+             "/etc/pam.d/irlume-retry-reset": 0o644,
+             "/usr/share/polkit-1/actions/org.irlume.enroll.policy": 0o644,
+             "/usr/share/polkit-1/actions/org.irlume.recovery-manage.policy": 0o644,
+             # nfpm retains the executable bit from the Rust cdylib; Arch
+             # explicitly installs the module 0644 in PKGBUILD.
+             pam: 0o755 if kind == "deb" else 0o644}
+    if kind == "rpm":
+        modes["/usr/share/selinux/packages/irlume.pp"] = 0o644
+    for path, mode in modes.items():
+        row = payload.get(path, {})
+        require(row.get("type") == "file" and row.get("mode") == mode
+                and row.get("uid") == row.get("gid") == 0, "candidate-required-payload")
+
+
+def execute(runner, kind, old, candidate, versions, result, stage_check=None, policies=None):
+    # A clean guest is essential: do not downgrade an unrelated installation.
+    if kind == "rpm":
+        require(policies is not None, "rpm-selinux-pair-required")
+        installed = runner.command(["rpm", "-qa", "--qf", "%{NAME}\\n"]).splitlines()
+        require(not {"irlume", "irlume-selinux"}.intersection(installed), "existing-package-refused")
+    else:
+        installed = runner.command(["dpkg-query", "-W", "-f=${Status}", "irlume"] if kind == "deb"
+                                   else ["pacman", "-Q", "irlume"], check=False)
+        require(not installed, "existing-package-refused")
+    previous = None
+    baseline_payload = candidate_payload = config = synthetic = root = enabled = None
+    for label, path, version, cli_version in (
+        ("old-install", old, versions[0], "0.11.3"),
+        ("candidate-upgrade", candidate, versions[1], "0.12.0"),
+        ("old-rollback", old, versions[0], "0.11.3"),
+        ("candidate-reupgrade", candidate, versions[1], "0.12.0"),
+    ):
+        row = {"step": label, "passed": False}
+        result["steps"].append(row)
+        policy = policies[0 if cli_version == "0.11.3" else 1] if policies else None
+        runner.install(kind, path, label, policy)
+        require(runner.installed_version(kind) == version, "installed-version-mismatch")
+        row["package_version"] = version
+        if kind == "rpm":
+            policy_version = runner.installed_version(kind, "irlume-selinux")
+            require(policy_version == version, "installed-policy-version-mismatch")
+            row["selinux_package_version"] = policy_version
+            row["selinux"] = runner.selinux()
+        check_cli_version(runner.command(["/usr/bin/irlume", "--version"]), cli_version)
+        row["cli_version"] = cli_version
+        payload = runner.payload(kind)
+        row["payload"] = payload
+        row["daemon"] = runner.daemon(previous)
+        previous = row["daemon"]["pid"]
+        row["service_enabled"] = {
+            unit: runner.command(["systemctl", "is-enabled", unit], check=False)
+            for unit in ("irlumed.service", "irlumed.socket")
+        }
+        if cli_version == "0.12.0":
+            check_candidate_payload(payload, kind)
+            candidate_payload = payload
+        if label == "old-install":
+            baseline_payload = payload
+            seed_synthetic()
+            config = snapshot_tree(CONFIG_ROOT)
+            synthetic = snapshot_tree(SYNTHETIC_ROOT)
+            root = file_record(STATE_ROOT)
+            enabled = row["service_enabled"]
+            result["preservation_baseline"] = {"config": config, "synthetic": synthetic, "state_root": root}
+        else:
+            require(row["service_enabled"] == enabled, "service-enabled-state-changed")
+            require(snapshot_tree(CONFIG_ROOT) == config, "configuration-preservation-failed")
+            require(snapshot_tree(SYNTHETIC_ROOT) == synthetic, "synthetic-preservation-failed")
+            current_root = file_record(STATE_ROOT)
+            check_root_state(root, current_root)
+            root = current_root
+            if label == "old-rollback":
+                # dpkg keeps obsolete conffiles in both its status database and
+                # file list. Preserve exact baseline entries and permit only
+                # explicitly declared obsolete candidate /etc files as extras.
+                obsolete = obsolete_conffiles(runner.command(
+                    ["dpkg-query", "-W", "-f=${Conffiles}", "irlume"])) if kind == "deb" else set()
+                residual = {}
+                for value in (candidate_payload.keys() | payload.keys()) - baseline_payload.keys():
+                    path = Path(value)
+                    if path.exists() or path.is_symlink():
+                        residual[value] = file_record(path)
+                row["retained_candidate_conffiles"] = check_rollback_payload(
+                    baseline_payload, candidate_payload, payload, residual, obsolete)
+        row["state_root"] = root
+        if stage_check is not None:
+            row["auth_check"] = runner.stage_check(stage_check, label)
+        row["passed"] = True
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--old", required=True)
+    parser.add_argument("--candidate", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--stage-check", help="Optional trusted Python checker emitting credential-free JSON with passed=true")
+    parser.add_argument("--old-selinux", help="RPM only: matching old irlume-selinux package")
+    parser.add_argument("--candidate-selinux", help="RPM only: matching candidate irlume-selinux package")
+    args = parser.parse_args(argv)
+    # No log, output, fixture or package write before all admission checks.
+    try:
+        kind_vm = admit_guest()
+        old, candidate = package_path(args.old), package_path(args.candidate)
+        stage_check = package_path(args.stage_check) if args.stage_check else None
+        kind = package_format(old)
+        require(package_format(candidate) == kind, "mixed-package-formats")
+        versions = (package_metadata(old, kind, "0.11.3"), package_metadata(candidate, kind, "0.12.0"))
+        policies = None
+        if kind == "rpm":
+            policies = rpm_companions(args.old_selinux, args.candidate_selinux, versions)
+            require(read_command(["getenforce"]) == "Enforcing", "selinux-not-enforcing")
+        else:
+            require(args.old_selinux is None and args.candidate_selinux is None, "selinux-options-require-rpm")
+        output = Path(args.output)
+        log_path = output.with_name(output.name + ".log")
+        for path in (output, log_path):
+            no_symlinks(path)
+            require(path.parent.is_dir() and not path.exists(), "new-output-required")
+    except (Failure, OSError) as error:
+        print("REFUSED: " + (str(error) if isinstance(error, Failure) else "preflight-filesystem-error"), file=sys.stderr)
+        return 2
+    os.umask(0o077)
+    result = {"schema": 1, "passed": False, "vm": kind_vm, "format": kind, "steps": [],
+              "auth_stage_check_supplied": stage_check is not None,
+              "scope": "synthetic byte/mode/owner preservation only; no enrollment usability or password fallback claim",
+              "package_sha256": {"old": digest(old), "candidate": digest(candidate)}}
+    if policies:
+        result["package_sha256"].update(old_selinux=digest(policies[0]), candidate_selinux=digest(policies[1]))
+    with output.open("x") as report, log_path.open("xb") as log:
+        runner = Runner(log)
+        try:
+            execute(runner, kind, old, candidate, versions, result, stage_check, policies)
+            result["passed"] = True
+        except (Failure, OSError, ValueError, KeyboardInterrupt) as error:
+            result["failure"] = str(error) if isinstance(error, Failure) else "harness-operation-failed"
+        finally:
+            runner.diagnostics()
+            json.dump(result, report, indent=2, sort_keys=True)
+            report.write("\n")
+    print("PASS" if result["passed"] else "FAIL; inspect guest-local JSON and log")
+    return 0 if result["passed"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test-package-upgrade.py
+++ b/scripts/test-package-upgrade.py
@@ -64,7 +64,9 @@ def no_symlinks(path):
 
 def admit_guest():
     require(os.geteuid() == 0, "root-required")
-    kind = read_command(["systemd-detect-virt", "--vm"])
+    # Unfiltered detection reports the innermost environment. --vm would hide
+    # a container inside QEMU and incorrectly admit its shared-kernel boundary.
+    kind = read_command(["systemd-detect-virt"])
     require(kind in {"qemu", "kvm"}, "qemu-kvm-required")
     no_symlinks(MARKER)
     require(MARKER.is_file(), "marker-missing")


### PR DESCRIPTION
Release validation exposed three defects: Packit labeled 0.12.0 binaries as 0.11.3, enforcing AppArmor denied retry-operation file locks, and the NixOS module left both shipped PAD models at missing /etc paths, forcing password-only authentication. Read the version from the checked-out spec, permit the precise missing AppArmor lock, and resolve both NixOS PAD models from the selected package. Existing password-reset confinement restrictions remain intact.

Prepare the unpublished 0.12.0 version consistently and add the documented, guarded package upgrade-validation workflow. Its disposable-guest sequence covers old install → upgrade → complete old rollback → re-upgrade, daemon identity, package/configuration/synthetic-state preservation, and password-fallback controls. CI runs 40 harness regressions and now asserts both NixOS PAD model paths; nested containers are refused before package mutation.

Validation:
- Debian 12, Arch and Fedora 44 each passed all four real package stages and correct/wrong-password PAM controls. Corrected install matrix 34467498724 passed all seven jobs, including five Debian/Ubuntu targets.
- Debian AppArmor remained enforcing, with retry status working and reset intentionally unavailable. Arch/Fedora passed wrong-then-correct password reset with counters verified zero. Fedora used signed matching main+SELinux packages and enforcing mode; its daemon intentionally runs as unconfined_service_t.
- Exact Nix packages and an isolated profile generation cycle passed. A separate pinned NixOS KVM guest now also passed all four system activation stages with real switch-to-configuration/rollback and bootloader hooks, matched daemon/PAM paths, PID replacement, password controls, polkit registration, and synthetic-state preservation. Both candidate stages reported cached Health.rgb_pad and Health.ir_pad as loaded. No cameras, physical TPMs, network devices or host shared folders were attached.
- The new Nix regression failed on the missing model path before the fix and passed afterward. Full Nix flake evaluation, packaging parity, NixOS driver type/lint checks and independent production-patch review passed. Earlier package harness checks, AppArmor parsers, actionlint, shellcheck and Python tests passed at their recorded revisions.
- The final NixOS VM powered off cleanly; earlier package VMs/software TPMs are stopped. All 14 PR checks pass at 41cba8bc, including both Fedora builds (Copr10971643).

Provenance: Debian/Arch package trials used e3be0f86; Fedora/Nix package builds used f507a7b0. The NixOS activation trial used those exact Nix package outputs with the module fix committed as 41cba8b. That fix changes only NixOS service configuration and evaluation assertions; the VM reused the recorded f507a7b0 package outputs. No byte-equivalence claim is made for the subsequent CI rebuild. Public hashes and sanitized receipts are retained in shared project memory.

This qualifies the recorded package and NixOS userspace activation behavior. It does not establish cryptographic enrollment usability, physical camera/TPM/liveness acceptance, each generation booting after a reboot, administrator-disabled service upgrades, graphical greeter/keyring behavior, or a fresh full nightly campaign. Model loading is not liveness qualification. Old 0.11.3 cannot enforce newer retry limits. No release/tag, main merge, host product installation or physical-camera test was performed.
