### PR TITLE
ci: require supported nightly capture scenarios by name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -527,8 +527,10 @@ jobs:
           python3 scripts/test-nightly-ir-capture.py
           python3 scripts/ci/test-irlume-ci-capture.py
 
-      - name: nightly coverage setup (fixtures only, no install or hardware)
-        run: python3 scripts/ci/test-setup-coverage-tools.py
+      - name: nightly coverage setup and contracts (fixtures only, no install or hardware)
+        run: |
+          python3 scripts/ci/test-setup-coverage-tools.py
+          python3 scripts/ci/test-nightly-coverage-contract.py
 
       - name: systemd-analyze verify (unit syntax)
         run: |

--- a/.github/workflows/hardware-suite.yml
+++ b/.github/workflows/hardware-suite.yml
@@ -338,7 +338,11 @@ jobs:
             -- "$IRLUME_COVERAGE_BIN" llvm-cov --no-report -p irlume-core --lib --locked -- --ignored \
             seal_unseal_pcrlock_roundtrip_provisioned_nv --test-threads=1
           ./scripts/run-tests-guarded.sh --min 15 -- "$IRLUME_COVERAGE_BIN" llvm-cov --no-report -p irlume-camera -p irlume-auth -p irlume-daemon --locked -- --ignored loopback_ --test-threads=1
-          ./scripts/run-tests-guarded.sh --min 7 -- "$IRLUME_COVERAGE_BIN" llvm-cov --no-report -p irlume-cli --test cli_capture --locked -- --ignored loopback_ --test-threads=1
+          # meshprobe and its test were intentionally retired in #502. Require
+          # every remaining command scenario by name; unrelated passes cannot
+          # substitute for a missing one, as a numeric minimum would allow.
+          ./scripts/run-tests-guarded.sh --require loopback_capture_runs_detection_and_reports_no_face,loopback_liveness_probe_gates_a_faceless_feed_as_not_live,loopback_calcapture_writes_header_and_faceless_samples,loopback_padcapture_ir_only_records_faceless_attack_presentations,loopback_genuine_declines_stats_without_two_face_frames,loopback_suncal_analyzes_a_faceless_burst_dataset \
+            -- "$IRLUME_COVERAGE_BIN" llvm-cov --no-report -p irlume-cli --test cli_capture --locked -- --ignored loopback_ --test-threads=1
           ./scripts/run-tests-guarded.sh --min 5 -- "$IRLUME_COVERAGE_BIN" llvm-cov --no-report -p irlume-cli --test cli_bench --locked -- --ignored bench_ --test-threads=1
           ./scripts/run-tests-guarded.sh --min 1 -- "$IRLUME_COVERAGE_BIN" llvm-cov --no-report -p irlume-daemon --test shutdown --locked -- --ignored --test-threads=1
           ./scripts/run-tests-guarded.sh --min 16 -- "$IRLUME_COVERAGE_BIN" llvm-cov --no-report -p irlume-pam --locked -- --include-ignored --test-threads=1

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -143,3 +143,13 @@ opens hardware. For a version update, also run a real tiny instrumented Rust
 test and `report --summary-only --fail-under-lines 75` as each runner account
 with the exact new setup, before qualifying the full nightly again. Keep the
 shared capability selectors, named-test guards and coverage threshold intact.
+
+
+The CLI capture coverage lane requires all six supported command scenarios by
+name. The former seventh scenario exercised `meshprobe`, intentionally removed
+with eye challenges in PR #502; its stale numeric minimum survived that removal.
+`python3 scripts/ci/test-nightly-coverage-contract.py` executes the actual
+workflow guard: all supported scenarios must pass, and seven unrelated or
+substituted successes cannot hide any missing required scenario. It also checks
+zero selection and propagation of a failed test command. Retiring a supported
+command requires an explicit review of this named contract and its fixtures.

