### PR TITLE
perf(camera): reduce target-bound IR startup delay

### DIFF
--- a/crates/irlume-camera/src/ir_target.rs
+++ b/crates/irlume-camera/src/ir_target.rs
@@ -137,8 +137,9 @@ impl IrCaptureTarget {
 
     /// Capture once through this exact configured target and operation lease.
     ///
-    /// The target is revalidated before open and again before its fixed-startup
-    /// session. Explicit metadata absence never falls back to discovery.
+    /// The target is revalidated before open and again before its adaptive-startup
+    /// session. The full delivered-rate window remains mandatory; explicit
+    /// metadata absence never falls back to discovery.
     ///
     /// # Errors
     /// Returns cancellation, deadline, target, lease, camera, metadata, emitter,
@@ -174,6 +175,24 @@ impl IrCaptureTarget {
     ) -> irlume_common::Result<T> {
         validate().map_err(|error| irlume_common::Error::Hardware(error.to_string()))?;
         open_ir(&self.endpoint)
+    }
+
+    pub(super) fn session_with<T>(
+        &self,
+        opened_endpoint: &str,
+        validate: impl FnOnce() -> Result<(), IrTargetError>,
+        start: impl FnOnce(
+            crate::IrSessionStartup,
+            crate::ir_metadata::MetadataSelection<'_>,
+        ) -> irlume_common::Result<T>,
+    ) -> irlume_common::Result<T> {
+        if opened_endpoint != self.endpoint() {
+            return Err(irlume_common::Error::Hardware(
+                "opened IR camera does not match validated target".into(),
+            ));
+        }
+        validate().map_err(|error| irlume_common::Error::Hardware(error.to_string()))?;
+        start(crate::IrSessionStartup::Adaptive, self.metadata_selection())
     }
 
     pub(crate) fn validate_in(&self, sysfs: &Path) -> Result<(), IrTargetError> {
@@ -675,6 +694,87 @@ mod tests {
             )
             .unwrap();
         assert_eq!(opens.into_inner(), [target.endpoint()]);
+    }
+
+    #[test]
+    fn target_session_uses_the_full_rate_window_without_an_unconditional_flush() {
+        let target = unopened_target();
+        let mut stream =
+            crate::tests::rate_fill_fixture(crate::contracts::StreamRole::Ir, 100, 66_667);
+        target
+            .session_with(
+                target.endpoint(),
+                || Ok(()),
+                |startup, metadata| {
+                    assert!(matches!(
+                        metadata,
+                        crate::ir_metadata::MetadataSelection::Absent
+                    ));
+                    startup.warm_up(target.endpoint(), &mut stream, &crate::no_progress())?;
+                    startup
+                        .fill(&mut stream)
+                        .map_err(|error| crate::map_io(target.endpoint(), error))
+                },
+            )
+            .unwrap();
+        assert_eq!(stream.observations, 32);
+        let (_, _, _, _, evidence) = stream.next().unwrap();
+        assert_eq!(evidence.window_count(), 30);
+        assert!(evidence.meets_floor());
+    }
+
+    #[test]
+    fn target_session_keeps_exact_metadata_and_refuses_a_slow_stream() {
+        let mut target = unopened_target();
+        target.metadata_endpoint = Some("/fixture/metadata".into());
+        let mut stream =
+            crate::tests::rate_fill_fixture(crate::contracts::StreamRole::Ir, 100, 200_000);
+        target
+            .session_with(
+                target.endpoint(),
+                || Ok(()),
+                |startup, metadata| {
+                    assert!(matches!(
+                        metadata,
+                        crate::ir_metadata::MetadataSelection::Exact("/fixture/metadata")
+                    ));
+                    startup.warm_up(target.endpoint(), &mut stream, &crate::no_progress())?;
+                    startup
+                        .fill(&mut stream)
+                        .map_err(|error| crate::map_io(target.endpoint(), error))
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            stream.observations, 42,
+            "slow startup retains the bounded extra work"
+        );
+        assert!(matches!(
+            stream.next(),
+            Err(crate::DeliveryError::BelowFloor(_))
+        ));
+    }
+
+    #[test]
+    fn target_session_refuses_a_mismatched_camera_before_validation_or_startup() {
+        let target = unopened_target();
+        let result: irlume_common::Result<()> = target.session_with(
+            "/fixture/another-camera",
+            || panic!("mismatched camera must be refused before validation"),
+            |_, _| panic!("mismatched camera must never start a session"),
+        );
+        assert!(matches!(result, Err(irlume_common::Error::Hardware(_))));
+    }
+
+    #[test]
+    fn target_session_revalidates_before_startup() {
+        let target = unopened_target();
+        let result: irlume_common::Result<()> = target.session_with(
+            target.endpoint(),
+            || Err(IrTargetError::Changed),
+            |_, _| panic!("changed target must never start a session"),
+        );
+        assert!(matches!(result, Err(irlume_common::Error::Hardware(_))));
     }
 
     #[test]

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -5582,9 +5582,11 @@ impl IrCamera {
         )
     }
 
-    /// Start a fixed-startup IR-only session bound to a previously validated
-    /// configured target. The target is revalidated before any stream or
-    /// metadata endpoint is opened; explicit metadata absence never discovers.
+    /// Start an adaptive-startup IR-only session bound to a previously validated
+    /// configured target. A full delivered-rate window remains mandatory; only
+    /// the unconditional startup flush is avoided when that window meets the
+    /// floor. The target is revalidated before any stream or metadata endpoint
+    /// is opened; explicit metadata absence never discovers.
     ///
     /// # Errors
     /// Returns target-change, camera, metadata, privacy, emitter, or capture errors.
@@ -5593,18 +5595,12 @@ impl IrCamera {
         target: &IrCaptureTarget,
         control: &CaptureControl,
     ) -> irlume_common::Result<IrSession<'a>> {
-        if self.device != target.endpoint() {
-            return Err(Error::Hardware(
-                "opened IR camera does not match validated target".into(),
-            ));
-        }
-        target
-            .validate()
-            .map_err(|error| Error::Hardware(error.to_string()))?;
-        self.session_with_control_startup_metadata(
-            control,
-            IrSessionStartup::Fixed,
-            target.metadata_selection(),
+        target.session_with(
+            &self.device,
+            || target.validate(),
+            |startup, metadata| {
+                self.session_with_control_startup_metadata(control, startup, metadata)
+            },
         )
     }
 
@@ -11132,7 +11128,7 @@ mod tests {
         }
     }
 
