### PR TITLE
fix(packaging): preserve stopped and disabled socket state on upgrades

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,6 +240,12 @@ jobs:
           python3 scripts/test-package-upgrade-harness.py
           python3 scripts/test-check-upgrade-auth.py
 
+      - name: Package service hook and state preservation regressions
+        run: |
+          sudo apt-get install -y --no-install-recommends pacman-package-manager
+          python3 scripts/test-package-service-hooks.py
+          python3 scripts/test-check-upgrade-service-state.py
+
       - name: test (TPM-gated, against swtpm)
         env:
           IRLUME_TCTI: swtpm:host=127.0.0.1,port=2321

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,7 +242,9 @@ jobs:
 
       - name: Package service hook and state preservation regressions
         run: |
-          sudo apt-get install -y --no-install-recommends pacman-package-manager
+          # Ubuntu ships vercmp in makepkg, a recommendation of pacman-package-manager.
+          # Install it explicitly because recommendations are disabled here.
+          sudo apt-get install -y --no-install-recommends pacman-package-manager makepkg
           python3 scripts/test-package-service-hooks.py
           python3 scripts/test-check-upgrade-service-state.py
 

--- a/docs/UPGRADE-VALIDATION.md
+++ b/docs/UPGRADE-VALIDATION.md
@@ -168,6 +168,68 @@ Do not delete individual fixture files or restart the sequence on a partially
 tested installation. Discard only the task-owned guest after preserving the
 sanitized evidence.
 
+## Administrator service choices
+
+The four-stage harness above intentionally requires a running daemon. Use
+[`check-upgrade-service-state.py`](../scripts/check-upgrade-service-state.py)
+for separate service-state trials in inspected disposable guests with the same
+admission marker. Stage it beside `test-package-upgrade.py`, which supplies its
+read-only admission and command helpers. The checker only observes systemd;
+it never starts a unit or connects to `/run/irlume.sock`.
+
+Test **both** `irlumed.service` and `irlumed.socket` together:
+
+| Case | Enablement | Runtime state after each transaction |
+| --- | --- | --- |
+| `disabled-running` | Both disabled | Both active; daemon has a new PID |
+| `disabled-stopped` | Both disabled | Both inactive |
+| `enabled-stopped` | Both enabled | Both inactive |
+| `masked-stopped` | Both masked | Both inactive and still masked |
+
+Disabling a unit does not stop it. Stopping only the daemon while its socket
+remains active permits the next connection to activate it again. Paired states
+make the administrator's intent explicit. NixOS activation is declarative and
+needs its own module/generation test; these package tests do not establish that
+imperative `systemctl` changes survive a NixOS switch.
+
+For example, after preparing the old package in a disposable guest, deliberately
+stop both enabled units and save a baseline:
+
+```sh
+systemctl enable irlumed.service irlumed.socket
+systemctl stop irlumed.service irlumed.socket
+python3 /var/tmp/irlume-upgrade-input/check-upgrade-service-state.py \
+  --case enabled-stopped \
+  --output /var/tmp/irlume-upgrade-output/stopped-before.json
+```
+
+Run the candidate package transaction using the distribution command and
+signature/conffile options described above, then check without activating it:
+
+```sh
+python3 /var/tmp/irlume-upgrade-input/check-upgrade-service-state.py \
+  --case enabled-stopped \
+  --before /var/tmp/irlume-upgrade-output/stopped-before.json \
+  --output /var/tmp/irlume-upgrade-output/stopped-after.json
+```
+
+Require both receipts to pass. Repeat for upgrade, old-package rollback, and
+candidate re-upgrade in every case, retaining exact package digests and source
+revisions. Use `disable` for disabled states, a separate `start` of both units
+for disabled-running, or `mask --now` for masked-stopped. Set these states only
+on the disposable guest. Preserve failure receipts before changing the fixture;
+if intent is deliberately re-established before each transaction, report that
+these are independent transition tests, not one uninterrupted passing cycle.
+An old package's rollback hook may itself violate the state contract: record
+that result separately; do not modify the published old package to hide it.
+
+This passive checker qualifies systemd state only. Retain separate package
+version/payload checks, configuration and synthetic-state preservation checks,
+AppArmor/SELinux assertions, and a working independent administrator login.
+For a running case, also verify the live executable matches the installed
+candidate. Never use the active-daemon harness or its Ping check to validate an
+inactive case: the check itself could activate the socket and invalidate it.
+
 ## Qualification limits
 
 - Synthetic configuration, state bytes, and retry records establish preservation