--- a/scripts/ci/test-nightly-coverage-contract.py
+++ b/scripts/ci/test-nightly-coverage-contract.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright the irlume contributors.
+"""Execute the nightly CLI coverage guard against synthetic test results."""
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+REQUIRED = [
+    'loopback_capture_runs_detection_and_reports_no_face',
+    'loopback_liveness_probe_gates_a_faceless_feed_as_not_live',
+    'loopback_calcapture_writes_header_and_faceless_samples',
+    'loopback_padcapture_ir_only_records_faceless_attack_presentations',
+    'loopback_genuine_declines_stats_without_two_face_frames',
+    'loopback_suncal_analyzes_a_faceless_burst_dataset',
+]
+
+
+def capture_guard():
+    workflow = (ROOT / '.github/workflows/hardware-suite.yml').read_text()
+    joined = workflow.replace('\\\n', ' ')
+    commands = [line.strip() for line in joined.splitlines()
+                if '--test cli_capture ' in line]
+    assert len(commands) == 1
+    return commands[0]
+
+
+class CaptureContractTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory(prefix='nightly coverage contract ')
+        self.addCleanup(self.tmp.cleanup)
+        self.bin = Path(self.tmp.name) / 'coverage fixture'
+        self.bin.write_text(r'''#!/usr/bin/env python3
+import json,os,sys
+args=sys.argv[1:]
+assert args[0]=='llvm-cov' and args[args.index('--test')+1]=='cli_capture'
+assert '--ignored' in args and 'loopback_' in args and '--test-threads=1' in args
+names=json.loads(os.environ['FIXTURE_NAMES'])
+for name in names:print('test '+name+' ... ok')
+print(f'test result: ok. {len(names)} passed; 0 failed; 0 ignored')
+sys.exit(int(os.environ['FIXTURE_EXIT']))
+''')
+        self.bin.chmod(0o755)
+
+    def run_guard(self, names, exit_code=0):
+        return subprocess.run(['bash', '-e', '-c', capture_guard()], cwd=ROOT,
+                              env=dict(os.environ, IRLUME_COVERAGE_BIN=str(self.bin),
+                                       FIXTURE_NAMES=json.dumps(names),
+                                       FIXTURE_EXIT=str(exit_code)),
+                              capture_output=True, text=True, timeout=10)
+
+    def test_all_supported_scenarios_pass(self):
+        result = self.run_guard(REQUIRED)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_each_missing_scenario_fails_even_with_seven_passing_tests(self):
+        for missing in REQUIRED:
+            with self.subTest(missing=missing):
+                names = [n for n in REQUIRED if n != missing]
+                names += ['loopback_unrelated_one', 'loopback_unrelated_two']
+                result = self.run_guard(names)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(missing, result.stderr)
+
+    def test_zero_selection_fails(self):
+        self.assertNotEqual(self.run_guard([]).returncode, 0)
+
+    def test_failed_command_cannot_pass_from_success_output(self):
+        self.assertEqual(self.run_guard(REQUIRED, exit_code=23).returncode, 23)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The full nightly run [34516890378](https://github.com/archledger/irlume/actions/runs/34516890378) passed all six current CLI capture tests, then failed because the workflow still required seven. PR #502 intentionally removed `meshprobe` and its test.

Require each of the six supported scenarios by name. A missing scenario now fails even when unrelated tests bring the total to seven. Hosted fixtures execute the actual workflow guard and verify missing scenarios, empty selection, and command-failure propagation. The test selection and 75% line-coverage floor remain unchanged.

Validation: 72 workflow/helper/guard fixtures passed; actionlint, ShellCheck, all 52 action pins, offline zizmor and diff checks passed. Independently reviewed with no actionable findings. The completed nightly's retained instrumented binaries also passed five synthetic benchmark tests, one shutdown test and 29 PAM integration tests with no skip diagnostics. Those direct runs validate the downstream stages; a complete corrected nightly coverage measurement remains pending integration.
