### PR TITLE
ci: distinguish verified emitter defaults from completed writes

### DIFF
--- a/.github/workflows/hardware-suite.yml
+++ b/.github/workflows/hardware-suite.yml
@@ -155,8 +155,8 @@ jobs:
           err="$(mktemp)"
           # Raw capture can succeed while emitter setup refuses to write, so
           # its exit status cannot select an unprivileged-to-sudo fallback.
-          # Run once with the required privilege, keeping the positive-write
-          # marker, frame count and spread checks below as independent gates.
+          # Run once with the required privilege, keeping the positive emitter
+          # proof, frame count and spread checks below as independent gates.
           helper=/usr/local/libexec/irlume-ci-capture
           captured=0
           if [ -x "$helper" ]; then
@@ -176,20 +176,13 @@ jobs:
             exit 1
           fi
           cat "$err"
-          # A POSITIVE marker, not the absence of one refusal string. The first
-          # version of this guard grepped for the lock refusal, which covers one
-          # of at least six inert paths through `ir_emitter::enable`: an
-          # unreadable USB identity, a recovery reporting Busy or
-          # OwnerStillRunning (both silent by design), no applicable control, and
-          # a failed apply_device_default or apply_known_payload. Any of those
-          # captures frames that look exactly like a successful run.
-          #
-          # `AlreadyHeld` is deliberately NOT accepted: it shows the control
-          # holds the wanted value, which is not the same as this invocation
-          # having driven it, and driving it is what this step claims to test
-          # (#384 review).
-          if ! grep -Fxq "irlume: capture emitter write completed" "$err"; then
-            echo "::error::irlume did not complete the emitter write, so the spread below is the emitter's leftover state rather than evidence irlume can light it (#384)"
+          # Two distinct positive proofs from the capture's own open camera:
+          # a completed write, or a validated active device default. The latter
+          # is read-only and cannot be emitted after a failed/configured write.
+          # Neither AlreadyHeld nor brightness alone establishes either proof.
+          proofs=$(grep -Fxc -e "irlume: capture emitter write completed" -e "irlume: capture emitter device default verified" "$err" || true)
+          if [ "$proofs" -ne 1 ]; then
+            echo "::error::irlume did not complete the emitter write or verify a unique active device default; missing, duplicate and ambiguous proofs fail"
             exit 1
           fi
           frames=$(find "$out" -name "frame*.pgm" | wc -l)
@@ -208,8 +201,8 @@ jobs:
           # Both alternate between roughly 30 and roughly 135: the camera cycles
           # its own state between capture sessions (#264's self-strobing seen
           # from the other side), and every run clears this floor by a wide
-          # margin either way. So this asserts that the camera delivers
-          # alternating frames, not that irlume's extension-unit write reached
+          # margin either way. So this asserts a non-flat brightness range,
+          # not frame alternation or that irlume's extension-unit write reached
           # it. A discriminator that depends on the write is tracked on #384.
           awk '{print $2}' "$out/means.txt" | sort -n | awk 'NR==1{min=$1} END{max=$1; d=max-min; printf "mean spread: %.1f\n", d; exit (d < 5)}'
 