@@ -180,8 +242,9 @@ sanitized evidence.
   separately. Do not turn off confinement to change the outcome.
 - The transaction sequence covers the package's enabled, running service path
   and checks that its enabled state remains unchanged. It does not qualify an
-  administrator-disabled or stopped-service upgrade, a wired graphical greeter,
-  or every login manager. An enabled SELinux module listing does not prove its
+  administrator-disabled or stopped-service upgrade; use the separate state
+  procedure above. Neither procedure qualifies a wired graphical greeter or
+  every login manager. An enabled SELinux module listing does not prove its
   live byte equivalence or confined greeter access.
 - A separate Nix profile generation rollback is not a NixOS system-generation,
   module, service, PAM, or hardware qualification. This package harness does not
@@ -192,4 +255,6 @@ Run the local harness regressions without installing any packages:
 ```sh
 python3 scripts/test-package-upgrade-harness.py
 python3 scripts/test-check-upgrade-auth.py
+python3 scripts/test-check-upgrade-service-state.py
+python3 scripts/test-package-service-hooks.py
 ```

--- a/packaging/arch/irlume.install
+++ b/packaging/arch/irlume.install
@@ -41,10 +41,17 @@ post_upgrade() {
     if command -v apparmor_parser >/dev/null 2>&1; then
         apparmor_parser -r /etc/apparmor.d/usr.bin.irlumed 2>/dev/null || true
     fi
-    # Upgrading from a version without the socket unit: enable it, but only
-    # if the admin has not deliberately disabled the service.
-    if systemctl is-enabled --quiet irlumed.service 2>/dev/null; then
-        systemctl enable --now irlumed.socket 2>/dev/null || true
+    # The socket first shipped in 0.8.1. Migrate older releases only: repeating
+    # this on modern upgrades would undo an administrator's socket disable/stop.
+    if [ "$(vercmp "$2" 0.8.1)" -lt 0 ] &&
+        systemctl is-enabled --quiet irlumed.service 2>/dev/null; then
+        # An enabled service can still be deliberately stopped. Preserve that
+        # runtime choice while enabling its new socket for the next boot.
+        if systemctl is-active --quiet irlumed.service 2>/dev/null; then
+            systemctl enable --now irlumed.socket 2>/dev/null || true
+        else
+            systemctl enable irlumed.socket 2>/dev/null || true
+        fi
     fi
     systemctl try-restart irlumed.service 2>/dev/null || true
     # Ensure the self-heal units are enabled and run one reconcile: adopts an

--- a/packaging/debian/postinstall.sh
+++ b/packaging/debian/postinstall.sh
@@ -60,9 +60,17 @@ fi
 if [ -n "${2:-}" ]; then
     systemctl start irlume-reconcile.service 2>/dev/null || true
 fi
-# Upgrading from a version without the socket unit.
-if systemctl is-enabled --quiet irlumed.service 2>/dev/null; then
-    systemctl enable --now irlumed.socket 2>/dev/null || true
+# The socket first shipped in 0.8.1. Migrate older releases only: repeating
+# this on modern upgrades would undo an administrator's socket disable/stop.
+if [ -n "${2:-}" ] && dpkg --compare-versions "$2" lt 0.8.1 &&
+    systemctl is-enabled --quiet irlumed.service 2>/dev/null; then
+    # An enabled service can still be deliberately stopped. Preserve that
+    # runtime choice while enabling its new socket for the next boot.
+    if systemctl is-active --quiet irlumed.service 2>/dev/null; then
+        systemctl enable --now irlumed.socket 2>/dev/null || true
+    else
+        systemctl enable irlumed.socket 2>/dev/null || true
+    fi
 fi
 systemctl try-restart irlumed.service 2>/dev/null || true
 cat <<'EOF'

--- a/scripts/check-upgrade-service-state.py
+++ b/scripts/check-upgrade-service-state.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Passively check daemon/socket state around a disposable-guest package upgrade.
+
+Run before the transaction with --case and --output, then after it with the
+same --case, --before pointing at that receipt, and a new --output. This checker
+never starts units or connects to the product socket. The operator sets the
+intended state and runs the package transaction separately. Raw command output
+stays in the receipt's private .log sibling; export JSON only.
+"""
+import argparse
+import importlib.util
+import json
+import os
+from pathlib import Path
+import sys
+
+SPEC = importlib.util.spec_from_file_location(
+    'package_upgrade', Path(__file__).with_name('test-package-upgrade.py'))
+upgrade = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(upgrade)
+UNITS = ('irlumed.service', 'irlumed.socket')
+CASES = ('disabled-running', 'disabled-stopped', 'enabled-stopped', 'masked-stopped')
+PROPERTIES = ('LoadState', 'UnitFileState', 'ActiveState', 'SubState', 'MainPID')
+
+
+def observe(runner):
+    result = {}
+    for unit in UNITS:
+        argv = ['systemctl', 'show', unit]
+        for name in PROPERTIES:
+            argv.extend(('-p', name))
+        fields = {}
+        for line in runner.command(argv).splitlines():
+            name, sep, value = line.partition('=')
+            upgrade.require(sep and name in PROPERTIES and name not in fields,
+                            'invalid-unit-properties')
+            fields[name] = value
+        result[unit] = fields
+    return result
+
+
+def check_state(units, case):
+    upgrade.require(case in CASES and isinstance(units, dict), 'invalid-state-case')
+    enabled = 'masked' if case == 'masked-stopped' else case.split('-')[0]
+    active = case.endswith('-running')
+    for unit in UNITS:
+        row = units.get(unit, {})
+        upgrade.require(isinstance(row, dict), 'invalid-unit-properties')
+        short = 'daemon' if unit.endswith('.service') else 'socket'
+        upgrade.require(row.get('UnitFileState') == enabled, short + '-enablement-changed')
+        upgrade.require(row.get('LoadState') == ('masked' if enabled == 'masked' else 'loaded'),
+                        short + '-load-state-changed')
+        upgrade.require(row.get('ActiveState') == ('active' if active else 'inactive'),
+                        short + '-activity-changed')
+        substate = row.get('SubState')
+        upgrade.require(isinstance(substate, str), 'invalid-unit-properties')
+        allowed = {'running'} if short == 'daemon' else {'running', 'listening'}
+        upgrade.require(substate in (allowed if active else {'dead'}),
+                        short + '-substate-changed')
+        if short == 'daemon':
+            value = row.get('MainPID', '')
+            upgrade.require(isinstance(value, str) and value.isascii() and value.isdigit(),
+                            'invalid-daemon-pid')
+            upgrade.require((int(value) > 0) if active else (int(value) == 0), 'daemon-pid-state')
+
+
+def check_transition(before, after, case):
+    check_state(before, case)
+    check_state(after, case)
+    if case.endswith('-running'):
+        upgrade.require(before['irlumed.service']['MainPID'] != after['irlumed.service']['MainPID'],
+                        'daemon-not-restarted')
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--case', choices=CASES, required=True)
+    parser.add_argument('--before', help='Successful pre-transaction JSON receipt')
+    parser.add_argument('--output', required=True, help='New JSON receipt in an existing directory')
+    args = parser.parse_args(argv)
+    os.umask(0o077)
+    try:
+        upgrade.admit_guest()
+        before = None
+        if args.before:
+            path = Path(args.before)
+            upgrade.no_symlinks(path)
+            before = json.loads(path.read_text())
+            upgrade.require(isinstance(before, dict) and before.get('schema') == 1
+                            and before.get('case') == args.case and before.get('passed') is True,
+                            'invalid-baseline-receipt')
+            check_state(before.get('units'), args.case)
+        output = Path(args.output)
+        log_path = output.with_name(output.name + '.log')
+        for path in (output, log_path):
+            upgrade.no_symlinks(path)
+            upgrade.require(path.parent.is_dir() and not path.exists(), 'new-output-required')
+    except (upgrade.Failure, OSError, ValueError) as error:
+        print(json.dumps({'passed': False, 'error': str(error) if isinstance(error, upgrade.Failure)
+                          else 'preflight-read-failed'}))
+        return 1
+    result = {'schema': 1, 'case': args.case, 'passed': False}
+    with output.open('x') as receipt, log_path.open('xb') as log:
+        try:
+            result['units'] = observe(upgrade.Runner(log))
+            check_state(result['units'], args.case)
+            if before is not None:
+                check_transition(before['units'], result['units'], args.case)
+            result['passed'] = True
+        except (upgrade.Failure, OSError) as error:
+            result['error'] = str(error) if isinstance(error, upgrade.Failure) else 'observation-failed'
+        json.dump(result, receipt, indent=2)
+        receipt.write('\n')
+    print(json.dumps(result))
+    return 0 if result['passed'] else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/test-check-upgrade-service-state.py
+++ b/scripts/test-check-upgrade-service-state.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Offline behavior tests for the passive upgrade service-state checker."""
+import copy
+import contextlib
+import io
+import json
+import tempfile
+from unittest import mock
+import importlib.util
+from pathlib import Path
+import unittest
+
+SPEC = importlib.util.spec_from_file_location(
+    'state_check', Path(__file__).with_name('check-upgrade-service-state.py'))
+CHECK = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(CHECK)
+
+
+def state(case, pid=101):
+    enabled = 'masked' if case == 'masked-stopped' else case.split('-')[0]
+    active = case.endswith('-running')
+    return {unit: {'UnitFileState': enabled, 'LoadState': 'masked' if enabled == 'masked' else 'loaded',
+                   'ActiveState': 'active' if active else 'inactive',
+                   'SubState': ('running' if unit.endswith('service') else 'listening') if active else 'dead',
+                   **({'MainPID': str(pid if active else 0)} if unit.endswith('service') else {})}
+            for unit in CHECK.UNITS}
+
+
+class StateChecks(unittest.TestCase):
+    def test_all_declared_states_survive_upgrade(self):
+        for case in CHECK.CASES:
+            with self.subTest(case=case):
+                CHECK.check_transition(state(case, 101), state(case, 202), case)
+
+    def test_deliberately_stopped_socket_must_not_be_started(self):
+        before = state('enabled-stopped'); after = copy.deepcopy(before)
+        after['irlumed.socket'].update(ActiveState='active', SubState='listening')
+        with self.assertRaisesRegex(CHECK.upgrade.Failure, 'socket-activity-changed'):
+            CHECK.check_transition(before, after, 'enabled-stopped')
+
+    def test_disabled_running_is_not_stopped(self):
+        with self.assertRaises(CHECK.upgrade.Failure):
+            CHECK.check_transition(state('disabled-running'), state('disabled-stopped'), 'disabled-running')
+
+    def test_disabled_units_must_not_be_reenabled(self):
+        for unit in CHECK.UNITS:
+            after = state('disabled-stopped'); after[unit]['UnitFileState'] = 'enabled'
+            with self.subTest(unit=unit), self.assertRaises(CHECK.upgrade.Failure):
+                CHECK.check_transition(state('disabled-stopped'), after, 'disabled-stopped')
+
+    def test_masks_must_not_be_removed(self):
+        for unit in CHECK.UNITS:
+            after = state('masked-stopped'); after[unit]['LoadState'] = 'loaded'
+            with self.subTest(unit=unit), self.assertRaises(CHECK.upgrade.Failure):
+                CHECK.check_transition(state('masked-stopped'), after, 'masked-stopped')
+
+    def test_running_daemon_must_get_new_process(self):
+        with self.assertRaisesRegex(CHECK.upgrade.Failure, 'daemon-not-restarted'):
+            CHECK.check_transition(state('disabled-running'), state('disabled-running'), 'disabled-running')
+
+    def test_invalid_baseline_is_rejected(self):
+        with self.assertRaises(CHECK.upgrade.Failure):
+            CHECK.check_transition(state('enabled-stopped'), state('disabled-stopped'), 'disabled-stopped')
+
+    def test_failed_or_transitional_state_is_rejected(self):
+        for active in ('failed', 'activating', 'deactivating'):
+            after = state('disabled-stopped'); after['irlumed.service']['ActiveState'] = active
+            with self.subTest(active=active), self.assertRaises(CHECK.upgrade.Failure):
+                CHECK.check_transition(state('disabled-stopped'), after, 'disabled-stopped')
+
+    def test_inactive_service_must_have_no_process(self):
+        after = state('disabled-stopped'); after['irlumed.service']['MainPID'] = '44'
+        with self.assertRaises(CHECK.upgrade.Failure):
+            CHECK.check_transition(state('disabled-stopped'), after, 'disabled-stopped')
+
+    def test_missing_properties_fail_closed(self):
+        after = state('disabled-stopped'); del after['irlumed.service']['UnitFileState']
+        with self.assertRaises(CHECK.upgrade.Failure):
+            CHECK.check_transition(state('disabled-stopped'), after, 'disabled-stopped')
+
+    def test_observation_is_passive(self):
+        class Runner:
+            def __init__(self): self.calls = []
+            def command(self, argv):
+                self.calls.append(argv)
+                return '\n'.join(k+'='+v for k,v in state('enabled-stopped')[argv[2]].items())
+        runner = Runner()
+        self.assertEqual(CHECK.observe(runner), state('enabled-stopped'))
+        self.assertEqual([call[:3] for call in runner.calls],
+                         [['systemctl','show',unit] for unit in CHECK.UNITS])
+
+
+class CliChecks(unittest.TestCase):
+    def run_cli(self, directory, case='enabled-stopped', before=None, observed=None):
+        output = Path(directory) / 'after.json'
+        args = ['--case', case, '--output', str(output)]
+        if before is not None:
+            baseline = Path(directory) / 'before.json'
+            baseline.write_text(json.dumps(before))
+            args.extend(['--before', str(baseline)])
+        with mock.patch.object(CHECK.upgrade, 'admit_guest'), \
+                mock.patch.object(CHECK, 'observe', return_value=observed or state(case)), \
+                contextlib.redirect_stdout(io.StringIO()):
+            status = CHECK.main(args)
+        return status, output
+
+    def test_real_host_refused_before_any_output_write(self):
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / 'receipt.json'
+            with mock.patch.object(CHECK.upgrade, 'admit_guest',
+                                   side_effect=CHECK.upgrade.Failure('qemu-kvm-required')), \
+                    contextlib.redirect_stdout(io.StringIO()):
+                self.assertEqual(CHECK.main(['--case', 'enabled-stopped', '--output', str(output)]), 1)
+            self.assertEqual(list(Path(directory).iterdir()), [])
+
+    def test_baseline_and_after_receipts_pass(self):
+        with tempfile.TemporaryDirectory() as directory:
+            before = {'schema': 1, 'case': 'enabled-stopped', 'passed': True,
+                      'units': state('enabled-stopped')}
+            status, output = self.run_cli(directory, before=before)
+            self.assertEqual(status, 0)
+            self.assertTrue(json.loads(output.read_text())['passed'])
+            self.assertEqual(output.stat().st_mode & 0o777, 0o600)
+
+    def test_failed_receipt_keeps_observed_state(self):
+        with tempfile.TemporaryDirectory() as directory:
+            changed = state('enabled-stopped')
+            changed['irlumed.socket'].update(ActiveState='active', SubState='listening')
+            status, output = self.run_cli(directory, observed=changed)
+            self.assertEqual(status, 1)
+            receipt = json.loads(output.read_text())
+            self.assertFalse(receipt['passed'])
+            self.assertEqual(receipt['units'], changed)
+
+    def test_failed_baseline_refused(self):
+        with tempfile.TemporaryDirectory() as directory:
+            status, output = self.run_cli(directory, before={'schema': 1, 'passed': False})
+            self.assertEqual(status, 1)
+            self.assertFalse(output.exists())
+
+    def test_malformed_baseline_substate_reports_fixed_error_without_output(self):
+        for case in ('enabled-stopped', 'disabled-running'):
+            for unit in CHECK.UNITS:
+                for substate in ([], {}, None, 0, True, 1.5):
+                    with self.subTest(case=case, unit=unit, substate=substate), \
+                            tempfile.TemporaryDirectory() as directory:
+                        baseline = Path(directory) / 'before.json'
+                        before = {'schema': 1, 'case': case, 'passed': True,
+                                  'units': state(case)}
+                        before['units'][unit]['SubState'] = substate
+                        baseline.write_text(json.dumps(before))
+                        output = Path(directory) / 'after.json'
+                        stdout = io.StringIO()
+                        with mock.patch.object(CHECK.upgrade, 'admit_guest'), \
+                                mock.patch.object(CHECK, 'observe', side_effect=AssertionError(
+                                    'invalid baseline must be rejected before observation')), \
+                                contextlib.redirect_stdout(stdout):
+                            status = CHECK.main(['--case', case, '--before', str(baseline),
+                                                 '--output', str(output)])
+                        self.assertEqual(status, 1)
+                        self.assertEqual(json.loads(stdout.getvalue()),
+                                         {'passed': False, 'error': 'invalid-unit-properties'})
+                        self.assertEqual(list(Path(directory).iterdir()), [baseline])
+
+    def test_existing_output_preserved(self):
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / 'after.json'
+            output.write_text('original')
+            status, _ = self.run_cli(directory)
+            self.assertEqual(status, 1)
+            self.assertEqual(output.read_text(), 'original')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/test-package-service-hooks.py
+++ b/scripts/test-package-service-hooks.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Execute package hooks with isolated command shims; never change host services.
+
+Requires dpkg and vercmp so migration decisions use the native comparators.
+The shell executes a copy with only /var/lib/irlume relocated into the fixture
+to isolate the unrelated reconcile marker; service commands and branches are
+unchanged. All external commands use a private PATH.
+These tests cover hook decisions, not systemd's dependency/activation engine.
+"""
+import json
+import os
+from pathlib import Path
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DAEMON = "irlumed.service"
+SOCKET = "irlumed.socket"
+
+# Model the systemctl command boundary, including enable vs. --now and masks.
+# Unsupported commands are recorded as errors even when a hook ignores status.
+SHIM = r'''
+import json
+import os
+from pathlib import Path
+import sys
+
+path = Path(os.environ["HOOK_STATE"])
+state = json.loads(path.read_text())
+name = Path(sys.argv[0]).name
+args = sys.argv[1:]
+state["calls"].append([name, *args])
+status = 0
+
+def unexpected():
+    state["errors"].append([name, *args])
+    return 99
+
+if name == "systemctl":
+    verb = args[0] if args else ""
+    flags = [arg for arg in args[1:] if arg.startswith("-")]
+    units = [arg for arg in args[1:] if not arg.startswith("-")]
+    if verb == "daemon-reload" and not flags and not units:
+        pass
+    elif verb in {"is-enabled", "is-active"} and flags == ["--quiet"] and len(units) == 1:
+        unit = state["units"].get(units[0])
+        if unit is None:
+            status = unexpected()
+        elif verb == "is-enabled":
+            status = 0 if unit["enabled"] in {"enabled", "enabled-runtime"} else 1
+        else:
+            status = 0 if unit["active"] else 3
+    elif verb in {"enable", "start", "try-restart"} and units and (
+        not flags or (verb == "enable" and flags == ["--now"])
+    ):
+        for unit_name in units:
+            if unit_name.startswith("irlume-reconcile."):
+                continue
+            unit = state["units"].get(unit_name)
+            if unit is None:
+                status = unexpected()
+                continue
+            if unit["enabled"] in {"masked", "masked-runtime"}:
+                status = 1
+                continue
+            if verb == "enable":
+                unit["enabled"] = "enabled"
+            if verb == "start" or (verb == "enable" and "--now" in flags):
+                if not unit["active"]:
+                    unit["starts"] += 1
+                unit["active"] = True
+            if verb == "try-restart" and unit["active"]:
+                unit["restarts"] += 1
+    else:
+        status = unexpected()
+elif name == "systemd-tmpfiles" and args == ["--create", "irlume.conf"]:
+    pass
+elif name == "apparmor_parser" and args == ["-r", "/etc/apparmor.d/usr.bin.irlumed"]:
+    pass
+else:
+    status = unexpected()
+
+path.write_text(json.dumps(state))
+sys.exit(status)
+'''
+
+class PackageServiceHookTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.commands = {}
+        for name in ("dpkg", "vercmp", "cat", "bash", "sh"):
+            executable = shutil.which(name)
+            if executable is None:
+                raise RuntimeError(f"required test dependency missing: {name}")
+            cls.commands[name] = executable
+
+    def run_hook(self, family, service, socket, old="0.11.3"):
+        with tempfile.TemporaryDirectory(prefix="irlume-hook-test-") as temp:
+            directory = Path(temp)
+            # A real marker under a private path works with both dash and Bash.
+            # Do not override shell builtins: dash rejects a function named [.
+            fixture_state = directory / "var/lib/irlume"
+            fixture_state.mkdir(parents=True)
+            (fixture_state / ".reconcile-timer-armed").touch()
+            source = ROOT / ("packaging/debian/postinstall.sh" if family == "debian"
+                             else "packaging/arch/irlume.install")
+            hook = directory / "hook.sh"
+            hook.write_text(source.read_text().replace("/var/lib/irlume", str(fixture_state)))
+            state_path = directory / "state.json"
+            state_path.write_text(json.dumps({
+                "units": {
+                    DAEMON: {"enabled": service[0], "active": service[1], "starts": 0, "restarts": 0},
+                    SOCKET: {"enabled": socket[0], "active": socket[1], "starts": 0, "restarts": 0},
+                },
+                "calls": [], "errors": [],
+            }))
+            for name in ("systemctl", "systemd-tmpfiles", "apparmor_parser", "mkdir"):
+                shim = directory / name
+                shim.write_text(f"#!{sys.executable}\n{SHIM}")
+                shim.chmod(0o700)
+            for name in ("dpkg", "vercmp", "cat"):
+                (directory / name).symlink_to(self.commands[name])
+            env = {
+                "PATH": str(directory), "HOOK_STATE": str(state_path),
+                "LC_ALL": "C", "PYTHONDONTWRITEBYTECODE": "1",
+            }
+            if family == "debian":
+                command = [self.commands["sh"], str(hook), "configure"]
+                if old is not None:
+                    command.append(old)
+            else:
+                env["HOOK_SCRIPT"] = str(hook)
+                function = "post_install" if old is None else "post_upgrade"
+                # Bash can read .bashrc for noninteractive remote invocations,
+                # even with a clean environment. Never run the user's startup.
+                command = [self.commands["bash"], "--noprofile", "--norc", "-c",
+                           f'. "$HOOK_SCRIPT"\n{function} "$@"\n',
+                           "hook-test", "0.12.0-1"]
+                if old is not None:
+                    command.append(old)
+            with subprocess.Popen(command, env=env, cwd=directory, stdout=subprocess.PIPE,
+                                  stderr=subprocess.PIPE, text=True, start_new_session=True) as process:
+                try:
+                    stdout, stderr = process.communicate(timeout=10)
+                except BaseException:
+                    # A timeout/interrupt must not leave a shell child behind.
+                    try:
+                        os.killpg(process.pid, signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
+                    process.communicate()
+                    raise
+            state = json.loads(state_path.read_text())
+            self.assertEqual(process.returncode, 0, stderr)
+            self.assertEqual(stderr, "", stdout)
+            self.assertEqual(state["errors"], [], "unexpected or unsafe hook command")
+            return state
+
+    def assert_unit(self, state, unit, enabled, active, starts=0, restarts=0):
+        self.assertEqual(state["units"][unit], {
+            "enabled": enabled, "active": active, "starts": starts, "restarts": restarts,
+        }, state["calls"])
+
+    def test_modern_upgrade_preserves_enabled_stopped_units(self):
+        for family in ("debian", "arch"):
+            with self.subTest(family=family):
+                state = self.run_hook(family, ("enabled", False), ("enabled", False))
+                self.assert_unit(state, DAEMON, "enabled", False)
+                self.assert_unit(state, SOCKET, "enabled", False)
+
+    def test_modern_upgrade_preserves_independently_disabled_socket(self):
+        for family in ("debian", "arch"):
+            with self.subTest(family=family):
+                state = self.run_hook(family, ("enabled", False), ("disabled", False))
+                self.assert_unit(state, DAEMON, "enabled", False)
+                self.assert_unit(state, SOCKET, "disabled", False)
+
+    def test_modern_upgrade_restarts_active_daemon_without_reenabling_units(self):
+        for family in ("debian", "arch"):
+            for enabled in ("enabled", "disabled", "enabled-runtime"):
+                with self.subTest(family=family, enabled=enabled):
+                    state = self.run_hook(family, (enabled, True), (enabled, True))
+                    self.assert_unit(state, DAEMON, enabled, True, restarts=1)
+                    self.assert_unit(state, SOCKET, enabled, True)
+
+    def test_modern_upgrade_keeps_disabled_stopped_units_stopped(self):
+        for family in ("debian", "arch"):
+            with self.subTest(family=family):
+                state = self.run_hook(family, ("disabled", False), ("disabled", False))
+                self.assert_unit(state, DAEMON, "disabled", False)
+                self.assert_unit(state, SOCKET, "disabled", False)
+
+    def test_upgrade_respects_service_and_socket_masks(self):
+        for family in ("debian", "arch"):
+            for old in ("0.8.0", "0.11.3"):
+                for mask in ("masked", "masked-runtime"):
+                    for service in ("enabled", mask):
+                        with self.subTest(family=family, old=old, mask=mask, service=service):
+                            state = self.run_hook(family, (service, False), (mask, False), old)
+                            self.assert_unit(state, DAEMON, service, False)
+                            self.assert_unit(state, SOCKET, mask, False)
+
+    def test_first_install_enables_and_starts_both_units(self):
+        for family in ("debian", "arch"):
+            with self.subTest(family=family):
+                state = self.run_hook(family, ("disabled", False), ("disabled", False), None)
+                self.assert_unit(state, DAEMON, "enabled", True, starts=1,
+                                 restarts=1 if family == "debian" else 0)
+                self.assert_unit(state, SOCKET, "enabled", True, starts=1)
+
+    def test_pre_socket_upgrade_enables_but_does_not_start_for_stopped_service(self):
+        for family in ("debian", "arch"):
+            for old in ("0.7.0", "0.8.0", "0.8.0-2"):
+                with self.subTest(family=family, old=old):
+                    state = self.run_hook(family, ("enabled", False), ("disabled", False), old)
+                    self.assert_unit(state, DAEMON, "enabled", False)
+                    self.assert_unit(state, SOCKET, "enabled", False)
+
+    def test_pre_socket_upgrade_starts_socket_for_enabled_running_service(self):
+        for family in ("debian", "arch"):
+            with self.subTest(family=family):
+                state = self.run_hook(family, ("enabled", True), ("disabled", False), "0.8.0-1")
+                self.assert_unit(state, DAEMON, "enabled", True, restarts=1)
+                self.assert_unit(state, SOCKET, "enabled", True, starts=1)
+
+    def test_pre_socket_upgrade_keeps_disabled_service_and_socket_disabled(self):
+        for family in ("debian", "arch"):
+            for active in (False, True):
+                with self.subTest(family=family, active=active):
+                    state = self.run_hook(family, ("disabled", active), ("disabled", False), "0.8.0")
+                    self.assert_unit(state, DAEMON, "disabled", active, restarts=int(active))
+                    self.assert_unit(state, SOCKET, "disabled", False)
+
+    def test_socket_release_and_later_package_versions_do_not_migrate(self):
+        # pkgrel is part of pacman's old-version argument; Debian versions can
+        # carry revisions and prereleases. Native comparison avoids lexical
+        # mistakes (0.11.3 sorts before 0.8.1 as text).
+        for family, versions in (
+            ("debian", ("0.8.1", "0.8.1-2", "0.8.1+git1", "0.12.0~rc1-1", "0.12.0-1")),
+            ("arch", ("0.8.1-1", "0.8.1-2", "0.8.1.r1-1", "0.12.0rc1-1", "0.12.0-1")),
+        ):
+            for old in versions:
+                with self.subTest(family=family, old=old):
+                    state = self.run_hook(family, ("enabled", False), ("disabled", False), old)
+                    self.assert_unit(state, SOCKET, "disabled", False)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Upgrading Irlume on Debian or Arch could start `irlumed.socket` after an administrator had deliberately stopped both it and the enabled daemon. The unconditional socket-migration hook treated enablement as a request to start it again. The same hook could also re-enable an independently disabled socket.

Limit that migration to published releases older than 0.8.1, when the socket first shipped. For those older installs, enable the new socket without starting it when the daemon is inactive. Preserve first-install behavior and `try-restart` for running daemons. Add behavioral shell-hook regressions to CI and a passive, disposable-guest state checker with an upgrade-test procedure.

Validation:

- Native Debian dash and Arch Bash hook suite: 10 tests / 52 cases pass, with the original hooks producing 22 failing assertions.
- Passive checker and existing package/auth harness regressions, shell syntax, ShellCheck, packaging parity, action pins and actionlint pass.
- Real Fedora 44 matrix: all 12 upgrade/rollback/re-upgrade transitions pass under enforcing SELinux with signed RPM verification.
- Corrected Arch test package: all 8 candidate upgrade/re-upgrade transitions pass across disabled-running, disabled-stopped, enabled-stopped and masked-stopped states. Its 55 payload entries match the frozen candidate; only packaging metadata/hook changed.
- Corrected Debian test package: all 8 candidate upgrade/re-upgrade transitions pass under enforcing AppArmor. Its 69 payload entries and compressed data member match the frozen candidate exactly; only the version and postinst control files changed.

The published 0.11.3 Debian/Arch rollback hook still starts an enabled-but-stopped socket; those immutable packages are tested and reported as a legacy limitation. Each transition deliberately re-establishes its stated administrator intent, so this does not claim an uninterrupted passing rollback cycle. These test-only packages retain the previously qualified e3be0f86 payload with the corrected hooks; they are not full rebuilds of current main. No real-device installation or release is part of this change.
