### PR TITLE
ci: provision pinned nightly coverage tools on either runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -527,6 +527,9 @@ jobs:
           python3 scripts/test-nightly-ir-capture.py
           python3 scripts/ci/test-irlume-ci-capture.py
 
+      - name: nightly coverage setup (fixtures only, no install or hardware)
+        run: python3 scripts/ci/test-setup-coverage-tools.py
+
       - name: systemd-analyze verify (unit syntax)
         run: |
           set -euo pipefail

--- a/.github/workflows/hardware-suite.yml
+++ b/.github/workflows/hardware-suite.yml
@@ -298,6 +298,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up pinned coverage tools (system Rust)
+        run: bash scripts/ci/setup-coverage-tools.sh
+
       - name: Fetch model weights (models-v1 release, sha256-verified)
         run: bash scripts/fetch-models.sh
 
@@ -322,21 +325,21 @@ jobs:
           # Each selection is guarded separately. Guarding the step as a whole
           # would let the workspace run satisfy the minimum for every filtered
           # lane after it, which is the failure being guarded against.
-          ./scripts/run-tests-guarded.sh --min 650 -- cargo llvm-cov --no-report --workspace --locked
+          ./scripts/run-tests-guarded.sh --min 650 -- "$IRLUME_COVERAGE_BIN" llvm-cov --no-report --workspace --locked
           IRLUME_TCTI=device:/dev/tpmrm0 \
             ./scripts/run-tests-guarded.sh --require seal_unseal_roundtrip_real_tpm,arm_and_unseal_roundtrip,reseal_only_when_stale,tpm_key_and_recovery_lifecycle,tpm_tampered_seal_falls_back_then_recovery_heals \
-            -- cargo llvm-cov --no-report -p irlume-core --lib --locked -- --ignored \
+            -- "$IRLUME_COVERAGE_BIN" llvm-cov --no-report -p irlume-core --lib --locked -- --ignored \
             seal_unseal_roundtrip_real_tpm arm_and_unseal_roundtrip reseal_only_when_stale \
             tpm_key_and_recovery_lifecycle tpm_tampered_seal_falls_back_then_recovery_heals --test-threads=1
           # This fixture replaces a fixed NV index. Preserve its coverage on
           # disposable TPM state, never the runner's persistent hardware.
           ./scripts/with-swtpm.sh \
             ./scripts/run-tests-guarded.sh --require seal_unseal_pcrlock_roundtrip_provisioned_nv \
-            -- cargo llvm-cov --no-report -p irlume-core --lib --locked -- --ignored \
+            -- "$IRLUME_COVERAGE_BIN" llvm-cov --no-report -p irlume-core --lib --locked -- --ignored \
             seal_unseal_pcrlock_roundtrip_provisioned_nv --test-threads=1
