### PR TITLE
ci: require privileged nightly capture with a restricted runner helper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -522,6 +522,9 @@ jobs:
       - name: doctor IR-node parser (the nightly hardware suite depends on it)
         run: ./scripts/ir-node-from-doctor.sh --self-test
 
+      - name: nightly IR capture guards (fixtures only, no hardware or sudo)
+        run: python3 scripts/test-nightly-ir-capture.py
+
       - name: systemd-analyze verify (unit syntax)
         run: |
           set -euo pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -523,7 +523,9 @@ jobs:
         run: ./scripts/ir-node-from-doctor.sh --self-test
 
       - name: nightly IR capture guards (fixtures only, no hardware or sudo)
-        run: python3 scripts/test-nightly-ir-capture.py
+        run: |
+          python3 scripts/test-nightly-ir-capture.py
+          python3 scripts/ci/test-irlume-ci-capture.py
 
       - name: systemd-analyze verify (unit syntax)
         run: |

--- a/.github/workflows/hardware-suite.yml
+++ b/.github/workflows/hardware-suite.yml
@@ -79,6 +79,7 @@ jobs:
       # and are deleted; they are never uploaded (they picture the room).
       - name: IR camera strobe-burst capture
         run: |
+          set -o pipefail
           # Distinguish "camera genuinely absent" from "doctor itself failed":
           # a doctor crash or a changed output format must NOT read as a clean
           # skip (that would let a real regression pass green). Run doctor once,
@@ -156,9 +157,22 @@ jobs:
           # its exit status cannot select an unprivileged-to-sudo fallback.
           # Run once with the required privilege, keeping the positive-write
           # marker, frame count and spread checks below as independent gates.
-          if ! sudo -n env IRLUME_LOG_EMITTER_WRITES=1 "$burst" "$out" "$ir" 6 2>"$err"; then
+          helper=/usr/local/libexec/irlume-ci-capture
+          captured=0
+          if [ -x "$helper" ]; then
+            # Restricted runners use an administrator-approved binary. The
+            # helper rejects a different source tree before opening the camera and
+            # streams only capture files from its private output directory.
+            tree=$(git rev-parse 'HEAD^{tree}')
+            if sudo -n "$helper" "$tree" "$ir" 2>"$err" | tar -xf - -C "$out"; then
+              captured=1
+            fi
+          elif sudo -n env IRLUME_LOG_EMITTER_WRITES=1 "$burst" "$out" "$ir" 6 2>"$err"; then
+            captured=1
+          fi
+          if [ "$captured" -eq 0 ]; then
             cat "$err"
-            echo "::error::privileged IR burst failed; inspect the capture or sudo diagnostic above. The trusted hardware runner needs noninteractive sudo for burst_dump."
+            echo "::error::privileged IR burst failed; inspect the capture or sudo diagnostic above. The trusted hardware runner needs noninteractive sudo for burst_dump (or its installed fixed capture helper)."
             exit 1
           fi
           cat "$err"

--- a/.github/workflows/hardware-suite.yml
+++ b/.github/workflows/hardware-suite.yml
@@ -27,6 +27,8 @@ concurrency:
 
 jobs:
   hardware:
+    # Manual dispatch must not run privileged hardware code from another ref.
+    if: github.ref == 'refs/heads/main'
     name: build · test · real-TPM · IR camera
     # Either available runner may take this lane when it carries every
     # required capability label. Labels describe capabilities, not priority.
@@ -140,16 +142,9 @@ jobs:
           echo "IR node: $ir"
           out=$(mktemp -d)
           trap 'rm -rf "$out"' EXIT
-          # Run the burst unprivileged. Since #392, irlume-camera creates the
-          # emitter lock 0660 root:video, matching /dev/video* (root:video
-          # 0660). The runner account is in the video group, so it can take
-          # the lock directly. Falling back to sudo if the lock is somehow
-          # still unreachable (the daemon has not run yet on this boot).
-          # The check below asserts the emitter strobes, and an unprivileged
-          # run measures whatever state the emitter was left in by the last
-          # root process rather than anything irlume did. It passed at a spread
-          # of 17.9 on 2026-08-08 with irlume's emitter control disabled
-          # throughout (#384).
+          # This trusted-main-only job must inspect the root-private recovery
+          # journal and create a lock when the daemon has not used this camera.
+          # Video-group membership alone cannot authorize those operations.
           burst="${CARGO_TARGET_DIR:-target}/debug/examples/burst_dump"
           cargo build -q -p irlume-camera --example burst_dump
           if [ ! -x "$burst" ]; then