-    struct QueuedContinuityFixture {
+    pub(super) struct QueuedContinuityFixture {
         payload: [u8; 1],
         metadata: std::collections::VecDeque<v4l::buffer::Metadata>,
     }
@@ -11164,7 +11160,7 @@ mod tests {
         }
     }
 
-    fn rate_fill_fixture(
+    pub(super) fn rate_fill_fixture(
         role: contracts::StreamRole,
         frames: u32,
         interval_us: i64,

--- a/docs/DESKTOP-AUTH.md
+++ b/docs/DESKTOP-AUTH.md
@@ -49,8 +49,12 @@ earlier. `IRLUME_GRACE_MS` remains the explicit 0–60000 ms override; zero reta
 legacy single-attempt behavior. A measured
 fixed-startup empty-view IR capture on one Minihost took about 5.5 seconds before
 identity work, so prerequisite-ready does not imply the five-second services can
-complete. IR-only opt-in does not silently extend a service window or adopt the
-separately measured adaptive startup experiment.
+complete. The target-bound IR route now uses adaptive startup while retaining the
+full 30-interval rate window, rate floor and continuity checks. Healthy startup
+can avoid the fixed ten-dequeue exclusion; a slow stream can use up to ten extra
+dequeues before the ordinary delivery gate accepts or refuses it. IR-only opt-in
+does not extend a service window. The historical fixed-startup measurement above
+does not predict the duration of a current attempt.
 
 Matches and prepared credentials observed after expiry are discarded. Capture
 checks expiry before and after returned driver calls and at inference

--- a/docs/IR_ONLY_QUALIFICATION.md
+++ b/docs/IR_ONLY_QUALIFICATION.md
@@ -223,7 +223,12 @@ does not grant from the diagnostic category. Camera-free preflight establishes
 prerequisites only. The existing product windows remain 15 seconds for login/lock
 and 5 seconds for short privileged services; a measured fixed-startup Minihost
 empty-view capture of about 5.5 seconds exceeded that short window before identity.
-The policy does not silently extend a window, adopt adaptive startup, or revive
+The target-bound IR route now uses the existing adaptive startup strategy: it
+measures the full 30-interval rate window first and uses up to ten additional
+dequeues if that window is too slow. The rate floor, continuity, metadata binding
+and all downstream authentication checks remain in place. This replaces the
+original integration's fixed startup; the historical Minihost measurement above
+describes that earlier behavior. It does not extend a window or revive
 stock-desktop hands-free scanning. This integration coverage permits explicit
 experimental opt-in; it does not qualify a device, participant group, or population.
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -121,8 +121,11 @@ settings select dual; malformed or unreadable settings make face authentication
 unavailable until repaired. IR-only opens only the configured, enrollment-bound IR
 image endpoint and its exact optional metadata companion. It does not probe RGB or
 fall back to RGB, and it adds no startup or background camera opens. The currently
-supported scope requires the enrolled isolated USB IR interface and fixed startup,
-with compatible IR templates and mandatory FLIR PAD.
+supported scope requires the enrolled isolated USB IR interface, compatible IR
+templates and mandatory FLIR PAD. Startup measures the full 30-interval rate window
+before spending up to ten additional dequeues on a slow-starting stream. The rate
+floor and continuity checks still apply; this does not qualify the device or
+guarantee that an attempt will finish within its service window.
 
 This sensor policy is independent of sequential/concurrent `CaptureMode`, the PAM
 `Method`, and privileged per-attempt consent. It changes none of those controls and


### PR DESCRIPTION
Healthy target-bound IR startup always discarded ten frames before measuring the full rate window. Use the existing Adaptive strategy to measure that window first and spend the additional dequeue budget only when startup is slow. A private target-session constructor keeps endpoint validation, revalidation and exact metadata selection together; generic fixed and paired sessions retain their behavior. Current docs describe the expanded experimental IR-only scope.

The full 30-interval rate window, rate floor, continuity checks, mandatory IR PAD, service deadlines and cleanup ownership are preserved. Four behavioral regressions cover actual target selection, slow-stream refusal, metadata and validation ordering; the healthy test reproduced 42 observations under Fixed versus 32 under Adaptive.

Validation: Rust 1.88 formatting, default/optional Clippy and warnings-denied docs, 2,248 workspace tests, 245 optional IR tests/examples, and release build passed. Independent source and harness reviews passed.

Attended ASUS comparison used two ABBA blocks with four fresh-daemon first-authentication samples per arm, after readiness, under the same models/runtimes and power policy. All eight granted. Request-to-reply median fell from **4.458 to 3.807 seconds (14.60%)**; IR capture median fell from 3.737 to 3.073 seconds.

The no-face control is a tradeoff: **11.450 to 12.512 seconds**, both denied. Trace confirms three versus four attempts; faster attempts fit one additional retry within the unchanged 15-second window. Both disconnect/camera-release controls passed. These small identity-only daemon measurements do not establish full desktop/wallet timing, tail latency, population accuracy or spoof qualification. All original service/protected-state restoration checks passed; the IR-only policy remains experimental.