-          ./scripts/run-tests-guarded.sh --min 15 -- cargo llvm-cov --no-report -p irlume-camera -p irlume-auth -p irlume-daemon --locked -- --ignored loopback_ --test-threads=1
-          ./scripts/run-tests-guarded.sh --min 7 -- cargo llvm-cov --no-report -p irlume-cli --test cli_capture --locked -- --ignored loopback_ --test-threads=1
-          ./scripts/run-tests-guarded.sh --min 5 -- cargo llvm-cov --no-report -p irlume-cli --test cli_bench --locked -- --ignored bench_ --test-threads=1
-          ./scripts/run-tests-guarded.sh --min 1 -- cargo llvm-cov --no-report -p irlume-daemon --test shutdown --locked -- --ignored --test-threads=1
-          ./scripts/run-tests-guarded.sh --min 16 -- cargo llvm-cov --no-report -p irlume-pam --locked -- --include-ignored --test-threads=1
-          cargo llvm-cov report --summary-only --fail-under-lines 75
+          ./scripts/run-tests-guarded.sh --min 15 -- "$IRLUME_COVERAGE_BIN" llvm-cov --no-report -p irlume-camera -p irlume-auth -p irlume-daemon --locked -- --ignored loopback_ --test-threads=1
+          ./scripts/run-tests-guarded.sh --min 7 -- "$IRLUME_COVERAGE_BIN" llvm-cov --no-report -p irlume-cli --test cli_capture --locked -- --ignored loopback_ --test-threads=1
+          ./scripts/run-tests-guarded.sh --min 5 -- "$IRLUME_COVERAGE_BIN" llvm-cov --no-report -p irlume-cli --test cli_bench --locked -- --ignored bench_ --test-threads=1
+          ./scripts/run-tests-guarded.sh --min 1 -- "$IRLUME_COVERAGE_BIN" llvm-cov --no-report -p irlume-daemon --test shutdown --locked -- --ignored --test-threads=1
+          ./scripts/run-tests-guarded.sh --min 16 -- "$IRLUME_COVERAGE_BIN" llvm-cov --no-report -p irlume-pam --locked -- --include-ignored --test-threads=1
+          "$IRLUME_COVERAGE_BIN" llvm-cov report --summary-only --fail-under-lines 75

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -115,3 +115,31 @@ and helper/artifact paths after identity checks, or restores the previous
 approved pair. It does not change product packages, enrollment, PAM, runner
 services or runner labels. Keep failed qualification evidence and report the
 remaining hardware gate accurately.