@@ -157,23 +152,13 @@ jobs:
             exit 1
           fi
           err="$(mktemp)"
-          # irlume-camera creates the emitter lock 0660 root:video, matching
-          # /dev/video* (root:video 0660). The runner account is in the video
-          # group, so the burst runs unprivileged. If the lock is somehow
-          # unreachable, sudo -n is the fallback, and the error message names
-          # both remedies.
-          # The lock is 0660 root:video since #392, so the runner account can
-          # take it directly. Fall back to sudo if the lock is still unreachable
-          # (the daemon has not run yet on this boot, or the machine's video
-          # group has a different gid than the one the daemon set).
-          locked=0
-          if env IRLUME_LOG_EMITTER_WRITES=1 "$burst" "$out" "$ir" 6 2>"$err"; then
-            locked=1
-          elif grep -q "cannot lock" "$err" && sudo -n true 2>/dev/null; then
-            sudo -n env IRLUME_LOG_EMITTER_WRITES=1 "$burst" "$out" "$ir" 6 2>"$err" && locked=1
-          fi
-          if [ "$locked" -eq 0 ]; then
-            echo "::error::this runner cannot take the emitter lock, so the emitter check cannot run. The lock is /run/lock/irlume-emitter-*.lock, created 0660 root:video by the daemon since #392. Two remedies: (a) make sure the runner account is in the video group, or (b) give it passwordless sudo. Failing rather than passing, because a check that cannot run has not passed"
+          # Raw capture can succeed while emitter setup refuses to write, so
+          # its exit status cannot select an unprivileged-to-sudo fallback.
+          # Run once with the required privilege, keeping the positive-write
+          # marker, frame count and spread checks below as independent gates.
+          if ! sudo -n env IRLUME_LOG_EMITTER_WRITES=1 "$burst" "$out" "$ir" 6 2>"$err"; then
+            cat "$err"
+            echo "::error::privileged IR burst failed; inspect the capture or sudo diagnostic above. The trusted hardware runner needs noninteractive sudo for burst_dump."
             exit 1
           fi
           cat "$err"

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -5140,35 +5140,24 @@ mod tests {
         );
     }
 
-    /// The same drift as above, one field over: the gate that refuses to run the
-    /// emitter check and the line that actually runs it must name the same
-    /// mechanism. The step invokes the burst through `sudo -n`, so passwordless
-    /// sudo is the only thing that lets it proceed, and a failure message
-    /// offering any other remedy sends an operator to a change the step ignores.
-    /// #393 shipped exactly that: the message offered a lock-permission route
-    /// while the gate still exited on `sudo -n true`, so following it left the
-    /// nightly red for a reason the message had ruled out.
-    ///
-    /// Both directions matter, which is why the first assertion is here. When
-    /// #392 is decided and the burst stops going through sudo, this fails and
-    /// forces the message to be rewritten in the same commit rather than
-    /// quietly becoming false.
-    ///
-    /// No `concat!` dance is needed: this reads the workflow only, and the
-    /// workflow does not contain this file's source, so a needle cannot match
-    /// itself the way it did in the test above.
+    /// Keep the privileged invocation and its operator guidance in agreement.
+    /// Raw capture can succeed even when emitter setup refuses an unreadable
+    /// recovery journal. Video-group membership cannot read that root-private
+    /// state, so the nightly must not advertise it as an alternative to sudo.
     #[test]