--- a/crates/irlume-camera/src/ir_emitter.rs
+++ b/crates/irlume-camera/src/ir_emitter.rs
@@ -1799,12 +1799,37 @@ fn enable_guarded(
     // instead.
     let recovery = recover_pending_write(fd, &id);
     let action = planned_action(&recovery, wanted, &id);
+    let can_prove_default = default_proof_allowed(&recovery, &action);
     report_recovery(&id, recovery);
 
     // Which control the write is going to. Needed here only to give the guard
     // its coordinates; every read of the control itself happens inside the
     // apply path, on the same pass that decides whether to write.
     let Some((unit, selector)) = action.coordinates() else {
+        // Diagnostic observation only. A configured/known write, explicit off,
+        // foreign owner or unchecked recovery can never fall back to this proof.
+        // Keep normal authentication's behavior unchanged when tracing is off.
+        if can_prove_default && std::env::var_os("IRLUME_LOG_EMITTER_WRITES").is_some() {
+            if let Ok(lock) = crate::stream_record::acquire(&id) {
+                if let Ok(Some(control)) = read_capture_default(fd, &id) {
+                    eprintln!("irlume: capture emitter device default verified");
+                    return Ok(StreamMode::new(Box::new(UvcMode {
+                        handle: Some(EmitterHandle {
+                            handle,
+                            lease: None,
+                        }),
+                        unit: control.unit,
+                        selector: control.selector,
+                        restore: Vec::new(),
+                        applied: Vec::new(),
+                        armed: false,
+                        active: false, // observational proof, not an enable operation
+                        record: None,
+                        _lock: Some(lock),
+                    })));
+                }
+            }
+        }
         return Ok(StreamMode::inert());
     };
 
@@ -3017,6 +3042,51 @@ struct IntendedValue {
     /// The value is not merely supported: it is also what `GET_DEF` says this
     /// camera chooses without a host write.
     is_device_default: bool,
+}
+
+/// A default observation cannot replace an attempted write or unresolved state.
+fn default_proof_allowed(recovery: &RecoveryOutcome, action: &CaptureAction) -> bool {
+    matches!(action, CaptureAction::Nothing)
+        && matches!(
+            recovery,
+            RecoveryOutcome::NothingPending
+                | RecoveryOutcome::ForAnotherCamera
+                | RecoveryOutcome::AlreadyRestored
+        )
+}
+
+/// Read-only Face Authentication D1 proof, using discovery's value validator.
+/// The descriptor and queries belong to the capture's open device. A current
+/// non-default value (including AlreadyHeld), changed value or query failure
+/// proves nothing. No measurement, SET_CUR, config or undo record is produced.
+fn read_capture_default(
+    fd: c_int,
+    id: &crate::uvc_descriptor::CameraIdentity,
+) -> XuResult<Option<EmitterControl>> {
+    let selector = crate::uvc_descriptor::MSXU_FACE_AUTHENTICATION;
+    let Some(ms) = id.microsoft_xu().filter(|ms| ms.advertises(selector)) else {
+        return Ok(None);
+    };
+    // Synchronous GET/SET support, with no disabled/automatic/async flags.
+    if get_info(fd, ms.unit_id, selector)? != 3 {
+        return Ok(None);
+    }
+    let len = get_len(fd, ms.unit_id, selector)?;
+    let original = get_cur(fd, ms.unit_id, selector, len)?;
+    let Ok(intended) = intended_value(fd, ms.unit_id, selector, len)? else {
+        return Ok(None);
+    };
+    if !intended.is_device_default || original != intended.payload {
+        return Ok(None);
+    }
+    if get_cur(fd, ms.unit_id, selector, len)? != original {
+        return Ok(None);
+    }
+    Ok(Some(EmitterControl {
+        unit: ms.unit_id,
+        selector,
+        payload: original,
+    }))
 }
 
 fn intended_value(
@@ -6001,6 +6071,138 @@ mod tests {
         assert_eq!(records, 0, "the confirmed restore clears the journal");
         drop(outcome);
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn capture_default_proof_reads_validated_current_default_without_writes() {
+        let _lock = crate::testenv::env_lock();
+        let _fake = fake_camera::install(fake_camera::Camera {
+            current: vec![1, 2, 2],
+            def: vec![1, 2, 2],
+            max: vec![1, 2, 3],
+            len: 3,
+            info: 3,
+            ..Default::default()
+        });
+        let control = read_capture_default(-1, &identity(0x046d, 0x085e))
+            .unwrap()
+            .unwrap();
+        assert_eq!(control.payload, vec![1, 2, 2]);
+        assert_eq!(fake_camera::current(), vec![1, 2, 2]);
+        let log = fake_camera::log();
+        assert_eq!(
+            log.iter()
+                .filter(|r| matches!(
+                    r,
+                    fake_camera::Request::Get {
+                        query: UVC_GET_CUR,
+                        ..
+                    }
+                ))
+                .count(),
+            2
+        );
+        assert!(log
+            .iter()
+            .all(|r| matches!(r, fake_camera::Request::Get { .. })));
+    }
+
+    #[test]
+    fn capture_default_proof_requires_an_advertised_microsoft_control() {
+        let _lock = crate::testenv::env_lock();
+        let _fake = fake_camera::install(fake_camera::Camera::default());
+        let mut id = identity(0x046d, 0x085e);
+        id.descriptors.clear();
+        assert!(read_capture_default(-1, &id).unwrap().is_none());
+        assert!(fake_camera::log().is_empty());
+    }
+
+    #[test]
+    fn capture_default_proof_marker_has_both_consumers() {
+        let marker = concat!("irlume: capture emitter ", "device default verified");
+        for consumer in [
+            include_str!("../../../.github/workflows/hardware-suite.yml"),
+            include_str!("../../../scripts/ci/irlume-ci-capture.py"),
+        ] {
+            assert!(consumer.contains(marker));
+        }
+        let producer = concat!(
+            "eprintln!(\"irlume: capture emitter ",
+            "device default verified\")"
+        );
+        assert!(include_str!("ir_emitter.rs").contains(producer));
+    }
+
+    #[test]
+    fn capture_default_proof_refuses_unverified_or_changing_state() {
+        let _lock = crate::testenv::env_lock();
+        for case in 0..6 {
+            let mut camera = fake_camera::Camera {
+                current: vec![1, 2, 2],
+                def: vec![1, 2, 2],
+                max: vec![1, 2, 3],
+                len: 3,
+                info: 3,
+                ..Default::default()
+            };
+            match case {
+                0 => camera.def = vec![1, 2, 1], // active, but not the default
+                1 => camera.current = vec![1, 2, 1],
+                2 => camera.max = vec![1, 2, 5], // D2 is not D1
+                3 => camera.info = 0x23,         // disabled by commit state
+                4 => camera.change_after_gets = Some((1, vec![1, 2, 1])),
+                _ => camera.fail_get_cur = Some(libc::EIO),
+            }
+            let _fake = fake_camera::install(camera);
+            assert!(
+                read_capture_default(-1, &identity(0x046d, 0x085e))
+                    .ok()
+                    .flatten()
+                    .is_none(),
+                "case {case}"
+            );
+            assert!(fake_camera::log()
+                .iter()
+                .all(|r| matches!(r, fake_camera::Request::Get { .. })));
+        }
+    }
+
+    #[test]
+    fn capture_default_proof_is_never_a_fallback_for_a_write_or_recovery_failure() {
+        let control = EmitterControl {
+            unit: 14,
+            selector: 6,
+            payload: vec![1, 2, 2],
+        };
+        for action in [
+            CaptureAction::KnownPayload(control.clone()),
+            CaptureAction::Override(control),
+            CaptureAction::DeviceDefault {
+                unit: 14,
+                selector: 6,
+            },
+        ] {
+            assert!(!default_proof_allowed(
+                &RecoveryOutcome::NothingPending,
+                &action
+            ));
+        }
+        for recovery in [
+            RecoveryOutcome::Busy,
+            RecoveryOutcome::Unchecked("fixture".into()),
+            RecoveryOutcome::Unresolved("fixture".into()),
+            RecoveryOutcome::OwnerStillRunning { pid: 1 },
+            RecoveryOutcome::Restored {
+                unit: 14,
+                selector: 6,
+            },
+        ] {
+            assert!(!default_proof_allowed(&recovery, &CaptureAction::Nothing));
+        }
+        assert!(default_proof_allowed(
+            &RecoveryOutcome::NothingPending,
+            &CaptureAction::Nothing
+        ));
     }
 
     /// Microsoft's Face Authentication control permits a dedicated IR

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -3,8 +3,8 @@
 `irlume-ci-capture.py` is an administrator-installed helper for a self-hosted
 runner without general sudo. The workflow uses it when
 `/usr/local/libexec/irlume-ci-capture` exists. Otherwise it uses the existing
-noninteractive-sudo capture route. Both paths retain the emitter-write marker,
-minimum frame count and brightness-spread gates.
+noninteractive-sudo capture route. Both paths require exactly one positive emitter proof, the minimum frame
+count and brightness-spread gates.
 
 The helper accepts exactly the checked-out Git source-tree ID and IR device. It
 runs a separately approved, root-owned capture ELF for six frames, with a clean
@@ -14,6 +14,33 @@ as a bounded archive into the workflow's temporary directory, and are removed
 by both sides' cleanup. It accepts no command, executable path, output path,
 frame count or environment overrides. The helper does not grant authentication
 or return enrolled biometric data.
+
+## Two positive outcomes
+
+The trace-enabled capture emits one of two exact diagnostic lines:
+
+- `irlume: capture emitter write completed`: this capture actually changed the
+  emitter control. Existing configured and known-device write paths keep this
+  requirement; a failed write or `AlreadyHeld` cannot use the default proof.
+- `irlume: capture emitter device default verified`: no write action was planned,
+  recovery was checked without a restore write, and the open camera advertised
+  a Microsoft Face Authentication control whose current value equals its own
+  validated D1 default. The capability/default validator is shared with setup;
+  a second current-value read rejects a change during validation. The capture
+  retains its stream lock but owns no control change to restore.
+
+The default path makes only control reads and exists only with emitter tracing
+requested. It does not alter normal authentication behavior, save a config,
+replay a payload, or manufacture a write. Missing, partial, repeated or mixed
+positive markers fail. Both outcomes still require frame delivery and brightness
+spread. These checks establish reported control state, frame delivery, and a non-flat
+brightness range;
+they do not establish that a host write caused an optical change. In particular,
+BRIO may operate in D1 by default while NexiGo requires an actual transition.
+
+The control contract is [Microsoft UVC Face Authentication](https://learn.microsoft.com/en-us/windows-hardware/drivers/stream/uvc-extensions-1-5#2226-face-authentication-control).
+Do not infer default readiness from VID:PID, successful face unlock, absence of
+errors, an already-held non-default value, or brightness alone.
 
 ## Installation and approval
 

--- a/scripts/ci/irlume-ci-capture.py
+++ b/scripts/ci/irlume-ci-capture.py
@@ -90,6 +90,16 @@ def archive_paths(output):
     return paths
 
 
+def capture_proof(diagnostic):
+    """Require exactly one positive outcome; an already-held value is neither."""
+    markers = {'irlume: capture emitter write completed': 'write',
+               'irlume: capture emitter device default verified': 'default'}
+    proofs = [markers[line] for line in diagnostic.splitlines() if line in markers]
+    if len(proofs) != 1:
+        raise ValueError('capture needs exactly one emitter write or verified device-default proof')
+    return proofs[0]
+
+
 def capture(tree, device):
     if os.geteuid() != 0:
         raise ValueError('capture helper requires root through its scoped sudo rule')
@@ -113,8 +123,7 @@ def capture(tree, device):
             sys.stderr.write(diagnostic[-16384:])
             if result.returncode:
                 raise ValueError(f'approved capture failed: exit {result.returncode}')
-            if 'irlume: capture emitter write completed' not in diagnostic.splitlines():
-                raise ValueError('approved capture did not complete an emitter write')
+            capture_proof(diagnostic)
             paths = archive_paths(output)
             with tarfile.open(fileobj=sys.stdout.buffer, mode='w|') as archive:
                 for path in paths:

--- a/scripts/ci/test-irlume-ci-capture.py
+++ b/scripts/ci/test-irlume-ci-capture.py
@@ -22,6 +22,17 @@ class CaptureValidationTests(unittest.TestCase):
         for i in range(6):
             (self.output / f'frame{i:02}.pgm').write_bytes(b'P5\n1 1\n255\n\x01')
 
+    def test_capture_proof_requires_one_exact_positive_outcome(self):
+        write = 'irlume: capture emitter write completed'
+        default = 'irlume: capture emitter device default verified'
+        self.assertEqual(HELPER.capture_proof(write), 'write')
+        self.assertEqual(HELPER.capture_proof(default), 'default')
+        for diagnostic in ['', 'irlume: capture emitter already held the requested value',
+                           'prefix ' + default, default + ' suffix',
+                           write + '\n' + default, write + '\n' + write]:
+            with self.subTest(diagnostic=diagnostic), self.assertRaises(ValueError):
+                HELPER.capture_proof(diagnostic)
+
     def test_only_fixed_flat_files_are_archived(self):
         self.assertEqual(len(HELPER.archive_paths(self.output)), 7)
 

--- a/scripts/test-nightly-ir-capture.py
+++ b/scripts/test-nightly-ir-capture.py
@@ -71,14 +71,20 @@ if [ "${FIXTURE_PRIVILEGED:-0}" != 1 ]; then
   # The actual failure: successful raw capture, but no managed emitter write.
   echo 'irlume: could not check interrupted emitter setup: lock: Permission denied' >&2
 elif [ "${NO_MARKER:-0}" != 1 ]; then
-  echo 'irlume: capture emitter write completed' >&2
+  case "${PROOF:-write}" in
+    write) echo 'irlume: capture emitter write completed' >&2 ;;
+    default) echo 'irlume: capture emitter device default verified' >&2 ;;
+    held) echo 'irlume: capture emitter already held the requested value' >&2 ;;
+    both) printf '%s\\n' 'irlume: capture emitter write completed' 'irlume: capture emitter device default verified' >&2 ;;
+    partial) echo 'prefix irlume: capture emitter device default verified' >&2 ;;
+  esac
 fi
 ''')
         self.env = dict(os.environ, PATH=f'{self.bin}:/usr/bin:/bin',
                         CARGO_TARGET_DIR=str(self.target), TMPDIR=str(self.root),
                         CALLS=str(self.root / 'calls'))
         for key in ['FIXTURE_PRIVILEGED', 'DENY_SUDO', 'FAIL_CAPTURE', 'FRAMES',
-                    'SPREAD', 'NO_MARKER', 'HELPER_EXIT', 'REJECT_BUILD']:
+                    'SPREAD', 'NO_MARKER', 'PROOF', 'HELPER_EXIT', 'REJECT_BUILD']:
             self.env.pop(key, None)
 
     def write(self, path, source):
@@ -132,6 +138,23 @@ exit "${HELPER_EXIT:-0}"
         self.assertNotEqual(result.returncode, 0)
         self.assertFalse((self.root / 'calls').exists())
         self.assertIn('build is not approved', result.stdout + result.stderr)
+
+    def test_verified_default_keeps_frame_and_spread_gates(self):
+        for helper in [False, True]:
+            if helper:
+                self.install_helper()
+            with self.subTest(helper=helper):
+                result = self.run_step(PROOF='default')
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                self.assertIn('device default verified', result.stdout)
+                for env in [dict(FRAMES='3'), dict(SPREAD='0')]:
+                    result = self.run_step(PROOF='default', **env)
+                    self.assertNotEqual(result.returncode, 0)
+
+    def test_held_partial_or_ambiguous_proof_is_rejected(self):
+        for proof in ['held', 'both', 'partial']:
+            with self.subTest(proof=proof):
+                self.assertNotEqual(self.run_step(PROOF=proof).returncode, 0)
 
     def test_privileged_hardware_job_is_restricted_to_main(self):
         workflow = (ROOT / '.github/workflows/hardware-suite.yml').read_text()


### PR DESCRIPTION
## Problem and resulting behavior

The BRIO reports an active, validated D1 Face Authentication device default and needs no emitter write. The nightly’s unconditional write marker therefore rejected a working camera. It now distinguishes two positive outcomes: an actual completed emitter write, or a separately verified active device default. Missing, partial, repeated, mixed, and AlreadyHeld-only markers still fail.

The default observation uses the capture’s open-device descriptors and the existing setup value validator: advertised Microsoft control, synchronous capabilities, current equals validated D1 default, and a second current-value read. It retains the stream lock without owning a restoration write. This diagnostic path runs only with emitter tracing and no planned write; configured/known write paths, explicit off, foreign ownership and unresolved recovery cannot fall back to it. Normal authentication behavior without tracing is unchanged.

The restricted helper and nightly shell require exactly one proof and preserve source-tree/digest authorization, privilege isolation, frame-count and brightness-spread gates. Shared runner selectors and main-only hardware execution remain unchanged. These tests establish reported control state, frame delivery and a non-flat brightness range; they do not claim optical causality or prove frame alternation from brightness spread alone.

## Validation

- Camera library: 662 passed; capture-timing: 675 passed; 27 existing hardware ignores each. Five new proof tests cover read-only success, invalid/moving/default-mismatched state, descriptor absence, write/recovery exclusions, and producer/consumer marker agreement.
- 12 executable workflow fixtures and 11 helper fixtures passed. Fifteen actual-root synthetic cases passed, including default proof, ambiguity/refusal, timeout and cleanup.
- Clippy, formatter, diff checks, actionlint, all 52 action pins and zizmor regular/offline audit passed. Independent review found no remaining code blocker.
- Exact signed-tree trusted candidate tested privately on both physical hosts: BRIO six frames, spread 39.4, GET-only trace and verified-default marker; NexiGo six frames, spread 11.1, completed write and restoration trace. Both cameras released, daemons/configuration unchanged, and no raw frames retained.

Candidate tests used private administrator stages, not a branch-triggered hardware workflow. The installed Archhost helper remains bound to current main; after merge, verify tree equality and promote the reviewed helper/artifact pair before running the complete main hardware and coverage suite. No package, PAM, enrollment, runner-label or permanent privilege change is included.