+
+
+## Nightly coverage prerequisites
+
+The coverage job prepares its own `cargo-llvm-cov` **0.9.1** using
+`setup-coverage-tools.sh` before model fetch or loopback-camera producers start.
+It builds with `cargo install --locked` into a unique directory under
+`RUNNER_TEMP`, verifies the installed version, and exports its absolute path as
+`IRLUME_COVERAGE_BIN`. Every coverage lane invokes that program directly so a
+missing or older runner-user installation cannot change the tool used. The
+runner cleans the temporary directory after the job; setup requires no sudo and
+does not replace tools in the runner's Cargo home.
+
+Both eligible runners use distribution Rust. Setup locates system `llvm-cov`
+and `llvm-profdata`, checks that their LLVM major versions match `rustc -vV`,
+and exports `LLVM_COV` and `LLVM_PROFDATA`. Missing tools, an incompatible LLVM,
+a failed install, or an unexpected coverage-tool version fails setup before
+any test capture. The version check is a prerequisite check; actual profile
+compatibility and the existing 75% line floor are still verified by coverage.
+See the [pinned tool's upstream environment contract](https://github.com/taiki-e/cargo-llvm-cov/tree/v0.9.1#environment-variables).
+
+`python3 scripts/ci/test-setup-coverage-tools.py` exercises fresh and previously
+provisioned runners, incompatible/missing LLVM, failed installation and wrong
+tool versions using executable fixtures. It neither installs real tools nor
+opens hardware. For a version update, also run a real tiny instrumented Rust
+test and `report --summary-only --fail-under-lines 75` as each runner account
+with the exact new setup, before qualifying the full nightly again. Keep the
+shared capability selectors, named-test guards and coverage threshold intact.

--- a/scripts/ci/setup-coverage-tools.sh
+++ b/scripts/ci/setup-coverage-tools.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright the irlume contributors.
+# Prepare coverage on either rolling-Arch runner without changing its user tools.
+set -euo pipefail
+: "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+: "${GITHUB_ENV:?GITHUB_ENV is required}"
+
+# These runners use distro Rust, so rustup's llvm-tools component is not the
+# source of the reporting tools. Refuse incompatible profile readers early.
+rust_version=$(rustc -vV)
+rust_llvm=$(sed -nE 's/^LLVM version: ([0-9]+)\..*/\1/p' <<<"$rust_version")
+[[ "$rust_llvm" =~ ^[0-9]+$ ]] || { echo 'Cannot determine rustc LLVM version' >&2; exit 1; }
+llvm_cov=$(command -v llvm-cov)
+llvm_profdata=$(command -v llvm-profdata)
+for tool in "$llvm_cov" "$llvm_profdata"; do
+  version=$("$tool" --version)
+  major=$(sed -nE 's/.*[Vv]ersion ([0-9]+)\..*/\1/p' <<<"$version")
+  if [[ "$major" != "$rust_llvm" ]]; then
+    echo "LLVM mismatch: $tool reports '$major', rustc uses '$rust_llvm'" >&2
+    exit 1
+  fi
+done
+
+# An existing cargo subcommand may be missing, stale or outside PATH. Always
+# install the reviewed version into this job's temporary directory and invoke
+# its absolute path; Cargo can also discover old tools in CARGO_HOME/bin.
+tool_dir=$(mktemp -d "${RUNNER_TEMP%/}/irlume-coverage-tools.XXXXXX")
+cargo install cargo-llvm-cov --version 0.9.1 --locked \
+  --root "$tool_dir" --target-dir "$tool_dir/build"
+coverage_bin="$tool_dir/bin/cargo-llvm-cov"
+version=$("$coverage_bin" llvm-cov --version)
+[[ "$version" == 'cargo-llvm-cov 0.9.1' ]] || { echo "Unexpected coverage tool: $version" >&2; exit 1; }
+printf '%s\n' "$version" "LLVM major: $rust_llvm"
+# Publish only after every prerequisite passed. RUNNER_TEMP is cleaned by the
+# runner after the job; no sudo, persistent PATH or Cargo-home changes needed.
+printf 'IRLUME_COVERAGE_BIN=%s\nLLVM_COV=%s\nLLVM_PROFDATA=%s\n' \
+  "$coverage_bin" "$llvm_cov" "$llvm_profdata" >> "$GITHUB_ENV"

--- a/scripts/ci/test-setup-coverage-tools.py
+++ b/scripts/ci/test-setup-coverage-tools.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright the irlume contributors.
+"""Exercise coverage bootstrap without downloading tools or accessing hardware."""
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / 'scripts/ci/setup-coverage-tools.sh'
+
+
+class SetupTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory(prefix='coverage setup ')
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.bin = self.root / 'bin'
+        self.bin.mkdir()
+        self.env_file = self.root / 'github env'
+        self.env_file.touch()
+        self.calls = self.root / 'calls'
+        self.env = dict(os.environ, PATH=f'{self.bin}:/usr/bin:/bin',
+                        RUNNER_TEMP=str(self.root), GITHUB_ENV=str(self.env_file),
+                        CALLS=str(self.calls))
+        for key in ['INSTALL_FAIL', 'COV_MAJOR', 'PROFDATA_MAJOR', 'BAD_VERSION',
+                    'MISSING_LLVM', 'RUST_BAD']:
+            self.env.pop(key, None)
+        self.write('rustc', '#!/bin/bash\n[ "${RUST_BAD:-0}" = 0 ] || exit 3\necho "LLVM version: 22.1.2"\n')
+        for tool, key in [('llvm-cov', 'COV_MAJOR'), ('llvm-profdata', 'PROFDATA_MAJOR')]:
+            self.write(tool, f'#!/bin/bash\n[ "${{MISSING_LLVM:-0}}" = 0 ] || exit 4\necho "LLVM version ${{{key}:-22}}.1.2"\n')
+        self.write('cargo', r'''#!/usr/bin/python3
+import json,os,sys
+from pathlib import Path
+with open(os.environ['CALLS'],'a') as f:f.write(json.dumps(sys.argv[1:])+'\n')
+if os.environ.get('INSTALL_FAIL')=='1':sys.exit(23)
+a=sys.argv[1:];assert a[0:2]==['install','cargo-llvm-cov'];assert '--locked' in a
+assert a[a.index('--version')+1]=='0.9.1'
+p=Path(a[a.index('--root')+1])/'bin';p.mkdir()
+(p/'cargo-llvm-cov').write_text('#!/bin/bash\n[ "$1" = llvm-cov ] && [ "$2" = --version ] || exit 90\necho "cargo-llvm-cov ${BAD_VERSION:-0.9.1}"\n')
+(p/'cargo-llvm-cov').chmod(0o755)
+''')
+
+    def write(self, name, body):
+        p = self.bin / name
+        p.write_text(body)
+        p.chmod(0o755)
+
+    def run_setup(self, **env):
+        return subprocess.run(['/bin/bash', str(SCRIPT)], env=dict(self.env, **env),
+                              capture_output=True, text=True, timeout=10)
+
+    def test_fresh_runner_installs_pinned_tool_and_exports_exact_paths(self):
+        p = self.run_setup()
+        self.assertEqual(p.returncode, 0, p.stderr)
+        env = dict(x.split('=', 1) for x in self.env_file.read_text().splitlines())
+        self.assertEqual(env['LLVM_COV'], str(self.bin / 'llvm-cov'))
+        self.assertEqual(env['LLVM_PROFDATA'], str(self.bin / 'llvm-profdata'))
+        self.assertTrue(Path(env['IRLUME_COVERAGE_BIN']).is_file())
+        self.assertTrue(Path(env['IRLUME_COVERAGE_BIN']).is_relative_to(self.root))
+        self.assertEqual(len(self.calls.read_text().splitlines()), 1)
+
+    def test_inherited_tool_cannot_replace_job_local_pin(self):
+        self.write('cargo-llvm-cov', '#!/bin/bash\nexit 99\n')
+        self.assertEqual(self.run_setup().returncode, 0)
+        self.assertNotIn(str(self.bin / 'cargo-llvm-cov'), self.env_file.read_text())
+
+    def test_mismatched_llvm_fails_before_install(self):
+        for key in ['COV_MAJOR', 'PROFDATA_MAJOR']:
+            with self.subTest(key=key):
+                p = self.run_setup(**{key: '21'})
+                self.assertNotEqual(p.returncode, 0)
+                self.assertIn('LLVM', p.stderr)
+                self.assertFalse(self.calls.exists())
+                self.assertEqual(self.env_file.read_text(), '')
+
+    def test_missing_llvm_and_invalid_rust_fail_before_install(self):
+        for key in ['MISSING_LLVM', 'RUST_BAD']:
+            with self.subTest(key=key):
+                self.assertNotEqual(self.run_setup(**{key: '1'}).returncode, 0)
+                self.assertFalse(self.calls.exists())
+
+    def test_install_failure_does_not_publish_environment(self):
+        p = self.run_setup(INSTALL_FAIL='1')
+        self.assertEqual(p.returncode, 23)
+        self.assertEqual(self.env_file.read_text(), '')
+
+    def test_wrong_installed_version_fails(self):
+        self.assertNotEqual(self.run_setup(BAD_VERSION='0.1.0').returncode, 0)
+        self.assertEqual(self.env_file.read_text(), '')
+
+    def test_workflow_uses_pinned_program_after_setup(self):
+        workflow = (ROOT / '.github/workflows/hardware-suite.yml').read_text()
+        coverage = workflow.split('\n  coverage:', 1)[1]
+        self.assertLess(coverage.index('bash scripts/ci/setup-coverage-tools.sh'),
+                        coverage.index('ffmpeg -loglevel'))
+        self.assertNotIn('-- cargo llvm-cov', coverage)
+        self.assertEqual(coverage.count('"$IRLUME_COVERAGE_BIN" llvm-cov'), 9)
+        self.assertIn('--fail-under-lines 75', coverage)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The Hardware suite failed at coverage because one eligible runner lacked `cargo-llvm-cov`. Install version 0.9.1 with `--locked` into the job's temporary directory, verify LLVM compatibility, and invoke the exact executable. This makes coverage setup consistent on either runner. Test selections and the 75% floor remain unchanged.

Validation: 68 executable fixtures passed, plus ShellCheck, actionlint, action pins and offline zizmor. Independent review found no actionable issues. Real tool installation and an instrumented test/report passed under both runner accounts. Full Irlume coverage remains pending merge.

Public failure log: https://github.com/archledger/irlume/actions/runs/34513648411/job/102994787980