-    fn the_emitter_gate_names_both_remedies() {
+    fn the_emitter_gate_names_the_required_privilege() {
         let workflow = include_str!("../../../.github/workflows/hardware-suite.yml");
         assert!(
-            workflow.contains("env IRLUME_LOG_EMITTER_WRITES=1"),
-            "the burst no longer carries IRLUME_LOG_EMITTER_WRITES in its \
-             invocation; the gate below has stopped being true (#392)"
+            workflow.contains("sudo -n env IRLUME_LOG_EMITTER_WRITES=1"),
+            "the emitter invocation must carry its trace flag through noninteractive sudo"
         );
         assert!(
-            workflow.contains("Two remedies"),
-            "the gate message no longer names both remedies: the video group \
-             route and the sudo fallback (#392)"
+            workflow.contains("needs noninteractive sudo for burst_dump"),
+            "the gate message must name the privilege used by the capture invocation"
+        );
+        assert!(
+            !workflow.contains("Two remedies"),
+            "video-group access alone cannot authorize recovery-journal inspection"
         );
     }
 

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -1,0 +1,90 @@
+# Restricted nightly IR capture
+
+`irlume-ci-capture.py` is an administrator-installed helper for a self-hosted
+runner without general sudo. The workflow uses it when
+`/usr/local/libexec/irlume-ci-capture` exists. Otherwise it uses the existing
+noninteractive-sudo capture route. Both paths retain the emitter-write marker,
+minimum frame count and brightness-spread gates.
+
+The helper accepts exactly the checked-out Git source-tree ID and IR device. It
+runs a separately approved, root-owned capture ELF for six frames, with a clean
+environment and a 45-second timeout. It executes the same inode whose SHA256 it
+verified. Capture files stay in a root-private temporary directory, are streamed
+as a bounded archive into the workflow's temporary directory, and are removed
+by both sides' cleanup. It accepts no command, executable path, output path,
+frame count or environment overrides. The helper does not grant authentication
+or return enrolled biometric data.
+
+## Installation and approval
+
+Installation is an administrator operation, separate from a runner job. Do not
+promote an existing runner-owned executable by merely copying and hashing it.
+Build `cargo build --locked -p irlume-camera --example burst_dump` from the exact
+reviewed source tree in a trusted build environment, record the toolchain and
+build result, and verify that tree against the approved signed commit. Verify
+the ELF interpreter, DT_NEEDED, RPATH/RUNPATH and the target host's resolved
+libraries; no loader/search path or dependency may be runner-writable. The
+source tree must match the checkout that the hardware workflow will test. A
+merge with the identical tree can reuse approval; a changed tree cannot.
+
+Install the following paths with root ownership and no group/other write access:
+
+| Path | Mode | Content |
+|---|---|---|
+| `/usr/local/libexec/irlume-ci-capture` | `0755` | Exact reviewed helper; preserve its `python3 -I` shebang |
+| `/usr/local/lib/irlume-ci` | `0755` | Approved-artifact directory |
+| `/usr/local/lib/irlume-ci/burst_dump` | `0755` | Trusted capture ELF |
+| `/usr/local/lib/irlume-ci/capture.json` | `0644` | Manifest below |
+| `/var/lib/irlume-ci` | `0700` | Private temporary capture storage |
+
+Every ancestor must be a real root-owned directory without group/other write
+access. The helper refuses symlinks, unsafe ownership/modes, mismatched tree,
+wrong device or changed executable digest before capture.
+
+Manifest (replace placeholders with verified values):
+
+```json
+{"schema": 1, "source_tree": "<40-character Git tree ID>", "sha256": "<64-character ELF SHA256>", "device": "/dev/video2"}
+```
+
+For the verified Archhost runner account `ghrunner`, the only required sudoers
+command rule is:
+
+```sudoers
+ghrunner ALL=(root) NOPASSWD: /usr/local/libexec/irlume-ci-capture
+```
+
+The helper itself validates its two arguments. Do not grant `env`, a shell,
+`SETENV`, a runner-writable binary, or `ALL`. Keep `env_reset` enabled. Stage the
+rule privately, validate it with `visudo -cf`, install it root-owned `0440`, and
+validate the complete sudo policy. Confirm ordinary `sudo -n true` and an
+unapproved helper source tree remain denied. Do not change runner labels to
+conceal a missing privilege prerequisite.
+
+## Qualification and maintenance
+
+Run `test-irlume-ci-capture.py` and `../test-nightly-ir-capture.py` without root;
+they do not operate hardware. Before deployment, also exercise actual root
+execution with a synthetic ELF in an isolated root-owned staging directory:
+valid capture/archive, environment isolation, rejected tree/device, writable or
+changed ELF, missing marker, symlink output, insufficient frames, timeout and
+cleanup. These integration fixtures must never use a physical camera.
+
+After installing an approved artifact, perform a separately authorized bounded
+hardware check and verify camera release and product-daemon health. Fixture
+success is not physical-camera acceptance. The normal nightly remains restricted
+to main and covers the complete build, tests, real TPM, camera and coverage flow.
+The helper's executable is an independently built artifact of that exact source
+tree; it is not claimed to be byte-identical to the runner's local build.
+
+A new source tree intentionally requires a new trusted build and administrator
+promotion. Prepare the new ELF and manifest together, keep the previous pair,
+and verify the new pair before enabling it. A mismatched pair fails closed.
+Do not silently approve whatever the runner has built to make CI green.
+
+Before initial installation, retain a root-private manifest of created paths and
+any pre-existing files. Rollback removes only the newly introduced sudoers rule
+and helper/artifact paths after identity checks, or restores the previous
+approved pair. It does not change product packages, enrollment, PAM, runner
+services or runner labels. Keep failed qualification evidence and report the
+remaining hardware gate accurately.

--- a/scripts/ci/irlume-ci-capture.py
+++ b/scripts/ci/irlume-ci-capture.py
@@ -1,0 +1,139 @@
+#!/usr/bin/python3 -I
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright the irlume contributors.
+"""Root-installed, source-bound, digest-pinned IR capture for a restricted CI account.
+
+The administrator installs this file and an approved ELF separately. No caller
+path, command, environment, frame count or output directory is accepted. Stdout
+is a tar archive of capture files; diagnostics go to stderr.
+"""
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import stat
+import subprocess
+import sys
+import tarfile
+import tempfile
+
+BASE = Path('/usr/local/lib/irlume-ci')
+MANIFEST = BASE / 'capture.json'
+BINARY = BASE / 'burst_dump'
+SCRATCH = Path('/var/lib/irlume-ci')
+MAX_ARCHIVE_BYTES = 32 * 1024 * 1024
+
+
+def trusted_metadata(path, *, directory=False):
+    """Reject symlinks and any path component writable by a non-root user."""
+    for current in [path, *path.parents]:
+        info = current.lstat()
+        is_dir = directory if current == path else True
+        expected = stat.S_ISDIR if is_dir else stat.S_ISREG
+        if not expected(info.st_mode) or info.st_uid != 0 or info.st_mode & 0o022:
+            raise ValueError(f'untrusted installed path: {current}')
+
+
+def approved_binary(tree, device):
+    if not re.fullmatch(r'[0-9a-f]{40}', tree):
+        raise ValueError('expected one Git source-tree identity')
+    if not re.fullmatch(r'/dev/video[0-9]{1,3}', device):
+        raise ValueError('expected a video device path')
+    trusted_metadata(MANIFEST)
+    if MANIFEST.stat().st_size > 4096:
+        raise ValueError('capture manifest is oversized')
+    config = json.loads(MANIFEST.read_text())
+    if config.get('schema') != 1 or config.get('source_tree') != tree:
+        raise ValueError('capture build is not approved; an administrator must promote it')
+    if config.get('device') != device:
+        raise ValueError('capture device is not approved')
+    digest = config.get('sha256', '')
+    if not isinstance(digest, str) or not re.fullmatch(r'[0-9a-f]{64}', digest):
+        raise ValueError('approved executable digest is invalid')
+    trusted_metadata(BINARY)
+    fd = os.open(BINARY, os.O_RDONLY | os.O_NOFOLLOW | os.O_CLOEXEC)
+    try:
+        info = os.fstat(fd)
+        if info.st_uid != 0 or info.st_mode & 0o022 or not stat.S_ISREG(info.st_mode):
+            raise ValueError('untrusted capture executable')
+        with os.fdopen(os.dup(fd), 'rb') as stream:
+            if stream.read(4) != b'\x7fELF':
+                raise ValueError('approved capture must be an ELF executable')
+            stream.seek(0)
+            if hashlib.file_digest(stream, 'sha256').hexdigest() != digest:
+                raise ValueError('approved capture executable digest changed')
+        return fd
+    except BaseException:
+        os.close(fd)
+        raise
+
+
+def archive_paths(output):
+    """Emit only bounded, regular capture files with fixed, flat names."""
+    paths = sorted(output.iterdir())
+    frames = []
+    total = 0
+    for path in paths:
+        info = path.lstat()
+        if not stat.S_ISREG(info.st_mode) or info.st_nlink != 1:
+            raise ValueError('capture output is not a standalone regular file')
+        if path.name != 'means.txt':
+            if not re.fullmatch(r'frame0[0-5]\.pgm', path.name):
+                raise ValueError('unexpected capture output name')
+            frames.append(path)
+        total += info.st_size
+    if not 4 <= len(frames) <= 6 or not (output / 'means.txt').is_file():
+        raise ValueError('capture output is incomplete')
+    if total > MAX_ARCHIVE_BYTES:
+        raise ValueError('capture output exceeds the size limit')
+    return paths
+
+
+def capture(tree, device):
+    if os.geteuid() != 0:
+        raise ValueError('capture helper requires root through its scoped sudo rule')
+    os.umask(0o077)
+    fd = approved_binary(tree, device)
+    try:
+        trusted_metadata(SCRATCH, directory=True)
+        with tempfile.TemporaryDirectory(prefix='capture-', dir=SCRATCH) as name:
+            output = Path(name)
+            # Execute the same inode we hashed, even during an administrator's
+            # atomic upgrade. Never forward the caller's loader or Irlume env.
+            result = subprocess.run(
+                [f'/proc/self/fd/{fd}', str(output), device, '6'],
+                pass_fds=(fd,), cwd=output,
+                env={'PATH': '/usr/bin:/bin', 'LC_ALL': 'C',
+                     'IRLUME_LOG_EMITTER_WRITES': '1'},
+                stdout=subprocess.DEVNULL, stderr=subprocess.PIPE,
+                timeout=45, check=False,
+            )
+            diagnostic = result.stderr.decode('utf-8', errors='replace')
+            sys.stderr.write(diagnostic[-16384:])
+            if result.returncode:
+                raise ValueError(f'approved capture failed: exit {result.returncode}')
+            if 'irlume: capture emitter write completed' not in diagnostic.splitlines():
+                raise ValueError('approved capture did not complete an emitter write')
+            paths = archive_paths(output)
+            with tarfile.open(fileobj=sys.stdout.buffer, mode='w|') as archive:
+                for path in paths:
+                    archive.add(path, arcname=path.name, recursive=False)
+    finally:
+        os.close(fd)
+
+
+def main():
+    if len(sys.argv) != 3:
+        print('usage: irlume-ci-capture SOURCE_TREE /dev/videoN', file=sys.stderr)
+        return 2
+    try:
+        capture(*sys.argv[1:])
+    except (OSError, ValueError, subprocess.TimeoutExpired) as error:
+        print(f'irlume-ci-capture: {error}', file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/ci/test-irlume-ci-capture.py
+++ b/scripts/ci/test-irlume-ci-capture.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Pure validation fixtures; no root commands or camera operations."""
+import importlib.util
+import os
+from pathlib import Path
+import stat
+import tempfile
+import unittest
+from unittest.mock import patch
+
+SPEC = importlib.util.spec_from_file_location('capture_helper', Path(__file__).with_name('irlume-ci-capture.py'))
+HELPER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(HELPER)
+
+
+class CaptureValidationTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.output = Path(self.temp.name)
+        (self.output / 'means.txt').write_text('00 1.0 0.0\n')
+        for i in range(6):
+            (self.output / f'frame{i:02}.pgm').write_bytes(b'P5\n1 1\n255\n\x01')
+
+    def test_only_fixed_flat_files_are_archived(self):
+        self.assertEqual(len(HELPER.archive_paths(self.output)), 7)
+
+    def test_unexpected_names_and_directories_are_rejected(self):
+        for name, directory in [('extra.txt', False), ('frame06.pgm', False), ('nested', True)]:
+            with self.subTest(name=name):
+                path = self.output / name
+                path.mkdir() if directory else path.write_text('unexpected')
+                with self.assertRaises(ValueError):
+                    HELPER.archive_paths(self.output)
+                path.rmdir() if directory else path.unlink()
+
+    def test_symlink_is_not_archived(self):
+        path = self.output / 'frame00.pgm'
+        path.unlink()
+        path.symlink_to('/etc/passwd')
+        with self.assertRaises(ValueError):
+            HELPER.archive_paths(self.output)
+
+    def test_hardlink_is_not_archived(self):
+        os.link(self.output / 'frame00.pgm', self.output / 'alias')
+        with self.assertRaises(ValueError):
+            HELPER.archive_paths(self.output)
+
+    def test_incomplete_capture_is_rejected(self):
+        for i in range(3):
+            (self.output / f'frame{i:02}.pgm').unlink()
+        with self.assertRaises(ValueError):
+            HELPER.archive_paths(self.output)
+
+    def test_missing_means_is_rejected(self):
+        (self.output / 'means.txt').unlink()
+        with self.assertRaises(ValueError):
+            HELPER.archive_paths(self.output)
+
+    def test_oversized_capture_is_rejected(self):
+        with open(self.output / 'frame00.pgm', 'wb') as stream:
+            stream.truncate(HELPER.MAX_ARCHIVE_BYTES + 1)
+        with self.assertRaises(ValueError):
+            HELPER.archive_paths(self.output)
+
+    def test_unprivileged_call_refused_before_binary_access(self):
+        with patch.object(HELPER.os, 'geteuid', return_value=1000), \
+             patch.object(HELPER, 'approved_binary') as approve:
+            with self.assertRaisesRegex(ValueError, 'requires root'):
+                HELPER.capture('a' * 40, '/dev/video2')
+            approve.assert_not_called()
+
+    def test_invalid_arguments_refused_before_installed_path_access(self):
+        for digest, device in [('bad', '/dev/video2'), ('a' * 40, '/etc/passwd'), ('A' * 40, '/dev/video2')]:
+            with self.subTest(digest=digest, device=device), \
+                 patch.object(HELPER, 'trusted_metadata') as metadata:
+                with self.assertRaises(ValueError):
+                    HELPER.approved_binary(digest, device)
+                metadata.assert_not_called()
+
+    def test_nonroot_writable_or_symlink_metadata_is_rejected(self):
+        # Metadata policy itself is tested independently of the CI user's uid.
+        for mode, uid in [(stat.S_IFREG | 0o644, 1000),
+                          (stat.S_IFREG | 0o664, 0),
+                          (stat.S_IFLNK | 0o777, 0)]:
+            info = os.stat_result((mode, 0, 0, 1, uid, 0, 0, 0, 0, 0))
+            with self.subTest(mode=mode, uid=uid), patch.object(Path, 'lstat', return_value=info):
+                with self.assertRaises(ValueError):
+                    HELPER.trusted_metadata(Path('/usr/local/lib/irlume-ci/burst_dump'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/test-nightly-ir-capture.py
+++ b/scripts/test-nightly-ir-capture.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright the irlume contributors.
+"""Execute the real nightly camera shell with fixtures; never access hardware."""
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def camera_step():
+    lines = (ROOT / '.github/workflows/hardware-suite.yml').read_text().splitlines()
+    start = lines.index('      - name: IR camera strobe-burst capture')
+    assert lines[start + 1] == '        run: |'
+    body = []
+    for line in lines[start + 2:]:
+        if line.strip() and not line.startswith('          '):
+            break
+        body.append(line[10:])
+    assert body
+    return '\n'.join(body)
+
+
+class NightlyCaptureTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory(prefix='irlume-nightly-fixture-')
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.bin = self.root / 'bin'
+        self.bin.mkdir()
+        self.target = self.root / 'target with spaces'
+        (self.target / 'debug/examples').mkdir(parents=True)
+        (self.root / 'scripts').mkdir()
+        shutil.copy(ROOT / 'scripts/ir-node-from-doctor.sh', self.root / 'scripts')
+        self.write(self.bin / 'cargo', '#!/bin/bash\nexit 0\n')
+        self.write(self.bin / 'sudo', '''#!/bin/bash
+set -eu
+[ "$1" = -n ] || exit 90
+shift
+if [ "${DENY_SUDO:-0}" = 1 ]; then
+  echo 'sudo: fixture requires a password' >&2
+  exit 1
+fi
+export FIXTURE_PRIVILEGED=1
+exec "$@"
+''')
+        self.write(self.target / 'debug/irlume', '''#!/bin/bash
+printf '%s\\n' '[doctor] camera nodes (classified by pixel format):' '  /dev/video2: Ir (uvcvideo, USB)'
+''')
+        self.write(self.target / 'debug/examples/burst_dump', '''#!/bin/bash
+set -eu
+printf '%s\\n' "${FIXTURE_PRIVILEGED:-0}" >> "$CALLS"
+[ "$2" = /dev/video2 ] && [ "$3" = 6 ] || exit 91
+[ "${IRLUME_LOG_EMITTER_WRITES:-0}" = 1 ] || exit 92
+if [ "${FAIL_CAPTURE:-0}" = 1 ]; then
+  echo 'fixture: capture failed' >&2
+  exit 23
+fi
+mkdir -p "$1"
+for ((i=0; i<${FRAMES:-6}; i++)); do
+  touch "$1/frame$i.pgm"
+  printf '%s %s\\n' "$i" "$((i * ${SPREAD:-10}))" >> "$1/means.txt"
+done
+if [ "${FIXTURE_PRIVILEGED:-0}" != 1 ]; then
+  # The actual failure: successful raw capture, but no managed emitter write.
+  echo 'irlume: could not check interrupted emitter setup: lock: Permission denied' >&2
+elif [ "${NO_MARKER:-0}" != 1 ]; then
+  echo 'irlume: capture emitter write completed' >&2
+fi
+''')
+        self.env = dict(os.environ, PATH=f'{self.bin}:/usr/bin:/bin',
+                        CARGO_TARGET_DIR=str(self.target), TMPDIR=str(self.root),
+                        CALLS=str(self.root / 'calls'))
+        for key in ['FIXTURE_PRIVILEGED', 'DENY_SUDO', 'FAIL_CAPTURE', 'FRAMES',
+                    'SPREAD', 'NO_MARKER']:
+            self.env.pop(key, None)
+
+    def write(self, path, source):
+        path.write_text(textwrap.dedent(source))
+        path.chmod(0o755)
+
+    def run_step(self, **env):
+        return subprocess.run(['/bin/bash', '-e', '-c', camera_step()],
+                              cwd=self.root, env=dict(self.env, **env),
+                              capture_output=True, text=True, timeout=10)
+
+    def test_privileged_hardware_job_is_restricted_to_main(self):
+        workflow = (ROOT / '.github/workflows/hardware-suite.yml').read_text()
+        hardware = workflow.split('  hardware:\n', 1)[1].split('    steps:', 1)[0]
+        self.assertIn("    if: github.ref == 'refs/heads/main'\n", hardware)
+
+    def test_privileged_capture_succeeds_without_unprivileged_probe(self):
+        result = self.run_step()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual((self.root / 'calls').read_text(), '1\n')
+        self.assertIn('captured 6 frames', result.stdout)
+        self.assertIn('mean spread: 50.0', result.stdout)
+
+    def test_sudo_denied_never_captures(self):
+        result = self.run_step(DENY_SUDO='1')
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse((self.root / 'calls').exists())
+        self.assertIn('requires a password', result.stdout + result.stderr)
+
+    def test_capture_failure_preserves_diagnostic(self):
+        result = self.run_step(FAIL_CAPTURE='1')
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn('fixture: capture failed', result.stdout + result.stderr)
+
+    def test_successful_capture_without_write_marker_fails(self):
+        result = self.run_step(NO_MARKER='1')
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn('did not complete the emitter write', result.stdout)
+
+    def test_insufficient_frames_fail(self):
+        result = self.run_step(FRAMES='3')
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn('captured 3 frames', result.stdout)
+
+    def test_flat_burst_fails(self):
+        result = self.run_step(SPREAD='0')
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn('mean spread: 0.0', result.stdout)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/test-nightly-ir-capture.py
+++ b/scripts/test-nightly-ir-capture.py
@@ -38,6 +38,7 @@ class NightlyCaptureTests(unittest.TestCase):
         (self.root / 'scripts').mkdir()
         shutil.copy(ROOT / 'scripts/ir-node-from-doctor.sh', self.root / 'scripts')
         self.write(self.bin / 'cargo', '#!/bin/bash\nexit 0\n')
+        self.write(self.bin / 'git', '#!/bin/bash\nprintf \"%s\\n\" aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n')
         self.write(self.bin / 'sudo', '''#!/bin/bash
 set -eu
 [ "$1" = -n ] || exit 90
@@ -77,7 +78,7 @@ fi
                         CARGO_TARGET_DIR=str(self.target), TMPDIR=str(self.root),
                         CALLS=str(self.root / 'calls'))
         for key in ['FIXTURE_PRIVILEGED', 'DENY_SUDO', 'FAIL_CAPTURE', 'FRAMES',
-                    'SPREAD', 'NO_MARKER']:
+                    'SPREAD', 'NO_MARKER', 'HELPER_EXIT', 'REJECT_BUILD']:
             self.env.pop(key, None)
 
     def write(self, path, source):
@@ -85,9 +86,52 @@ fi
         path.chmod(0o755)
 
     def run_step(self, **env):
-        return subprocess.run(['/bin/bash', '-e', '-c', camera_step()],
+        body = camera_step().replace('/usr/local/libexec/irlume-ci-capture', str(self.root / 'capture-helper'))
+        return subprocess.run(['/bin/bash', '-e', '-c', body],
                               cwd=self.root, env=dict(self.env, **env),
                               capture_output=True, text=True, timeout=10)
+
+    def install_helper(self):
+        self.write(self.root / 'capture-helper', '''#!/bin/bash
+set -eu
+[ "${FIXTURE_PRIVILEGED:-0}" = 1 ] || exit 93
+export IRLUME_LOG_EMITTER_WRITES=1
+[ "$1" = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ] || exit 94
+if [ "${REJECT_BUILD:-0}" = 1 ]; then
+  echo 'fixture: build is not approved' >&2
+  exit 1
+fi
+out=$(mktemp -d)
+trap 'rm -rf "$out"' EXIT
+"$CARGO_TARGET_DIR/debug/examples/burst_dump" "$out" "$2" 6 >/dev/null
+tar -C "$out" -cf - .
+exit "${HELPER_EXIT:-0}"
+''')
+
+    def test_installed_helper_preserves_all_capture_gates(self):
+        self.install_helper()
+        result = self.run_step()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual((self.root / 'calls').read_text(), '1\n')
+        self.assertIn('captured 6 frames', result.stdout)
+        self.assertIn('mean spread: 50.0', result.stdout)
+        for env in [dict(NO_MARKER='1'), dict(FRAMES='3'), dict(SPREAD='0')]:
+            with self.subTest(env=env):
+                result = self.run_step(**env)
+                self.assertNotEqual(result.returncode, 0)
+
+    def test_helper_failure_cannot_hide_behind_successful_archive_extraction(self):
+        self.install_helper()
+        result = self.run_step(HELPER_EXIT='23')
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn('privileged IR burst failed', result.stdout)
+
+    def test_unapproved_helper_build_never_captures(self):
+        self.install_helper()
+        result = self.run_step(REJECT_BUILD='1')
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse((self.root / 'calls').exists())
+        self.assertIn('build is not approved', result.stdout + result.stderr)
 
     def test_privileged_hardware_job_is_restricted_to_main(self):
         workflow = (ROOT / '.github/workflows/hardware-suite.yml').read_text()


### PR DESCRIPTION
## Problem and behavior

The nightly camera capture could exit successfully after emitter setup was refused: six raw frames existed, so its exit-status-based sudo fallback never ran. The positive emitter-write gate then correctly failed. The capture now starts with its required privilege and retains the exact emitter-write marker, minimum frame count, and brightness-spread gates.

Runners without general sudo can use a separately installed, root-owned helper. It accepts only an administrator-approved Git source tree and fixed camera, verifies a trusted build's ELF digest, captures six frames with a clean environment and 45-second timeout, and streams a bounded archive from private temporary storage. It accepts no caller command, executable or output path. A changed tree requires administrator promotion. Hardware jobs explicitly require the main ref; shared runner capability labels remain unchanged.

The Rust workflow contract now checks the actual privilege requirement and rejects the obsolete video-group remedy. Operator documentation covers trusted builds, target loader checks, installation, qualification, maintenance and rollback.

## Validation

- Camera library: 657 passed; capture-timing: 670 passed; 27 existing hardware ignores in each host run.
- Final emitter contract: 5 passed, 1 existing ignore.
- 10 executable workflow fixtures and 10 helper validation fixtures passed.
- 11 actual-root synthetic integration cases passed: environment isolation, fixed device/tree, ownership/hash refusals, failed child, exact marker, archive validation, timeout and cleanup. No physical camera was used for those fixtures.
- Camera all-target clippy, fmt, diff checks, actionlint 1.7.12, all 52 action pins, and zizmor 1.28.0 regular/offline audit passed.
- Independent source review found no remaining actionable findings.

The trusted local capture ELF passed Archhost interpreter/library resolution and ownership checks. Its persistent helper/sudo rule installation is prepared but awaiting explicit approval after automatic review rejected the privilege change. No corrected full hardware suite has run yet; that remains a post-merge gate. These changes do not alter product authentication behavior.
