### PR TITLE
perf(auth): collect concurrent PAD evidence in one camera session

### DIFF
--- a/crates/irlume-auth/src/engine_tests/managed_pad_tests.rs
+++ b/crates/irlume-auth/src/engine_tests/managed_pad_tests.rs
@@ -1,0 +1,766 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+use super::pair_identity_tests::{
+    materialize_synthetic_pair, paired_enrollment, visible_pair_sample,
+};
+use super::*;
+use std::cell::Cell;
+use std::time::{Duration, Instant};
+
+#[test]
+fn managed_pending_collects_five_fresh_samples_and_materializes_only_the_last() {
+    let _guard = env_guard();
+    let mut state = shared();
+    let engine = &mut state.engine;
+    let previous_ir = engine.ir_available;
+    engine.ir_available = true;
+    // Another transaction's partial vote must not shorten this collection.
+    engine.vit_scores.extend([0.2; 4]);
+    let mut samples = 0;
+    let mut identities = Vec::new();
+    let prepared = engine
+        .collect_concurrent_pending_with(
+            Instant::now() + Duration::from_secs(15),
+            |engine| {
+                let sample = samples;
+                samples += 1;
+                let evidence = visible_pair_sample(engine, sample, 0.2, false);
+                engine
+                    .prepare_pair_authentication_with(evidence, |_, evidence| {
+                        identities.push(evidence.identity.0.as_ref().unwrap().data[0]);
+                        assert_eq!(evidence.identity.1.as_ref().unwrap().data[0], sample);
+                        Ok(materialize_synthetic_pair(evidence))
+                    })
+                    .map_err(CapturePathError::from)
+            },
+            Instant::now,
+        )
+        .map_err(CapturePathError::into_inner)
+        .unwrap();
+    assert_eq!(samples, 5);
+    assert_eq!(identities, [4]);
+    assert!(
+        engine.vit_scores.is_empty(),
+        "transaction must retire its vote"
+    );
+    let out = engine
+        .finish_pair_authentication(
+            &paired_enrollment(),
+            AuthenticationPurpose::Verify,
+            Some("login"),
+            Ok(prepared),
+            None,
+            &(),
+        )
+        .unwrap();
+    engine.ir_available = previous_ir;
+    assert!(
+        out.granted,
+        "complete concurrent identity must retain its grant arms"
+    );
+}
+
+#[test]
+fn managed_pending_hard_ir_failure_stops_without_identity_or_a_sixth_sample() {
+    let _guard = env_guard();
+    let mut state = shared();
+    for fail_at in 0..5 {
+        let mut samples = 0;
+        let prepared = state
+            .engine
+            .collect_concurrent_pending_with(
+                Instant::now() + Duration::from_secs(15),
+                |engine| {
+                    let mut evidence = visible_pair_sample(engine, samples, 0.2, false);
+                    if samples == fail_at {
+                        evidence.assessment.ir_pad = PadEvidence::InferenceFailed;
+                    }
+                    samples += 1;
+                    engine
+                        .prepare_pair_authentication_with(evidence, |_, _| {
+                            panic!("identity on failed PAD")
+                        })
+                        .map_err(CapturePathError::from)
+                },
+                Instant::now,
+            )
+            .map_err(CapturePathError::into_inner)
+            .unwrap();
+        let PreparedPairAuthentication::Refused(outcome) = prepared else {
+            panic!("PAD failure admitted");
+        };
+        assert_eq!(outcome.kind, OutcomeKind::RuntimeUnavailable);
+        assert_eq!(samples, fail_at + 1);
+        assert!(state.engine.vit_scores.is_empty());
+    }
+    let mut samples = 0;
+    let prepared = state
+        .engine
+        .collect_concurrent_pending_with(
+            Instant::now() + Duration::from_secs(15),
+            |_| {
+                samples += 1;
+                Ok(PreparedPairAuthentication::Refused(Outcome::deny(
+                    OutcomeKind::RgbPadPending,
+                    "synthetic pending",
+                )))
+            },
+            Instant::now,
+        )
+        .map_err(CapturePathError::into_inner)
+        .unwrap();
+    assert_eq!(samples, VIT_PAD_VOTE_N);
+    assert!(matches!(
+        prepared,
+        PreparedPairAuthentication::Refused(Outcome {
+            kind: OutcomeKind::RgbPadPending,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn managed_non_live_ends_the_collection_and_preserves_eager_preparation() {
+    let _guard = env_guard();
+    let mut state = shared();
+    for verdict in [Verdict::Uncertain, Verdict::Spoof] {
+        let mut samples = 0;
+        let mut identities = 0;
+        let prepared = state
+            .engine
+            .collect_concurrent_pending_with(
+                Instant::now() + Duration::from_secs(15),
+                |engine| {
+                    let mut evidence = visible_pair_sample(engine, samples, 0.2, false);
+                    if samples == 1 {
+                        evidence.assessment.verdict = verdict;
+                    }
+                    samples += 1;
+                    engine
+                        .prepare_pair_authentication_with(evidence, |_, evidence| {
+                            identities += 1;
+                            Ok(materialize_synthetic_pair(evidence))
+                        })
+                        .map_err(CapturePathError::from)
+                },
+                Instant::now,
+            )
+            .map_err(CapturePathError::into_inner)
+            .unwrap();
+        assert_eq!(samples, 2);
+        assert_eq!(identities, 1);
+        assert!(matches!(prepared, PreparedPairAuthentication::Ready(_)));
+        assert!(state.engine.vit_scores.is_empty());
+    }
+}
+
+#[test]
+fn managed_transport_or_inference_failure_discards_prepared_evidence_and_facts() {
+    let _guard = env_guard();
+    let mut state = shared();
+    for transport in [false, true] {
+        let mut samples = 0;
+        let mut identities = 0;
+        let result = state.engine.collect_concurrent_pending_with(
+            Instant::now() + Duration::from_secs(15),
+            |engine| {
+                let evidence = visible_pair_sample(engine, samples, 0.2, false);
+                samples += 1;
+                let prepared = engine
+                    .prepare_pair_authentication_with(evidence, |_, evidence| {
+                        identities += 1;
+                        if transport {
+                            Ok(materialize_synthetic_pair(evidence))
+                        } else {
+                            Err(irlume_common::Error::Hardware("synthetic inference".into()))
+                        }
+                    })
+                    .map_err(CapturePathError::from)?;
+                if samples == 5 {
+                    drop(prepared); // Successful work is invalidated by its tail drain.
+                    Err(CapturePathError::ConcurrentPair(
+                        irlume_common::Error::Hardware("synthetic tail".into()),
+                    ))
+                } else {
+                    Ok(prepared)
+                }
+            },
+            Instant::now,
+        );
+        assert_eq!(samples, 5);
+        assert_eq!(identities, 1);
+        assert_eq!(
+            matches!(&result, Err(CapturePathError::ConcurrentPair(_))),
+            transport
+        );
+        assert!(result.is_err());
+        assert!(state.engine.vit_scores.is_empty());
+        assert_eq!(state.engine.last_attempt_facts.rgb_face, None);
+    }
+}
+
+#[test]
+fn managed_completed_pending_at_expiry_and_panic_clear_votes_without_later_work() {
+    let _guard = env_guard();
+    let mut state = shared();
+    let start = Instant::now();
+    let clock = Cell::new(start);
+    let deadline = start + Duration::from_secs(15);
+    let mut samples = 0;
+    let result = state.engine.collect_concurrent_pending_with(
+        deadline,
+        |engine| {
+            samples += 1;
+            let evidence = visible_pair_sample(engine, 0, 0.2, false);
+            let prepared = engine
+                .prepare_pair_authentication_with(evidence, |_, _| panic!("pending identity"))
+                .map_err(CapturePathError::from);
+            clock.set(deadline);
+            prepared
+        },
+        || clock.get(),
+    );
+    assert_eq!(samples, 1);
+    assert!(matches!(
+        result,
+        Ok(PreparedPairAuthentication::Refused(Outcome {
+            kind: OutcomeKind::RgbPadPending,
+            ..
+        }))
+    ));
+    assert!(state.engine.vit_scores.is_empty());
+    assert!(
+        state.engine.last_attempt_facts.rgb_face.is_some(),
+        "completed denial retains its own facts"
+    );
+
+    let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        state.engine.collect_concurrent_pending_with(
+            deadline,
+            |engine| {
+                engine.vit_scores.push(0.2);
+                engine.last_attempt_facts.rgb_face = Some((0.5, 0.5));
+                panic!("synthetic processing panic")
+            },
+            || start,
+        )
+    }));
+    assert!(panic.is_err());
+    assert!(state.engine.vit_scores.is_empty());
+    assert_eq!(state.engine.last_attempt_facts.rgb_face, None);
+}
+
+fn concurrent_mode() -> CaptureModeSelection {
+    CaptureModeSelection {
+        sequential: false,
+        source: STORED_CAPTURE_MODE_SOURCE,
+        runtime_key: Some("synthetic".into()),
+        runtime_contract: None,
+        qualification_state: irlume_common::diagnostics::QualificationState::QualifiedConcurrent,
+        qualification_reason: None,
+        authoritative_rate_shortfalls: None,
+        latest_attempt_rate_shortfalls: None,
+        operation_demoted: Cell::new(false),
+    }
+}
+
+#[test]
+fn managed_eligibility_preserves_authority_models_service_and_window_scope() {
+    for source in [
+        STORED_CAPTURE_MODE_SOURCE,
+        ENV_CAPTURE_MODE_SOURCE,
+        "default",
+        RUNTIME_CAPTURE_MODE_SOURCE,
+    ] {
+        for (service, verify, release) in [
+            (Some("login"), true, true),
+            (Some("kde-fingerprint"), true, true),
+            (None, true, false),
+            (Some("unknown-local-service"), true, false),
+            (Some("sudo"), false, false),
+            (Some("sshd"), false, false),
+        ] {
+            let mut mode = concurrent_mode();
+            mode.source = source;
+            for purpose in [
+                AuthenticationPurpose::Verify,
+                AuthenticationPurpose::CredentialRelease,
+                AuthenticationPurpose::AppConsent,
+            ] {
+                let purpose_allowed = match purpose {
+                    AuthenticationPurpose::Verify => verify,
+                    AuthenticationPurpose::CredentialRelease => release,
+                    AuthenticationPurpose::AppConsent => false,
+                };
+                assert_eq!(
+                    crate::managed_pad::eligible_configuration(
+                        &mode, true, true, true, 15_000, purpose, service
+                    ),
+                    purpose_allowed
+                        && matches!(source, STORED_CAPTURE_MODE_SOURCE | ENV_CAPTURE_MODE_SOURCE)
+                );
+            }
+        }
+    }
+    let mut mode = concurrent_mode();
+    assert!(
+        !crate::managed_pad::eligible(
+            &mode,
+            true,
+            true,
+            true,
+            15_000,
+            AuthenticationPurpose::Verify,
+            Some("login")
+        ),
+        "no exact live contract"
+    );
+    for (ir, rgb_pad, ir_pad, window) in [
+        (false, true, true, 15_000),
+        (true, false, true, 15_000),
+        (true, true, false, 15_000),
+        (true, true, true, 14_999),
+    ] {
+        assert!(!crate::managed_pad::eligible_configuration(
+            &mode,
+            ir,
+            rgb_pad,
+            ir_pad,
+            window,
+            AuthenticationPurpose::Verify,
+            Some("login")
+        ));
+    }
+    mode.qualification_state = irlume_common::diagnostics::QualificationState::MeasuredSequential;
+    assert!(!crate::managed_pad::eligible_configuration(
+        &mode,
+        true,
+        true,
+        true,
+        15_000,
+        AuthenticationPurpose::Verify,
+        Some("login")
+    ));
+    mode.source = ENV_CAPTURE_MODE_SOURCE;
+    assert!(crate::managed_pad::eligible_configuration(
+        &mode,
+        true,
+        true,
+        true,
+        15_000,
+        AuthenticationPurpose::Verify,
+        Some("login")
+    ));
+    mode.operation_demoted.set(true);
+    assert!(!crate::managed_pad::eligible_configuration(
+        &mode,
+        true,
+        true,
+        true,
+        15_000,
+        AuthenticationPurpose::Verify,
+        Some("login")
+    ));
+}
+
+#[test]
+fn managed_cancel_between_samples_stops_and_releases_both_owners_without_fallback() {
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
+    struct Owner<'a>(&'a Cell<usize>);
+    impl Drop for Owner<'_> {
+        fn drop(&mut self) {
+            self.0.set(self.0.get() + 1);
+        }
+    }
+    let _guard = env_guard();
+    let mut state = shared();
+    let signal = Arc::new(AtomicBool::new(false));
+    let hook = signal.clone();
+    state
+        .engine
+        .set_request_cancel_signal(Arc::new(move || hook.load(Ordering::SeqCst)));
+    let released = Cell::new(0);
+    let mut samples = 0;
+    let prepared = with_owned_pair((Owner(&released), Owner(&released)), &(), |_, _| {
+        state.engine.collect_concurrent_pending_with(
+            Instant::now() + Duration::from_secs(15),
+            |engine| {
+                assert_eq!(released.get(), 0);
+                samples += 1;
+                let evidence = visible_pair_sample(engine, 0, 0.2, false);
+                let result = engine
+                    .prepare_pair_authentication_with(evidence, |_, _| panic!("pending identity"))
+                    .map_err(CapturePathError::from);
+                signal.store(true, Ordering::SeqCst);
+                result
+            },
+            Instant::now,
+        )
+    });
+    state.engine.request_cancelled = None;
+    assert_eq!(released.get(), 2);
+    let mut fallback = false;
+    let result = state.engine.finish_pair_authentication(
+        &paired_enrollment(),
+        AuthenticationPurpose::Verify,
+        Some("login"),
+        prepared,
+        Some(&mut fallback),
+        &(),
+    );
+    assert_eq!(samples, 1);
+    assert!(!fallback);
+    assert!(matches!(result, Err(irlume_common::Error::Preempted(_))));
+    assert!(state.engine.vit_scores.is_empty());
+    assert_eq!(state.engine.last_attempt_facts.rgb_face, None);
+}
+
+#[test]
+fn managed_complete_batch_is_one_outer_attempt_and_preserves_final_match_decision() {
+    let _guard = env_guard();
+    let mut state = shared();
+    let engine = &mut state.engine;
+    let previous_ir = engine.ir_available;
+    engine.ir_available = true;
+    for matching in [true, false] {
+        let started = Instant::now();
+        let clock = Cell::new(started);
+        let attempts = Cell::new(0);
+        let mut samples = 0;
+        let mut identities = 0;
+        let mut costliest = Duration::ZERO;
+        let (result, fallback) = engine.authentication_attempt_loop_with(
+            started + Duration::from_secs(15),
+            15_000,
+            &mut costliest,
+            |engine| {
+                attempts.set(attempts.get() + 1);
+                assert_eq!(attempts.get(), 1, "identity decision must not repeat");
+                // Includes startup, every sample, processing and owner release.
+                clock.set(clock.get() + Duration::from_secs(3));
+                let prepared = engine.collect_concurrent_pending_with(
+                    started + Duration::from_secs(15),
+                    |engine| {
+                        let mut evidence = visible_pair_sample(engine, samples, 0.2, false);
+                        samples += 1;
+                        if !matching {
+                            evidence.identity.0.as_mut().unwrap().data[1] = 1;
+                            evidence.identity.1.as_mut().unwrap().data[1] = 1;
+                        }
+                        clock.set(clock.get() + Duration::from_millis(400));
+                        engine
+                            .prepare_pair_authentication_with(evidence, |_, evidence| {
+                                identities += 1;
+                                Ok(materialize_synthetic_pair(evidence))
+                            })
+                            .map_err(CapturePathError::from)
+                    },
+                    || clock.get(),
+                );
+                (
+                    engine.finish_pair_authentication(
+                        &paired_enrollment(),
+                        AuthenticationPurpose::Verify,
+                        Some("login"),
+                        prepared,
+                        None,
+                        &(),
+                    ),
+                    false,
+                )
+            },
+            || clock.get(),
+        );
+        assert!(!fallback);
+        assert_eq!(samples, 5);
+        assert_eq!(identities, 1);
+        assert_eq!(costliest, Duration::from_secs(5));
+        assert_eq!(
+            result.unwrap().kind,
+            if matching {
+                OutcomeKind::Granted
+            } else {
+                OutcomeKind::BelowThreshold
+            }
+        );
+    }
+    engine.ir_available = previous_ir;
+}
+
+#[test]
+fn managed_missing_face_retires_votes_before_another_presentation() {
+    let _guard = env_guard();
+    let mut state = shared();
+    let mut samples = 0;
+    let prepared = state.engine.collect_concurrent_pending_with(
+        Instant::now() + Duration::from_secs(15),
+        |engine| {
+            let mut evidence = visible_pair_sample(engine, samples, 0.2, false);
+            samples += 1;
+            if samples == 5 {
+                evidence.identity = (None, None);
+                evidence.assessment.signals = Signals::default();
+                evidence.assessment.verdict = Verdict::Uncertain;
+                evidence.assessment.rgb_pad = PadEvidence::NotApplicable;
+                evidence.assessment.ir_pad = PadEvidence::NotApplicable;
+            }
+            engine
+                .prepare_pair_authentication_with(evidence, |_, evidence| {
+                    Ok(materialize_synthetic_pair(evidence))
+                })
+                .map_err(CapturePathError::from)
+        },
+        Instant::now,
+    );
+    let result = state
+        .engine
+        .finish_pair_authentication(
+            &paired_enrollment(),
+            AuthenticationPurpose::Verify,
+            Some("login"),
+            prepared,
+            None,
+            &(),
+        )
+        .unwrap();
+    assert_eq!(result.kind, OutcomeKind::Uncertain);
+    assert!(state.engine.vit_scores.is_empty());
+    let mut fresh = 0;
+    let prepared = state
+        .engine
+        .collect_concurrent_pending_with(
+            Instant::now() + Duration::from_secs(15),
+            |engine| {
+                let evidence = visible_pair_sample(engine, fresh, 0.2, false);
+                fresh += 1;
+                engine
+                    .prepare_pair_authentication_with(evidence, |_, evidence| {
+                        Ok(materialize_synthetic_pair(evidence))
+                    })
+                    .map_err(CapturePathError::from)
+            },
+            Instant::now,
+        )
+        .map_err(CapturePathError::into_inner)
+        .unwrap();
+    assert_eq!(fresh, 5);
+    assert!(matches!(prepared, PreparedPairAuthentication::Ready(_)));
+    assert!(state.engine.vit_scores.is_empty());
+}
+
+#[test]
+fn managed_pair_windows_reject_replay_overlap_reversal_and_accept_drain_gaps() {
+    use crate::managed_pad::PairWindows;
+    use irlume_camera::CaptureWindow;
+    let start = Instant::now();
+    let window = |a, b| CaptureWindow {
+        start: start + Duration::from_millis(a),
+        end: start + Duration::from_millis(b),
+    };
+    for (rgb, ir) in [
+        (window(0, 20), window(5, 25)),   // replay
+        (window(20, 40), window(30, 50)), // shared RGB endpoint
+        (window(21, 40), window(24, 50)), // overlapping IR
+        (window(15, 10), window(30, 50)), // reversed window
+        (window(30, 50), window(35, 31)), // reversed IR
+    ] {
+        let mut windows = PairWindows::default();
+        assert!(windows.advance(window(0, 20), window(5, 25)));
+        assert!(!windows.advance(rgb, ir));
+        assert!(
+            windows.advance(window(200, 220), window(205, 225)),
+            "validated drained frames need not be samples"
+        );
+    }
+    let mut windows = PairWindows::default();
+    assert!(
+        !windows.advance(window(20, 0), window(5, 25)),
+        "first sample must be well ordered"
+    );
+    assert!(windows.advance(window(0, 20), window(5, 25)));
+    assert!(windows.advance(window(21, 41), window(26, 46)));
+}
+
+#[test]
+fn managed_pair_arms_and_establishes_once_and_releases_before_admission() {
+    use crate::managed_pad::with_managed_pair;
+    struct Owner<'a>(&'a Cell<usize>);
+    impl Drop for Owner<'_> {
+        fn drop(&mut self) {
+            self.0.set(self.0.get() + 1);
+        }
+    }
+    let _guard = env_guard();
+    let mut state = shared();
+    let released = Cell::new(0);
+    let armed = Cell::new(0);
+    let rate = Cell::new(0);
+    let mut samples = 0;
+    let prepared = with_managed_pair(
+        || {
+            armed.set(armed.get() + 1);
+            Ok((Owner(&released), Owner(&released)))
+        },
+        |_, _| {
+            assert_eq!(released.get(), 0);
+            rate.set(rate.get() + 1);
+            Ok(())
+        },
+        |_, _| {
+            state.engine.collect_concurrent_pending_with(
+                Instant::now() + Duration::from_secs(15),
+                |engine| {
+                    assert_eq!(armed.get(), 1);
+                    assert_eq!(rate.get(), 1);
+                    assert_eq!(released.get(), 0);
+                    let sample = visible_pair_sample(engine, samples, 0.2, false);
+                    samples += 1;
+                    engine
+                        .prepare_pair_authentication_with(sample, |_, evidence| {
+                            assert_eq!(
+                                released.get(),
+                                0,
+                                "identity processing still owns serviced queues"
+                            );
+                            Ok(materialize_synthetic_pair(evidence))
+                        })
+                        .map_err(CapturePathError::from)
+                },
+                Instant::now,
+            )
+        },
+        &(),
+    );
+    assert_eq!(
+        (armed.get(), rate.get(), samples, released.get()),
+        (1, 1, 5, 2)
+    );
+    let previous_ir = state.engine.ir_available;
+    state.engine.ir_available = true;
+    let result = state.engine.finish_pair_authentication(
+        &paired_enrollment(),
+        AuthenticationPurpose::Verify,
+        Some("login"),
+        prepared,
+        None,
+        &(),
+    );
+    state.engine.ir_available = previous_ir;
+    assert!(result.unwrap().granted);
+}
+
+#[test]
+fn managed_pair_releases_on_rate_processing_error_and_panic_without_admission() {
+    use crate::managed_pad::with_managed_pair;
+    struct Owner<'a>(&'a Cell<usize>);
+    impl Drop for Owner<'_> {
+        fn drop(&mut self) {
+            self.0.set(self.0.get() + 1);
+        }
+    }
+    for fault in ["rate", "processing", "panic"] {
+        let released = Cell::new(0);
+        let processed = Cell::new(0);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            with_managed_pair(
+                || Ok((Owner(&released), Owner(&released))),
+                |_, _| {
+                    if fault == "rate" {
+                        Err(CapturePathError::ConcurrentPair(
+                            irlume_common::Error::Hardware("rate failure".into()),
+                        ))
+                    } else {
+                        Ok(())
+                    }
+                },
+                |_, _| {
+                    processed.set(processed.get() + 1);
+                    assert_ne!(fault, "panic", "processing panic");
+                    Err::<(), _>(CapturePathError::Other(irlume_common::Error::Hardware(
+                        "inference failure".into(),
+                    )))
+                },
+                &(),
+            )
+        }));
+        assert_eq!(released.get(), 2);
+        assert_eq!(processed.get(), usize::from(fault != "rate"));
+        match result {
+            Ok(Err(error)) => assert_eq!(
+                matches!(error, CapturePathError::ConcurrentPair(_)),
+                fault == "rate"
+            ),
+            Err(_) => assert_eq!(fault, "panic"),
+            Ok(Ok(_)) => panic!("failed work admitted"),
+        }
+    }
+}
+
+#[test]
+fn managed_deadline_preserves_completed_hard_refusal_but_never_admits_ready_or_starts_expired() {
+    let _guard = env_guard();
+    let mut state = shared();
+    let start = Instant::now();
+    let deadline = start + Duration::from_secs(15);
+    for hard_failure in [false, true] {
+        let clock = Cell::new(start);
+        let mut samples = 0;
+        let result = state.engine.collect_concurrent_pending_with(
+            deadline,
+            |engine| {
+                let mut evidence = visible_pair_sample(engine, samples, 0.2, false);
+                samples += 1;
+                if hard_failure {
+                    evidence.assessment.ir_pad = PadEvidence::InferenceFailed;
+                }
+                let prepared = engine
+                    .prepare_pair_authentication_with(evidence, |_, evidence| {
+                        Ok(materialize_synthetic_pair(evidence))
+                    })
+                    .map_err(CapturePathError::from);
+                if hard_failure || samples == 5 {
+                    clock.set(deadline);
+                }
+                prepared
+            },
+            || clock.get(),
+        );
+        if hard_failure {
+            assert_eq!(samples, 1);
+            assert!(matches!(
+                result,
+                Ok(PreparedPairAuthentication::Refused(Outcome {
+                    kind: OutcomeKind::RuntimeUnavailable,
+                    ..
+                }))
+            ));
+            assert!(state.engine.last_attempt_facts.rgb_face.is_some());
+        } else {
+            assert_eq!(samples, 5);
+            assert!(matches!(
+                result,
+                Err(CapturePathError::Other(
+                    irlume_common::Error::DeadlineExpired
+                ))
+            ));
+            assert_eq!(state.engine.last_attempt_facts.rgb_face, None);
+        }
+        assert!(state.engine.vit_scores.is_empty());
+    }
+    let result = state.engine.collect_concurrent_pending_with(
+        deadline,
+        |_| panic!("expired sample must not start"),
+        || deadline,
+    );
+    assert!(matches!(
+        result,
+        Err(CapturePathError::Other(
+            irlume_common::Error::DeadlineExpired
+        ))
+    ));
+    assert!(state.engine.vit_scores.is_empty());
+}

--- a/crates/irlume-auth/src/engine_tests/pair_identity_tests.rs
+++ b/crates/irlume-auth/src/engine_tests/pair_identity_tests.rs
@@ -1,0 +1,1063 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+use super::*;
+use irlume_common::diagnostics::{DiagnosticSink, TraceEventKind, TraceRefusalReason, TraceStage};
+
+#[derive(Debug)]
+enum Recorded {
+    Trace(TraceEventKind),
+    Dropped(&'static str),
+}
+
+#[derive(Default)]
+struct RecordingSink(Mutex<Vec<Recorded>>);
+
+impl DiagnosticSink for RecordingSink {
+    fn emit_trace(&self, kind: TraceEventKind) {
+        self.0.lock().unwrap().push(Recorded::Trace(kind));
+    }
+}
+
+impl RecordingSink {
+    fn traces(&self) -> Vec<TraceEventKind> {
+        self.0
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(|record| match record {
+                Recorded::Trace(event) => Some(event.clone()),
+                Recorded::Dropped(_) => None,
+            })
+            .collect()
+    }
+}
+
+#[test]
+fn rgb_pad_pending_is_distinct_from_liveness_uncertain_and_still_retryable() {
+    let rgb = pad_evidence_refusal(PadModality::Rgb, PadEvidence::Pending).unwrap();
+    let ir = pad_evidence_refusal(PadModality::Ir, PadEvidence::Pending).unwrap();
+    assert_eq!(rgb.kind, OutcomeKind::RgbPadPending);
+    assert_eq!(ir.kind, OutcomeKind::Uncertain);
+    assert!(presence_retryable(&rgb));
+    assert!(!rgb.granted && !rgb.live);
+    assert_eq!(rgb.score, 0.0);
+    assert_eq!(rgb.reason, "collecting RGB PAD evidence");
+    let facts = AttemptFacts::default();
+    assert_eq!(
+        auth_attempt_situation(rgb.kind, &facts),
+        auth_attempt_situation(OutcomeKind::Uncertain, &facts)
+    );
+}
+
+#[test]
+fn pending_rgb_does_not_replace_a_required_ir_refusal() {
+    for ir in [
+        PadEvidence::Unavailable,
+        PadEvidence::InferenceFailed,
+        PadEvidence::NotApplicable,
+    ] {
+        let refusal =
+            pad_policy_refusal(PadRequirements::RgbAndIr, PadEvidence::Pending, ir).unwrap();
+        assert_eq!(refusal.kind, OutcomeKind::RuntimeUnavailable);
+        assert!(!presence_retryable(&refusal));
+    }
+    let ir_pending = pad_policy_refusal(
+        PadRequirements::RgbAndIr,
+        PadEvidence::Pending,
+        PadEvidence::Pending,
+    )
+    .unwrap();
+    assert_eq!(ir_pending.kind, OutcomeKind::Uncertain);
+    assert_eq!(ir_pending.reason, "collecting IR PAD evidence");
+}
+
+#[test]
+fn ordinary_authentication_traces_the_selected_refusal_without_prose() {
+    let _guard = env_guard();
+    let mut state = shared();
+    let engine = &mut state.engine;
+    let previous_ir = engine.ir_available;
+    engine.ir_available = true;
+    let mut results = Vec::new();
+    for ir in [PadEvidence::Score(0.1), PadEvidence::InferenceFailed] {
+        engine.vit_scores.clear();
+        engine.vit_pad_votes_deny(0.2);
+        let (enrollment, mut assessment) = pad_matching_fixture(0.2, false);
+        assessment.ir_pad = ir;
+        assessment.reason = "private reason canary".into();
+        let sink = RecordingSink::default();
+        let result = engine.authenticate_assessment(
+            &enrollment,
+            AuthenticationPurpose::Verify,
+            None,
+            assessment,
+            &sink,
+        );
+        results.push((result, sink.traces()));
+    }
+    engine.ir_available = previous_ir;
+    engine.vit_scores.clear();
+    for ((result, traces), expected) in results.into_iter().zip([
+        TraceRefusalReason::RgbPadPending,
+        TraceRefusalReason::RuntimeUnavailable,
+    ]) {
+        assert!(!result.unwrap().granted);
+        let refusals: Vec<_> = traces
+            .iter()
+            .filter_map(|event| match event {
+                TraceEventKind::AuthenticationRefusal { reason } => Some(*reason),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(refusals, [expected]);
+        assert!(!serde_json::to_string(&traces)
+            .unwrap()
+            .contains("private reason canary"));
+    }
+}
+
+#[test]
+fn refusal_trace_uses_only_typed_kinds_and_omits_grants() {
+    for (kind, expected) in [
+        (
+            OutcomeKind::RgbPadPending,
+            TraceRefusalReason::RgbPadPending,
+        ),
+        (OutcomeKind::NoFace, TraceRefusalReason::NoFace),
+        (OutcomeKind::Uncertain, TraceRefusalReason::Uncertain),
+        (
+            OutcomeKind::SpoofNoIrFace,
+            TraceRefusalReason::SpoofNoIrFace,
+        ),
+        (OutcomeKind::Spoof, TraceRefusalReason::Spoof),
+        (
+            OutcomeKind::BelowThreshold,
+            TraceRefusalReason::BelowThreshold,
+        ),
+        (
+            OutcomeKind::SetupUnavailable,
+            TraceRefusalReason::SetupUnavailable,
+        ),
+        (
+            OutcomeKind::DeadlineExpired,
+            TraceRefusalReason::DeadlineExpired,
+        ),
+        (
+            OutcomeKind::RuntimeUnavailable,
+            TraceRefusalReason::RuntimeUnavailable,
+        ),
+        (OutcomeKind::OtherDeny, TraceRefusalReason::OtherDeny),
+    ] {
+        for prose in ["collecting RGB PAD evidence", "unrelated private reason"] {
+            let sink = RecordingSink::default();
+            emit_authentication_refusal(&sink, &Outcome::deny_live(kind, 0.12345, prose));
+            let traces = sink.traces();
+            assert!(matches!(traces.as_slice(), [
+                TraceEventKind::AuthenticationRefusal { reason }
+            ] if *reason == expected));
+            let json = serde_json::to_value(&traces[0]).unwrap();
+            assert_eq!(json.as_object().unwrap().len(), 2);
+            assert!(json.get("score").is_none());
+            assert!(!json.to_string().contains(prose));
+        }
+    }
+    let sink = RecordingSink::default();
+    emit_authentication_refusal(&sink, &Outcome::grant(0.12345, "private grant reason"));
+    assert!(sink.traces().is_empty());
+}
+
+struct DropStream<'a>(&'a RecordingSink, &'static str);
+
+impl Drop for DropStream<'_> {
+    fn drop(&mut self) {
+        std::thread::sleep(std::time::Duration::from_millis(1));
+        self.0 .0.lock().unwrap().push(Recorded::Dropped(self.1));
+    }
+}
+
+fn assert_pair_released(sink: &RecordingSink) {
+    let recorded = sink.0.lock().unwrap();
+    assert!(
+        matches!(recorded.as_slice(), [
+            Recorded::Dropped("rgb"),
+            Recorded::Dropped("ir"),
+            Recorded::Trace(TraceEventKind::StageTiming {
+                stage: TraceStage::StreamOwnerRelease,
+                elapsed_us,
+            }),
+        ] if *elapsed_us >= 2_000),
+        "both owner destructors must complete in the measured release interval: {recorded:?}"
+    );
+}
+
+#[test]
+fn stream_release_trace_follows_both_destructors_on_success_and_error() {
+    for succeed in [true, false] {
+        let sink = RecordingSink::default();
+        let result = with_owned_pair(
+            (DropStream(&sink, "rgb"), DropStream(&sink, "ir")),
+            &sink,
+            |_, _| {
+                assert!(sink.traces().is_empty());
+                if succeed {
+                    Ok(7)
+                } else {
+                    Err("assessment error")
+                }
+            },
+        );
+        assert_eq!(
+            result,
+            if succeed {
+                Ok(7)
+            } else {
+                Err("assessment error")
+            }
+        );
+        assert_pair_released(&sink);
+    }
+}
+
+#[test]
+fn stream_release_trace_follows_both_destructors_during_unwind() {
+    let sink = RecordingSink::default();
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        with_owned_pair(
+            (DropStream(&sink, "rgb"), DropStream(&sink, "ir")),
+            &sink,
+            |_, _| panic!("synthetic assessment panic"),
+        );
+    }));
+    assert!(result.is_err());
+    assert_pair_released(&sink);
+}
+
+fn synthetic_identity(landmarks: Landmarks5) -> IdentityImage {
+    IdentityImage {
+        data: (0..112 * 112 * 3).map(|i| (i % 251) as u8).collect(),
+        width: 112,
+        height: 112,
+        face: Detection {
+            bbox: [0.0, 0.0, 111.0, 111.0],
+            score: 1.0,
+            landmarks,
+        },
+    }
+}
+
+#[test]
+fn identity_timing_covers_eager_materialization_and_alignment_failure() {
+    let _guard = env_guard();
+    let mut state = shared();
+    for succeeds in [true, false] {
+        let (_, mut assessment) = pad_matching_fixture(0.2, false);
+        assessment.embedding = None;
+        let landmarks = if succeeds {
+            align::ARCFACE_REF_112
+        } else {
+            [(0.0, 0.0); 5]
+        };
+        let sink = RecordingSink::default();
+        let result = state.engine.materialize_pair_identity(
+            DeferredAssessment {
+                assessment,
+                identity: (
+                    Some(synthetic_identity(landmarks)),
+                    Some(synthetic_identity(landmarks)),
+                ),
+            },
+            &sink,
+        );
+        if succeeds {
+            let assessment = result.unwrap();
+            assert!(assessment.embedding.is_some());
+            assert!(assessment.ir_embedding.is_some());
+            assert_eq!(assessment.rgb_pad, PadEvidence::Score(0.2));
+        } else {
+            assert!(matches!(result, Err(irlume_common::Error::Protocol(_))));
+        }
+        let traces = sink.traces();
+        assert!(matches!(
+            traces.as_slice(),
+            [TraceEventKind::StageTiming {
+                stage: TraceStage::IdentityInference,
+                ..
+            }]
+        ));
+        let json = serde_json::to_value(&traces[0]).unwrap();
+        assert_eq!(json.as_object().unwrap().len(), 3);
+        assert!(json["elapsed_us"].is_u64());
+    }
+}
+
+#[test]
+fn identity_timing_preserves_empty_input_and_deadline_refusal() {
+    let _guard = env_guard();
+    let mut state = shared();
+    for expired in [false, true] {
+        let (_, mut assessment) = pad_matching_fixture(0.2, false);
+        assessment.embedding = None;
+        let sink = RecordingSink::default();
+        let previous = state.engine.authentication_deadline;
+        if expired {
+            state.engine.authentication_deadline = Some(std::time::Instant::now());
+        }
+        let result = state.engine.materialize_pair_identity(
+            DeferredAssessment {
+                assessment,
+                identity: (None, None),
+            },
+            &sink,
+        );
+        state.engine.authentication_deadline = previous;
+        if expired {
+            assert!(matches!(result, Err(irlume_common::Error::DeadlineExpired)));
+        } else {
+            let assessment = result.unwrap();
+            assert!(assessment.embedding.is_none() && assessment.ir_embedding.is_none());
+        }
+        assert!(matches!(
+            sink.traces().as_slice(),
+            [TraceEventKind::StageTiming {
+                stage: TraceStage::IdentityInference,
+                ..
+            }]
+        ));
+    }
+}
+
+pub(super) fn visible_pair_sample(
+    engine: &mut Engine,
+    sample: u8,
+    score: f32,
+    sequential: bool,
+) -> DeferredAssessment<PairIdentity> {
+    let deny = engine.vit_pad_votes_deny(score);
+    let (_, mut assessment) = pad_matching_fixture(score, deny);
+    assessment.embedding = None;
+    assessment.signals = Signals {
+        rgb_face: Some(irlume_liveness::FaceBox {
+            cx: 0.5,
+            cy: 0.5,
+            score: 0.9,
+        }),
+        ir_face: Some(irlume_liveness::FaceBox {
+            cx: 0.5,
+            cy: 0.5,
+            score: 0.9,
+        }),
+        face_frac: 0.3,
+        ir_face_brightness: 90.0,
+        ir_center_edge_ratio: 1.2,
+        ir_eye_glint: Some(220.0),
+        ir_ceiling_known: true,
+        ir_saturated_frac: Some(0.0),
+        rgb_face_brightness: 120.0,
+        ..Signals::default()
+    };
+    assessment.ir_pad = PadEvidence::Score(0.1);
+    assessment.sequential_pair = sequential;
+    let image = || {
+        let mut image = synthetic_identity(align::ARCFACE_REF_112);
+        image.data[0] = sample;
+        image.data[1] = 0; // synthetic matching identity; separate from sample provenance
+        image
+    };
+    DeferredAssessment {
+        assessment,
+        identity: (Some(image()), Some(image())),
+    }
+}
+
+pub(super) fn materialize_synthetic_pair(evidence: DeferredAssessment<PairIdentity>) -> Assessment {
+    let mut assessment = evidence.assessment;
+    let embedding = |image: IdentityImage| {
+        let mut embedding = [0.0; EMBED_DIM];
+        embedding[usize::from(image.data[1])] = 1.0;
+        embedding
+    };
+    assessment.embedding = evidence.identity.0.map(embedding);
+    assessment.ir_embedding = evidence.identity.1.map(|image| embedding(image).to_vec());
+    assessment
+}
+
+pub(super) fn paired_enrollment() -> Enrollment {
+    let (mut enrollment, _) = pad_matching_fixture(0.2, false);
+    let scan = &mut enrollment.profiles[0].scans[0];
+    scan.ir = Some(scan.rgb.clone());
+    scan.ir_space = Some("raw".into());
+    enrollment
+}
+
+#[test]
+fn ordinary_preparation_materializes_every_sample_before_pad_qualification() {
+    let _guard = env_guard();
+    let mut state = shared();
+    let engine = &mut state.engine;
+    let previous_ir = engine.ir_available;
+    engine.ir_available = true;
+    for sequential in [false, true] {
+        engine.vit_scores.clear();
+        let mut identities = Vec::new();
+        for sample in 0..5 {
+            let evidence = visible_pair_sample(engine, sample, 0.2, sequential);
+            let prepared = engine
+                .prepare_ordinary_pair_authentication_with(evidence, |_, evidence| {
+                    assert_eq!(evidence.assessment.rgb_pad, PadEvidence::Score(0.2));
+                    identities.push(evidence.identity.0.as_ref().unwrap().data[0]);
+                    Ok(materialize_synthetic_pair(evidence))
+                })
+                .unwrap();
+            assert_eq!(
+                identities.len(),
+                usize::from(sample) + 1,
+                "ordinary authentication must materialize even incomplete PAD"
+            );
+            let outcome = engine
+                .finish_pair_authentication(
+                    &paired_enrollment(),
+                    AuthenticationPurpose::Verify,
+                    Some("login"),
+                    Ok(prepared),
+                    None,
+                    &(),
+                )
+                .unwrap();
+            assert_eq!(outcome.granted, sample == 4);
+            assert_eq!(engine.vit_scores.len(), usize::from(sample) + 1);
+            if sample < 4 {
+                assert_eq!(outcome.kind, OutcomeKind::RgbPadPending);
+            }
+        }
+        assert_eq!(identities, [0, 1, 2, 3, 4]);
+    }
+    engine.ir_available = previous_ir;
+    engine.vit_scores.clear();
+}
+
+#[test]
+fn ordinary_preparation_preserves_identity_failure_before_pad_refusal() {
+    let _guard = env_guard();
+    let mut state = shared();
+    for ir_pad in [PadEvidence::Score(0.1), PadEvidence::InferenceFailed] {
+        state.engine.vit_scores.clear();
+        let mut evidence = visible_pair_sample(&mut state.engine, 0, 0.2, false);
+        evidence.assessment.ir_pad = ir_pad;
+        let prepared = state
+            .engine
+            .prepare_ordinary_pair_authentication_with(evidence, |_, _| {
+                Err(irlume_common::Error::Hardware(
+                    "identity inference failed".into(),
+                ))
+            })
+            .map_err(CapturePathError::from);
+        let mut fallback = false;
+        let result = state.engine.finish_pair_authentication(
+            &paired_enrollment(),
+            AuthenticationPurpose::Verify,
+            Some("login"),
+            prepared,
+            Some(&mut fallback),
+            &(),
+        );
+        assert!(matches!(
+            result,
+            Err(irlume_common::Error::Hardware(ref message))
+                if message == "identity inference failed"
+        ));
+        assert!(!fallback, "identity failure must not demote capture");
+        assert!(state.engine.vit_scores.is_empty());
+    }
+}
+
+#[test]
+fn managed_preparation_keeps_pending_votes_and_materializes_only_the_final_sample() {
+    let _guard = env_guard();
+    let mut state = shared();
+    let engine = &mut state.engine;
+    let previous_ir = engine.ir_available;
+    engine.ir_available = true;
+    for sequential in [false, true] {
+        for purpose in [
+            AuthenticationPurpose::Verify,
+            AuthenticationPurpose::CredentialRelease,
+        ] {
+            engine.vit_scores.clear();
+            let mut materialized = Vec::new();
+            let mut admitted = 0;
+            for (index, score) in [0.2, 0.2, 0.99, 0.2, 0.2].into_iter().enumerate() {
+                let sample = visible_pair_sample(engine, index as u8, score, sequential);
+                let prepared = engine
+                    .prepare_pair_authentication_with(sample, |_, evidence| {
+                        materialized.push(evidence.identity.0.as_ref().unwrap().data[0]);
+                        assert_eq!(evidence.identity.1.as_ref().unwrap().data[0], index as u8);
+                        Ok(materialize_synthetic_pair(evidence))
+                    })
+                    .unwrap();
+                if matches!(prepared, PreparedPairAuthentication::Ready(_)) {
+                    admitted += 1;
+                }
+                let out = engine
+                    .finish_pair_authentication(
+                        &paired_enrollment(),
+                        purpose,
+                        Some("login"),
+                        Ok(prepared),
+                        None,
+                        &(),
+                    )
+                    .unwrap();
+                assert_eq!(out.granted, index == 4, "sample {index}: {out:?}");
+                assert_eq!(
+                    engine.vit_scores.len(),
+                    index + 1,
+                    "qualification must happen once"
+                );
+                if index < 4 {
+                    assert_eq!(out.kind, OutcomeKind::RgbPadPending);
+                    assert!(!out.live && out.score == 0.0);
+                    assert!(materialized.is_empty());
+                    assert_eq!(engine.last_attempt_facts.rgb_face, Some((0.5, 0.5)));
+                }
+            }
+            assert_eq!(materialized, [4]);
+            assert_eq!(admitted, 1);
+        }
+    }
+    engine.ir_available = previous_ir;
+    engine.vit_scores.clear();
+}
+
+#[test]
+fn managed_preparation_required_pad_refusals_do_not_materialize_identity() {
+    let _guard = env_guard();
+    let mut state = shared();
+    let engine = &mut state.engine;
+    for (rgb, ir, expected) in [
+        (
+            PadEvidence::Score(0.2),
+            PadEvidence::Unavailable,
+            OutcomeKind::RuntimeUnavailable,
+        ),
+        (
+            PadEvidence::Score(0.2),
+            PadEvidence::InferenceFailed,
+            OutcomeKind::RuntimeUnavailable,
+        ),
+        (
+            PadEvidence::Score(0.2),
+            PadEvidence::NotApplicable,
+            OutcomeKind::RuntimeUnavailable,
+        ),
+        (
+            PadEvidence::Score(0.2),
+            PadEvidence::Pending,
+            OutcomeKind::Uncertain,
+        ),
+        (
+            PadEvidence::Unavailable,
+            PadEvidence::Score(0.1),
+            OutcomeKind::RuntimeUnavailable,
+        ),
+        (
+            PadEvidence::InferenceFailed,
+            PadEvidence::Score(0.1),
+            OutcomeKind::RuntimeUnavailable,
+        ),
+        (
+            PadEvidence::NotApplicable,
+            PadEvidence::Score(0.1),
+            OutcomeKind::RuntimeUnavailable,
+        ),
+        (
+            PadEvidence::Score(f32::NAN),
+            PadEvidence::Score(0.1),
+            OutcomeKind::RuntimeUnavailable,
+        ),
+    ] {
+        engine.vit_scores.clear();
+        let mut sample = visible_pair_sample(engine, 0, 0.2, false);
+        sample.assessment.rgb_pad = rgb;
+        sample.assessment.ir_pad = ir;
+        let prepared = engine
+            .prepare_pair_authentication_with(sample, |_, _| {
+                panic!("refused PAD must not attempt identity, even if its inputs would fail")
+            })
+            .unwrap();
+        let PreparedPairAuthentication::Refused(out) = prepared else {
+            panic!("PAD admitted");
+        };
+        assert_eq!(out.kind, expected);
+        assert!(!out.granted && !out.live && out.score == 0.0);
+    }
+    engine.vit_scores.clear();
+}
+
+#[test]
+fn managed_preparation_interruption_resets_votes_but_pending_does_not() {
+    let _guard = env_guard();
+    let mut state = shared();
+    let engine = &mut state.engine;
+    for interruption in [
+        "no-face",
+        "uncertain",
+        "spoof",
+        "missing-pad",
+        "invalid-pad",
+    ] {
+        engine.vit_scores.clear();
+        for i in 0..4 {
+            let sample = visible_pair_sample(engine, i, 0.2, false);
+            assert!(matches!(
+                engine.prepare_pair_authentication_with(sample, |_, _| panic!("pending identity")),
+                Ok(PreparedPairAuthentication::Refused(_))
+            ));
+        }
+        assert_eq!(engine.vit_scores.len(), 4);
+        let mut interrupted = visible_pair_sample(engine, 4, 0.2, false);
+        match interruption {
+            "no-face" => {
+                interrupted.identity = (None, None);
+                interrupted.assessment.signals.rgb_face = None;
+                interrupted.assessment.signals.ir_face = None;
+                interrupted.assessment.verdict = Verdict::Uncertain;
+                interrupted.assessment.rgb_pad = PadEvidence::NotApplicable;
+            }
+            "uncertain" => interrupted.assessment.verdict = Verdict::Uncertain,
+            "spoof" => interrupted.assessment.verdict = Verdict::Spoof,
+            "missing-pad" => interrupted.assessment.rgb_pad = PadEvidence::NotApplicable,
+            "invalid-pad" => interrupted.assessment.rgb_pad = PadEvidence::Score(f32::NAN),
+            _ => unreachable!(),
+        }
+        engine
+            .prepare_pair_authentication_with(interrupted, |_, evidence| {
+                Ok(materialize_synthetic_pair(evidence))
+            })
+            .unwrap();
+        assert!(engine.vit_scores.is_empty(), "interruption {interruption}");
+        let sample = visible_pair_sample(engine, 5, 0.2, false);
+        assert!(matches!(
+            engine.prepare_pair_authentication_with(sample, |_, _| panic!(
+                "new presentation identity"
+            )),
+            Ok(PreparedPairAuthentication::Refused(Outcome {
+                kind: OutcomeKind::RgbPadPending,
+                ..
+            }))
+        ));
+        assert_eq!(engine.vit_scores.len(), 1);
+    }
+    engine.vit_scores.clear();
+}
+
+#[test]
+fn managed_preparation_non_live_precedence_matches_eager_admission() {
+    let _guard = env_guard();
+    let mut state = shared();
+    let engine = &mut state.engine;
+    let previous_ir = engine.ir_available;
+    engine.ir_available = true;
+    for (verdict, reason) in [
+        (Verdict::Uncertain, "framing fixture"),
+        (Verdict::Uncertain, "IR exposure unmeasurable fixture"),
+        (Verdict::Spoof, "no face in IR fixture"),
+        (Verdict::Spoof, "spoof fixture"),
+    ] {
+        for (rgb, ir) in [(true, true), (true, false), (false, true), (false, false)] {
+            let make = |engine: &mut Engine| {
+                engine.vit_scores.clear();
+                let mut sample = visible_pair_sample(engine, 0, 0.2, false);
+                sample.assessment.verdict = verdict;
+                sample.assessment.reason = reason.into();
+                sample.assessment.ir_pad = PadEvidence::InferenceFailed;
+                if !rgb {
+                    sample.identity.0 = None;
+                    sample.assessment.signals.rgb_face = None;
+                }
+                if !ir {
+                    sample.identity.1 = None;
+                    sample.assessment.signals.ir_face = None;
+                }
+                sample
+            };
+            let sample = make(engine);
+            let mut calls = 0;
+            let prepared = engine
+                .prepare_pair_authentication_with(sample, |engine, evidence| {
+                    calls += 1;
+                    assert_eq!(
+                        engine.vit_scores.len(),
+                        1,
+                        "non-Live still materializes before qualification"
+                    );
+                    Ok(materialize_synthetic_pair(evidence))
+                })
+                .unwrap();
+            let actual = engine
+                .finish_pair_authentication(
+                    &paired_enrollment(),
+                    AuthenticationPurpose::Verify,
+                    None,
+                    Ok(prepared),
+                    None,
+                    &(),
+                )
+                .unwrap();
+            let eager = materialize_synthetic_pair(make(engine));
+            let expected = engine
+                .authenticate_assessment(
+                    &paired_enrollment(),
+                    AuthenticationPurpose::Verify,
+                    None,
+                    eager,
+                    &(),
+                )
+                .unwrap();
+            assert_eq!(calls, 1);
+            assert_eq!(
+                (
+                    actual.kind,
+                    actual.granted,
+                    actual.live,
+                    actual.score,
+                    actual.reason
+                ),
+                (
+                    expected.kind,
+                    expected.granted,
+                    expected.live,
+                    expected.score,
+                    expected.reason
+                )
+            );
+        }
+    }
+    engine.ir_available = previous_ir;
+    engine.vit_scores.clear();
+}
+
+#[test]
+fn managed_preparation_dark_routes_keep_eager_identity_and_existing_gate_order() {
+    let _guard = env_guard();
+    let mut state = shared();
+    let engine = &mut state.engine;
+    let previous_ir = engine.ir_available;
+    engine.ir_available = true;
+    for (lit, ir_failure, ir_matches, tagged) in [
+        (false, false, true, true),
+        (true, false, true, true),
+        (false, true, true, true),
+        (false, false, false, true),
+        (false, false, true, false),
+        (false, true, true, false),
+    ] {
+        engine.vit_scores.clear();
+        let mut sample = visible_pair_sample(engine, 0, 0.2, true);
+        sample.identity.0 = None;
+        sample.assessment.signals.rgb_face = None;
+        sample.assessment.verdict = Verdict::Uncertain;
+        sample.assessment.rgb_pad = PadEvidence::NotApplicable;
+        sample.assessment.rgb_frame_mean = if lit {
+            irlume_camera::CONCLUSIVE_SCENE_BRIGHTNESS
+        } else {
+            10.0
+        };
+        if ir_failure {
+            sample.assessment.ir_pad = PadEvidence::InferenceFailed;
+        }
+        if !ir_matches {
+            sample.identity.1.as_mut().unwrap().data[1] = 1;
+        }
+        let mut calls = 0;
+        let prepared = engine
+            .prepare_pair_authentication_with(sample, |_, evidence| {
+                calls += 1;
+                Ok(materialize_synthetic_pair(evidence))
+            })
+            .unwrap();
+        let mut enrollment = paired_enrollment();
+        if !tagged {
+            enrollment.profiles[0].scans[0].ir_space = None;
+        }
+        let out = engine
+            .finish_pair_authentication(
+                &enrollment,
+                AuthenticationPurpose::Verify,
+                None,
+                Ok(prepared),
+                None,
+                &(),
+            )
+            .unwrap();
+        assert_eq!(calls, 1, "dark identity must remain eager");
+        assert_eq!(
+            out.granted,
+            !lit && !ir_failure && ir_matches && tagged,
+            "{out:?}"
+        );
+        if !tagged {
+            assert_eq!(
+                out.kind,
+                OutcomeKind::OtherDeny,
+                "template compatibility precedes dark PAD"
+            );
+        }
+        if lit {
+            assert_eq!(out.kind, OutcomeKind::Uncertain);
+        }
+    }
+    engine.ir_available = previous_ir;
+    engine.vit_scores.clear();
+}
+
+#[test]
+fn managed_preparation_ready_preserves_sequential_identity_restriction() {
+    let _guard = env_guard();
+    let mut state = shared();
+    let engine = &mut state.engine;
+    let previous_ir = engine.ir_available;
+    engine.ir_available = true;
+    for sequential in [false, true] {
+        engine.vit_scores = vec![0.2; 4];
+        let mut sample = visible_pair_sample(engine, 4, 0.2, sequential);
+        sample.identity.1.as_mut().unwrap().data[1] = 1;
+        let prepared = engine
+            .prepare_pair_authentication_with(sample, |_, evidence| {
+                assert_eq!(evidence.assessment.sequential_pair, sequential);
+                Ok(materialize_synthetic_pair(evidence))
+            })
+            .unwrap();
+        let out = engine
+            .finish_pair_authentication(
+                &paired_enrollment(),
+                AuthenticationPurpose::Verify,
+                None,
+                Ok(prepared),
+                None,
+                &(),
+            )
+            .unwrap();
+        assert_eq!(out.granted, !sequential);
+        if sequential {
+            assert_eq!(out.kind, OutcomeKind::BelowThreshold);
+            assert!(!presence_retryable(&out));
+        }
+    }
+    engine.ir_available = previous_ir;
+    engine.vit_scores.clear();
+}
+
+#[test]
+fn managed_preparation_checks_cancellation_and_deadline_around_identity() {
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
+    let _guard = env_guard();
+    let mut state = shared();
+    let engine = &mut state.engine;
+    for cancel in [false, true] {
+        for before in [false, true] {
+            engine.vit_scores = vec![0.2; 4];
+            let sample = visible_pair_sample(engine, 4, 0.2, false);
+            let cancelled = Arc::new(AtomicBool::new(cancel && before));
+            let signal = cancelled.clone();
+            engine.set_request_cancel_signal(Arc::new(move || signal.load(Ordering::SeqCst)));
+            engine.authentication_deadline = (!cancel && before).then(std::time::Instant::now);
+            let mut calls = 0;
+            let prepared = engine
+                .prepare_pair_authentication_with(sample, |engine, evidence| {
+                    calls += 1;
+                    if cancel {
+                        cancelled.store(true, Ordering::SeqCst);
+                    } else {
+                        engine.authentication_deadline = Some(std::time::Instant::now());
+                    }
+                    Ok(materialize_synthetic_pair(evidence))
+                })
+                .map_err(CapturePathError::from);
+            let mut fallback = false;
+            let out = engine.finish_pair_authentication(
+                &paired_enrollment(),
+                AuthenticationPurpose::Verify,
+                None,
+                prepared,
+                Some(&mut fallback),
+                &(),
+            );
+            engine.request_cancelled = None;
+            engine.authentication_deadline = None;
+            assert_eq!(calls, usize::from(!before));
+            assert!(!fallback);
+            assert!(engine.vit_scores.is_empty());
+            assert!(if cancel {
+                matches!(out, Err(irlume_common::Error::Preempted(_)))
+            } else {
+                matches!(out, Err(irlume_common::Error::DeadlineExpired))
+            });
+        }
+    }
+}
+
+#[test]
+fn managed_preparation_required_identity_errors_clear_votes_without_capture_fallback() {
+    let _guard = env_guard();
+    let mut state = shared();
+    let engine = &mut state.engine;
+    engine.vit_scores = vec![0.2; 4];
+    let sample = visible_pair_sample(engine, 4, 0.2, false);
+    let mut materialized = 0;
+    let prepared = engine
+        .prepare_pair_authentication_with(sample, |_, _| {
+            materialized += 1;
+            Err(irlume_common::Error::Protocol(
+                "synthetic identity failure".into(),
+            ))
+        })
+        .map_err(CapturePathError::from);
+    let mut fallback = false;
+    let result = engine.finish_pair_authentication(
+        &paired_enrollment(),
+        AuthenticationPurpose::Verify,
+        None,
+        prepared,
+        Some(&mut fallback),
+        &(),
+    );
+    assert_eq!(materialized, 1);
+    assert!(matches!(result, Err(irlume_common::Error::Protocol(_))));
+    assert!(!fallback && engine.vit_scores.is_empty());
+    engine.vit_scores = vec![0.2; 4];
+    let result = engine.finish_pair_authentication(
+        &paired_enrollment(),
+        AuthenticationPurpose::Verify,
+        None,
+        Err(CapturePathError::ConcurrentPair(
+            irlume_common::Error::Hardware("synthetic capture failure".into()),
+        )),
+        Some(&mut fallback),
+        &(),
+    );
+    assert!(matches!(result, Err(irlume_common::Error::Hardware(_))));
+    assert!(fallback && engine.vit_scores.is_empty());
+}
+
+#[test]
+fn managed_preparation_admission_and_refusal_follow_stream_owner_release() {
+    let _guard = env_guard();
+    let mut state = shared();
+    let engine = &mut state.engine;
+    let previous_ir = engine.ir_available;
+    engine.ir_available = true;
+    for ready in [false, true] {
+        engine.vit_scores = vec![0.2; if ready { 4 } else { 0 }];
+        let sample = visible_pair_sample(engine, 4, 0.2, false);
+        let sink = RecordingSink::default();
+        let prepared = with_owned_pair(
+            (DropStream(&sink, "rgb"), DropStream(&sink, "ir")),
+            &sink,
+            |_, _| {
+                engine
+                    .prepare_pair_authentication_with(sample, |_, evidence| {
+                        assert!(ready);
+                        assert!(
+                            sink.0.lock().unwrap().is_empty(),
+                            "materialization still owns streams"
+                        );
+                        Ok(materialize_synthetic_pair(evidence))
+                    })
+                    .map_err(CapturePathError::from)
+            },
+        );
+        assert_pair_released(&sink);
+        let outcome = engine
+            .finish_pair_authentication(
+                &paired_enrollment(),
+                AuthenticationPurpose::Verify,
+                None,
+                prepared,
+                None,
+                &sink,
+            )
+            .unwrap();
+        assert_eq!(outcome.granted, ready);
+        let records = sink.0.lock().unwrap();
+        assert!(
+            matches!(records[3], Recorded::Trace(TraceEventKind::Decision { .. })) && ready
+                || matches!(
+                    records[3],
+                    Recorded::Trace(TraceEventKind::AuthenticationRefusal {
+                        reason: TraceRefusalReason::RgbPadPending
+                    })
+                ) && !ready
+        );
+    }
+    engine.ir_available = previous_ir;
+    engine.vit_scores.clear();
+}
+
+#[test]
+fn managed_preparation_retry_loop_reaches_identity_once_and_stops_after_a_match_decision() {
+    use std::{
+        cell::Cell,
+        time::{Duration, Instant},
+    };
+    let _guard = env_guard();
+    let mut state = shared();
+    let engine = &mut state.engine;
+    let previous_ir = engine.ir_available;
+    engine.ir_available = true;
+    for (score, matches, expected) in [
+        (0.2, true, OutcomeKind::Granted),
+        (0.2, false, OutcomeKind::BelowThreshold),
+        (0.99, true, OutcomeKind::Spoof),
+    ] {
+        engine.vit_scores.clear();
+        let started = Instant::now();
+        let clock = Cell::new(started);
+        let attempts = Cell::new(0);
+        let identities = Cell::new(0);
+        let mut costliest = Duration::ZERO;
+        let (result, fallback) = engine.authentication_attempt_loop_with(
+            started + Duration::from_secs(15),
+            15_000,
+            &mut costliest,
+            |engine| {
+                let sample_id = attempts.get();
+                assert!(sample_id < 5, "completed admission must not retry");
+                attempts.set(sample_id + 1);
+                let mut sample = visible_pair_sample(engine, sample_id, score, false);
+                if !matches {
+                    sample.identity.0.as_mut().unwrap().data[1] = 1;
+                    sample.identity.1.as_mut().unwrap().data[1] = 1;
+                }
+                let prepared = engine
+                    .prepare_pair_authentication_with(sample, |_, evidence| {
+                        identities.set(identities.get() + 1);
+                        Ok(materialize_synthetic_pair(evidence))
+                    })
+                    .map_err(CapturePathError::from);
+                let out = engine.finish_pair_authentication(
+                    &paired_enrollment(),
+                    AuthenticationPurpose::Verify,
+                    Some("login"),
+                    prepared,
+                    None,
+                    &(),
+                );
+                clock.set(clock.get() + Duration::from_millis(1000));
+                (out, false)
+            },
+            || clock.get(),
+        );
+        assert!(!fallback);
+        assert_eq!(result.unwrap().kind, expected);
+        assert_eq!(attempts.get(), 5);
+        // The terminal Spoof remains deliberately eager outside the Live-only optimization.
+        assert_eq!(identities.get(), 1);
+        assert_eq!(costliest, Duration::from_millis(1000));
+    }
+    engine.ir_available = previous_ir;
+    engine.vit_scores.clear();
+}

--- a/crates/irlume-auth/src/grouped_auth.rs
+++ b/crates/irlume-auth/src/grouped_auth.rs
@@ -284,7 +284,7 @@ impl Engine {
                     )
                     .map_err(CapturePathError::into_inner)
             },
-            |engine, evidence| engine.materialize_pair_identity(evidence),
+            |engine, evidence| engine.materialize_pair_identity(evidence, diagnostics),
             Instant::now,
         )?;
         match prepared {

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -195,6 +195,7 @@ pub struct Assessment {
 mod authentication_window;
 pub use authentication_window::AuthenticationWindow;
 mod grouped_auth;
+mod managed_pad;
 
 struct DeferredAssessment<I> {
     assessment: Assessment,
@@ -209,6 +210,13 @@ struct IdentityImage {
 }
 
 type PairIdentity = (Option<IdentityImage>, Option<IdentityImage>);
+
+enum PreparedPairAuthentication {
+    // Already qualified once; final admission must not reset a pending vote by
+    // entering the qualifying eager wrapper again.
+    Ready(Box<Assessment>),
+    Refused(Outcome),
+}
 
 struct PairAssessmentContext<'a> {
     sequential: bool,
@@ -245,6 +253,9 @@ pub enum OutcomeKind {
     NoFace,
     /// Liveness gate returned Uncertain (framing/quality, not an attack).
     Uncertain,
+    /// The live RGB presentation needs more samples for its required PAD vote.
+    /// Retains the retry and account-history semantics of liveness Uncertain.
+    RgbPadPending,
     /// Spoof verdict raised only because RGB saw a face and IR did not. Both a
     /// screen attack and a genuine user mid-settle produce it, so it is the
     /// one Spoof class the grace window may retry (see [`presence_retryable`]).
@@ -1063,7 +1074,10 @@ fn legacy_eye_policy(enrollment: &irlume_core::storage::Enrollment) -> Result<()
 pub fn presence_retryable(o: &Outcome) -> bool {
     matches!(
         o.kind,
-        OutcomeKind::NoFace | OutcomeKind::Uncertain | OutcomeKind::SpoofNoIrFace
+        OutcomeKind::NoFace
+            | OutcomeKind::Uncertain
+            | OutcomeKind::RgbPadPending
+            | OutcomeKind::SpoofNoIrFace
     )
 }
 
@@ -1107,6 +1121,61 @@ fn emit_trace_stage_ms(
             .unwrap_or(u64::MAX)
             .saturating_mul(1_000),
     });
+}
+
+/// Measure work through early returns and unwinding without recording its data
+/// or error text. The scope chooses the exact work included in this interval.
+struct TraceStageTimer<'a> {
+    diagnostics: &'a dyn irlume_common::diagnostics::DiagnosticSink,
+    stage: irlume_common::diagnostics::TraceStage,
+    started: std::time::Instant,
+}
+
+impl<'a> TraceStageTimer<'a> {
+    fn new(
+        diagnostics: &'a dyn irlume_common::diagnostics::DiagnosticSink,
+        stage: irlume_common::diagnostics::TraceStage,
+    ) -> Self {
+        Self {
+            diagnostics,
+            stage,
+            started: std::time::Instant::now(),
+        }
+    }
+}
+
+impl Drop for TraceStageTimer<'_> {
+    fn drop(&mut self) {
+        self.diagnostics
+            .emit_trace(irlume_common::diagnostics::TraceEventKind::StageTiming {
+                stage: self.stage,
+                elapsed_us: u64::try_from(self.started.elapsed().as_micros()).unwrap_or(u64::MAX),
+            });
+    }
+}
+
+fn emit_authentication_refusal(
+    diagnostics: &dyn irlume_common::diagnostics::DiagnosticSink,
+    outcome: &Outcome,
+) {
+    use irlume_common::diagnostics::{TraceEventKind, TraceRefusalReason};
+    if outcome.granted {
+        return;
+    }
+    let reason = match outcome.kind {
+        OutcomeKind::Granted => return,
+        OutcomeKind::RgbPadPending => TraceRefusalReason::RgbPadPending,
+        OutcomeKind::NoFace => TraceRefusalReason::NoFace,
+        OutcomeKind::Uncertain => TraceRefusalReason::Uncertain,
+        OutcomeKind::SpoofNoIrFace => TraceRefusalReason::SpoofNoIrFace,
+        OutcomeKind::Spoof => TraceRefusalReason::Spoof,
+        OutcomeKind::BelowThreshold => TraceRefusalReason::BelowThreshold,
+        OutcomeKind::SetupUnavailable => TraceRefusalReason::SetupUnavailable,
+        OutcomeKind::DeadlineExpired => TraceRefusalReason::DeadlineExpired,
+        OutcomeKind::RuntimeUnavailable => TraceRefusalReason::RuntimeUnavailable,
+        OutcomeKind::OtherDeny => TraceRefusalReason::OtherDeny,
+    };
+    diagnostics.emit_trace(TraceEventKind::AuthenticationRefusal { reason });
 }
 
 fn emit_trace_match(
@@ -1379,6 +1448,10 @@ enum PadRequirements {
 }
 
 fn pad_evidence_refusal(modality: PadModality, evidence: PadEvidence) -> Option<Outcome> {
+    let pending_kind = match modality {
+        PadModality::Rgb => OutcomeKind::RgbPadPending,
+        PadModality::Ir => OutcomeKind::Uncertain,
+    };
     let modality = match modality {
         PadModality::Rgb => "RGB",
         PadModality::Ir => "IR",
@@ -1386,7 +1459,7 @@ fn pad_evidence_refusal(modality: PadModality, evidence: PadEvidence) -> Option<
     let reason = match evidence {
         PadEvidence::Pending => {
             return Some(Outcome::deny(
-                OutcomeKind::Uncertain,
+                pending_kind,
                 format!("collecting {modality} PAD evidence"),
             ));
         }
@@ -3073,7 +3146,36 @@ mod capture_mode_switch_tests {
 
 /// Own streaming queues only for one assessment. The result cannot borrow
 /// either session, so both drop before matching, consent or another attempt.
-fn with_owned_pair<R, I, T>(mut pair: (R, I), assess: impl FnOnce(&mut R, &mut I) -> T) -> T {
+fn with_owned_pair<R, I, T>(
+    pair: (R, I),
+    diagnostics: &dyn irlume_common::diagnostics::DiagnosticSink,
+    assess: impl FnOnce(&mut R, &mut I) -> T,
+) -> T {
+    struct Owners<'a, R, I> {
+        pair: Option<(R, I)>,
+        diagnostics: &'a dyn irlume_common::diagnostics::DiagnosticSink,
+    }
+
+    impl<R, I> Drop for Owners<'_, R, I> {
+        fn drop(&mut self) {
+            // This interval covers only the two attempt streaming owners. The
+            // camera objects and request lease are owned by the caller.
+            let _timing = TraceStageTimer::new(
+                self.diagnostics,
+                irlume_common::diagnostics::TraceStage::StreamOwnerRelease,
+            );
+            drop(self.pair.take());
+        }
+    }
+
+    let mut owners = Owners {
+        pair: Some(pair),
+        diagnostics,
+    };
+    let pair = owners
+        .pair
+        .as_mut()
+        .expect("owners hold the assessment pair");
     assess(&mut pair.0, &mut pair.1)
 }
 
@@ -4065,6 +4167,29 @@ impl Engine {
         operation: &irlume_camera::lease::CameraOperationSession,
         diagnostics: &dyn irlume_common::diagnostics::DiagnosticSink,
     ) -> Result<Assessment, CapturePathError> {
+        self.assess_with_fresh_pair_finish(
+            rgb,
+            ir,
+            mode,
+            operation,
+            diagnostics,
+            |engine, evidence| {
+                engine
+                    .materialize_pair_identity(evidence, diagnostics)
+                    .map_err(CapturePathError::from)
+            },
+        )
+    }
+
+    fn assess_with_fresh_pair_finish<T>(
+        &mut self,
+        rgb: &irlume_camera::RgbCamera,
+        ir: &irlume_camera::IrCamera,
+        mode: Option<&CaptureModeSelection>,
+        operation: &irlume_camera::lease::CameraOperationSession,
+        diagnostics: &dyn irlume_common::diagnostics::DiagnosticSink,
+        finish: impl FnOnce(&mut Self, DeferredAssessment<PairIdentity>) -> Result<T, CapturePathError>,
+    ) -> Result<T, CapturePathError> {
         let setup_error = |reason, error| concurrent_setup_error(mode, diagnostics, reason, error);
         let control = self.capture_control();
         let started = std::time::Instant::now();
@@ -4077,7 +4202,7 @@ impl Engine {
             elapsed_us: u64::try_from(started.elapsed().as_micros()).unwrap_or(u64::MAX),
         });
         let pair = pair.map_err(|error| setup_error(RuntimeDegradation::PairArmFailure, error))?;
-        with_owned_pair(pair, |rgb, ir| {
+        with_owned_pair(pair, diagnostics, |rgb, ir| {
             let started = std::time::Instant::now();
             let rate = irlume_camera::establish_pair_rate(rgb, ir);
             diagnostics.emit_trace(irlume_common::diagnostics::TraceEventKind::StageTiming {
@@ -4087,7 +4212,7 @@ impl Engine {
             rate.map_err(|error| {
                 setup_error(RuntimeDegradation::PairRateEstablishmentFailure, error)
             })?;
-            self.assess_full_with(Some((rgb, ir)), mode, operation, diagnostics)
+            self.assess_full_with_finish(Some((rgb, ir)), mode, operation, diagnostics, finish)
         })
     }
 
@@ -4119,6 +4244,30 @@ impl Engine {
         operation: &irlume_camera::lease::CameraOperationSession,
         diagnostics: &dyn irlume_common::diagnostics::DiagnosticSink,
     ) -> Result<Assessment, CapturePathError> {
+        self.assess_full_with_finish(
+            held,
+            capture_mode,
+            operation,
+            diagnostics,
+            |engine, evidence| {
+                engine
+                    .materialize_pair_identity(evidence, diagnostics)
+                    .map_err(CapturePathError::from)
+            },
+        )
+    }
+
+    fn assess_full_with_finish<T>(
+        &mut self,
+        held: Option<(
+            &mut irlume_camera::RgbSession<'_>,
+            &mut irlume_camera::IrSession<'_>,
+        )>,
+        capture_mode: Option<&CaptureModeSelection>,
+        operation: &irlume_camera::lease::CameraOperationSession,
+        diagnostics: &dyn irlume_common::diagnostics::DiagnosticSink,
+        finish: impl FnOnce(&mut Self, DeferredAssessment<PairIdentity>) -> Result<T, CapturePathError>,
+    ) -> Result<T, CapturePathError> {
         // Median-denoise the RGB frame so a single blurry/over-exposed frame
         // can't false-reject a genuine user (IR is already brightest-of-burst).
         //
@@ -4566,8 +4715,7 @@ impl Engine {
                 diagnostics,
             },
         )?;
-        self.materialize_pair_identity(evidence)
-            .map_err(CapturePathError::from)
+        finish(self, evidence)
     }
 
     fn detect_rgb_assessment(
@@ -5055,7 +5203,15 @@ impl Engine {
     fn materialize_pair_identity(
         &mut self,
         evidence: DeferredAssessment<PairIdentity>,
+        diagnostics: &dyn irlume_common::diagnostics::DiagnosticSink,
     ) -> irlume_common::Result<Assessment> {
+        // One materializer invocation, possibly with no identity inputs. RGB
+        // alignment/TTA and IR alignment/inference/adapter work share this
+        // interval; its event count is not a count of model invocations.
+        let _timing = TraceStageTimer::new(
+            diagnostics,
+            irlume_common::diagnostics::TraceStage::IdentityInference,
+        );
         let DeferredAssessment {
             mut assessment,
             identity: (rgb, ir),
@@ -5588,6 +5744,28 @@ impl Engine {
             |engine| {
                 let mut held_pair_failed = false;
                 let result = Self::run_camera_operation(camera_operation, || {
+                    if let Some(cameras) = cameras.filter(|_| {
+                        managed_pad::eligible(
+                            capture_mode,
+                            engine.ir_available,
+                            engine.has_vit_pad(),
+                            engine.has_pad_ir(),
+                            window,
+                            purpose,
+                            service,
+                        )
+                    }) {
+                        return engine.authenticate_managed_concurrent_once(
+                            enr,
+                            purpose,
+                            service,
+                            cameras,
+                            capture_mode,
+                            deadline,
+                            &mut held_pair_failed,
+                            diagnostics,
+                        );
+                    }
                     engine.authenticate_once(
                         enr,
                         purpose,
@@ -5714,18 +5892,113 @@ impl Engine {
             held_pair_failed,
             diagnostics,
         } = capture;
-        let assessment = if !self.ir_available {
-            self.assess_rgb_only_with_diagnostics(diagnostics)
-                .map_err(CapturePathError::from)
-        } else if let (Some((rgb, ir)), Some(operation)) = (cameras, operation) {
-            self.assess_with_fresh_pair(rgb, ir, mode, operation, diagnostics)
-        } else if let Some(operation) = operation {
-            self.assess_full_with(None, mode, operation, diagnostics)
-        } else {
-            self.assess().map_err(CapturePathError::from)
+        let operation = match (self.ir_available, operation) {
+            (true, Some(operation)) => operation,
+            _ => {
+                // RGB-only and the legacy operationless path remain eager.
+                let assessment = if !self.ir_available {
+                    self.assess_rgb_only_with_diagnostics(diagnostics)
+                } else {
+                    self.assess()
+                };
+                let a = match assessment {
+                    Ok(a) => a,
+                    Err(error) => {
+                        self.vit_scores.clear();
+                        return Err(error);
+                    }
+                };
+                self.last_attempt_facts = AttemptFacts::from_assessment(&a);
+                return self.authenticate_assessment(enr, purpose, service, a, diagnostics);
+            }
         };
-        let a = match assessment {
-            Ok(assessment) => assessment,
+        let finish = |engine: &mut Self, evidence| {
+            engine
+                .prepare_ordinary_pair_authentication_with(evidence, |engine, evidence| {
+                    engine.materialize_pair_identity(evidence, diagnostics)
+                })
+                .map_err(CapturePathError::from)
+        };
+        let prepared = if let Some((rgb, ir)) = cameras {
+            self.assess_with_fresh_pair_finish(rgb, ir, mode, operation, diagnostics, finish)
+        } else {
+            self.assess_full_with_finish(None, mode, operation, diagnostics, finish)
+        };
+        self.finish_pair_authentication(
+            enr,
+            purpose,
+            service,
+            prepared,
+            held_pair_failed,
+            diagnostics,
+        )
+    }
+
+    /// Ordinary capture stays eager, including Pending PAD and PAD failures.
+    /// Only the separately eligible managed collector defers identity work.
+    fn prepare_ordinary_pair_authentication_with(
+        &mut self,
+        evidence: DeferredAssessment<PairIdentity>,
+        materialize: impl FnOnce(
+            &mut Self,
+            DeferredAssessment<PairIdentity>,
+        ) -> irlume_common::Result<Assessment>,
+    ) -> irlume_common::Result<PreparedPairAuthentication> {
+        self.check_request_active()?;
+        let mut assessment = materialize(self, evidence)?;
+        self.check_request_active()?;
+        self.qualify_rgb_pad_evidence(&mut assessment);
+        Ok(PreparedPairAuthentication::Ready(Box::new(assessment)))
+    }
+
+    /// Managed collection defers visible-pair identity until required PAD admits
+    /// it, using ordinary admission policy. Actual eligible identity input
+    /// distinguishes visible from dark; unfinished embeddings say nothing about
+    /// face presence. Ordinary attempts use the eager preparation above.
+    fn prepare_pair_authentication_with(
+        &mut self,
+        mut evidence: DeferredAssessment<PairIdentity>,
+        materialize: impl FnOnce(
+            &mut Self,
+            DeferredAssessment<PairIdentity>,
+        ) -> irlume_common::Result<Assessment>,
+    ) -> irlume_common::Result<PreparedPairAuthentication> {
+        self.check_request_active()?;
+        let qualified_before_identity =
+            evidence.identity.0.is_some() && evidence.assessment.verdict == Verdict::Live;
+        if qualified_before_identity {
+            self.qualify_rgb_pad_evidence(&mut evidence.assessment);
+            if let Some(outcome) = pad_policy_refusal(
+                PadRequirements::RgbAndIr,
+                evidence.assessment.rgb_pad,
+                evidence.assessment.ir_pad,
+            ) {
+                self.last_attempt_facts = AttemptFacts::from_assessment(&evidence.assessment);
+                return Ok(PreparedPairAuthentication::Refused(outcome));
+            }
+        }
+        let mut assessment = materialize(self, evidence)?;
+        self.check_request_active()?;
+        // Dark and non-Live paths retain eager materialization and the existing
+        // outcome precedence. Pending Live evidence keeps its accumulated vote.
+        if !qualified_before_identity {
+            self.qualify_rgb_pad_evidence(&mut assessment);
+        }
+        Ok(PreparedPairAuthentication::Ready(Box::new(assessment)))
+    }
+
+    /// Complete the ordinary pair attempt after its streaming owners drop.
+    fn finish_pair_authentication(
+        &mut self,
+        enr: &irlume_core::storage::Enrollment,
+        purpose: AuthenticationPurpose,
+        service: Option<&str>,
+        prepared: Result<PreparedPairAuthentication, CapturePathError>,
+        held_pair_failed: Option<&mut bool>,
+        diagnostics: &dyn irlume_common::diagnostics::DiagnosticSink,
+    ) -> irlume_common::Result<Outcome> {
+        let prepared = match prepared {
+            Ok(prepared) => prepared,
             Err(CapturePathError::ConcurrentPair(error)) => {
                 self.vit_scores.clear();
                 if let Some(failed) = held_pair_failed {
@@ -5738,10 +6011,15 @@ impl Engine {
                 return Err(error.into_inner());
             }
         };
-        // Snapshot capture facts before any decision branch returns. This stays
-        // on the attempt path so failed-attempt diagnostics describe this take.
-        self.last_attempt_facts = AttemptFacts::from_assessment(&a);
-        self.authenticate_assessment(enr, purpose, service, a, diagnostics)
+        let outcome = match prepared {
+            PreparedPairAuthentication::Ready(a) => {
+                self.last_attempt_facts = AttemptFacts::from_assessment(&a);
+                self.authenticate_qualified_assessment(enr, purpose, service, *a, diagnostics)?
+            }
+            PreparedPairAuthentication::Refused(outcome) => outcome,
+        };
+        emit_authentication_refusal(diagnostics, &outcome);
+        Ok(outcome)
     }
 
     /// Decide using a captured assessment after its streaming owners have been
@@ -5755,7 +6033,10 @@ impl Engine {
         diagnostics: &dyn irlume_common::diagnostics::DiagnosticSink,
     ) -> irlume_common::Result<Outcome> {
         self.qualify_rgb_pad_evidence(&mut a);
-        self.authenticate_qualified_assessment(enr, purpose, service, a, diagnostics)
+        let outcome =
+            self.authenticate_qualified_assessment(enr, purpose, service, a, diagnostics)?;
+        emit_authentication_refusal(diagnostics, &outcome);
+        Ok(outcome)
     }
 
     fn authenticate_qualified_assessment(
@@ -6539,7 +6820,10 @@ impl Engine {
                 PadRequirements::RgbOnly
             };
             if let Some(refusal) = pad_policy_refusal(requirements, a.rgb_pad, a.ir_pad) {
-                if refusal.kind == OutcomeKind::Uncertain {
+                if matches!(
+                    refusal.kind,
+                    OutcomeKind::Uncertain | OutcomeKind::RgbPadPending
+                ) {
                     return Ok(None);
                 }
                 return Err(CapturePathError::Other(irlume_common::Error::Protocol(
@@ -10769,6 +11053,8 @@ mod pad_cue_tests {
 #[cfg(test)]
 mod engine_tests {
     mod grouped_tests;
+    mod managed_pad_tests;
+    mod pair_identity_tests;
     use super::tests::env_guard;
     use super::*;
     use irlume_core::storage::{CameraBinding, Enrollment, FaceProfile, FaceScan};
@@ -11352,6 +11638,7 @@ mod engine_tests {
             OutcomeKind::BelowThreshold,
             OutcomeKind::Spoof,
             OutcomeKind::Uncertain,
+            OutcomeKind::RgbPadPending,
             OutcomeKind::DeadlineExpired,
         ] {
             let start = std::time::Instant::now();
@@ -11413,7 +11700,7 @@ mod engine_tests {
         let (out, calls, cost) = scripted_pad_retry(&mut s.engine, 15_000, 100, &[7_800], 0.20, 0);
         assert_eq!(calls, 1);
         assert!(!out.granted);
-        assert_eq!(out.kind, OutcomeKind::Uncertain);
+        assert_eq!(out.kind, OutcomeKind::RgbPadPending);
         assert!(out.reason.contains("collecting RGB PAD evidence"));
         assert_eq!(out.score, 0.0);
         assert_eq!(cost, std::time::Duration::from_millis(7_800));
@@ -11439,7 +11726,7 @@ mod engine_tests {
             "an exactly fitting retry is admitted, a third is not"
         );
         assert!(!out.granted);
-        assert_eq!(out.kind, OutcomeKind::Uncertain);
+        assert_eq!(out.kind, OutcomeKind::RgbPadPending);
     }
 
     #[test]
@@ -11477,7 +11764,7 @@ mod engine_tests {
         let (out, calls, _) = scripted_pad_retry(&mut s.engine, 5_000, 0, &[1_100; 4], 0.20, 0);
         assert_eq!(calls, 4);
         assert!(!out.granted);
-        assert_eq!(out.kind, OutcomeKind::Uncertain);
+        assert_eq!(out.kind, OutcomeKind::RgbPadPending);
         let (out, calls, _) = scripted_pad_retry(&mut s.engine, 15_000, 0, &[1_000; 5], 0.99, 0);
         assert_eq!(calls, 5);
         assert!(!out.granted);
@@ -11710,7 +11997,7 @@ mod engine_tests {
             assert_eq!(
                 out.kind,
                 if sample < 5 {
-                    OutcomeKind::Uncertain
+                    OutcomeKind::RgbPadPending
                 } else {
                     OutcomeKind::Spoof
                 }
@@ -11780,7 +12067,7 @@ mod engine_tests {
                 .authenticate_assessment(&enr, AuthenticationPurpose::Verify, None, a, &())
                 .unwrap();
             assert!(!out.granted);
-            assert_eq!(out.kind, OutcomeKind::Uncertain);
+            assert_eq!(out.kind, OutcomeKind::RgbPadPending);
             assert_eq!(out.score, 0.0);
         }
         e.ir_available = prior_ir;
@@ -11817,7 +12104,7 @@ mod engine_tests {
             let out = e
                 .authenticate_assessment(&enr, AuthenticationPurpose::Verify, None, a, &())
                 .unwrap();
-            assert_eq!(out.kind, OutcomeKind::Uncertain);
+            assert_eq!(out.kind, OutcomeKind::RgbPadPending);
         }
         e.vit_scores.clear();
     }
@@ -13343,6 +13630,7 @@ mod engine_tests {
         for attempt in 0..3 {
             let output = with_owned_pair(
                 (AttemptStream::open(&active), AttemptStream::open(&active)),
+                &(),
                 |_, _| {
                     assert_eq!(active.get(), 2);
                     attempt
@@ -13362,6 +13650,7 @@ mod engine_tests {
         let active = std::cell::Cell::new(0);
         let result = with_owned_pair(
             (AttemptStream::open(&active), AttemptStream::open(&active)),
+            &(),
             |_, _| Err::<(), _>("assessment refused"),
         );
         assert_eq!(result, Err("assessment refused"));
@@ -13374,6 +13663,7 @@ mod engine_tests {
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             with_owned_pair(
                 (AttemptStream::open(&active), AttemptStream::open(&active)),
+                &(),
                 |_, _| panic!("assessment panicked"),
             );
         }));
@@ -13401,6 +13691,7 @@ mod engine_tests {
                 rgb_cam.session().expect("hold RGB"),
                 cam.session().expect("hold IR"),
             ),
+            &(),
             |_, _| {
                 assert!(
                     cam.session().is_err() && rgb_cam.session().is_err(),

--- a/crates/irlume-auth/src/managed_pad.rs
+++ b/crates/irlume-auth/src/managed_pad.rs
@@ -1,0 +1,455 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! One concurrent capture transaction for incomplete ordinary RGB PAD evidence.
+//! Processing stays inside active queue servicing; admission follows owner Drop.
+
+use super::*;
+use std::time::Instant;
+
+pub(super) fn eligible(
+    mode: &CaptureModeSelection,
+    has_ir: bool,
+    has_rgb_pad: bool,
+    has_ir_pad: bool,
+    window: u64,
+    purpose: AuthenticationPurpose,
+    service: Option<&str>,
+) -> bool {
+    mode.runtime_contract.is_some()
+        && eligible_configuration(
+            mode,
+            has_ir,
+            has_rgb_pad,
+            has_ir_pad,
+            window,
+            purpose,
+            service,
+        )
+}
+
+pub(super) fn eligible_configuration(
+    mode: &CaptureModeSelection,
+    has_ir: bool,
+    has_rgb_pad: bool,
+    has_ir_pad: bool,
+    window: u64,
+    purpose: AuthenticationPurpose,
+    service: Option<&str>,
+) -> bool {
+    let service_kind = service.and_then(irlume_common::pam_service::classify);
+    let local_session = matches!(
+        service_kind,
+        Some(
+            irlume_common::pam_service::ServiceKind::Greeter
+                | irlume_common::pam_service::ServiceKind::ScreenUnlock
+        )
+    );
+    let in_scope = match purpose {
+        AuthenticationPurpose::Verify => local_session || service_kind.is_none(),
+        AuthenticationPurpose::CredentialRelease => local_session,
+        AuthenticationPurpose::AppConsent => false,
+    };
+    let authority = mode.source == ENV_CAPTURE_MODE_SOURCE
+        || (mode.source == STORED_CAPTURE_MODE_SOURCE
+            && mode.qualification_state
+                == irlume_common::diagnostics::QualificationState::QualifiedConcurrent);
+    in_scope
+        && authority
+        && !mode.is_sequential()
+        && !mode.operation_demoted.get()
+        && has_ir
+        && has_rgb_pad
+        && has_ir_pad
+        && window >= GRACE_WINDOW_MS
+}
+
+/// Votes belong to this transaction, including callback side effects that a
+/// failed tail dequeue subsequently invalidates. Never retain them on unwind.
+struct CollectionState<'a> {
+    engine: &'a mut Engine,
+    retain_facts: bool,
+}
+
+impl<'a> CollectionState<'a> {
+    fn new(engine: &'a mut Engine) -> Self {
+        engine.vit_scores.clear();
+        engine.last_attempt_facts = AttemptFacts::default();
+        Self {
+            engine,
+            retain_facts: false,
+        }
+    }
+}
+
+impl Drop for CollectionState<'_> {
+    fn drop(&mut self) {
+        self.engine.vit_scores.clear();
+        if !self.retain_facts {
+            self.engine.last_attempt_facts = AttemptFacts::default();
+        }
+    }
+}
+
+/// Underlying tracked delivery validates intentional drain gaps. This adds
+/// distinctness of analyzed acquisition windows, not sequence adjacency.
+#[derive(Default)]
+pub(super) struct PairWindows(Option<(irlume_camera::CaptureWindow, irlume_camera::CaptureWindow)>);
+
+impl PairWindows {
+    pub(super) fn advance(
+        &mut self,
+        rgb: irlume_camera::CaptureWindow,
+        ir: irlume_camera::CaptureWindow,
+    ) -> bool {
+        let ordered = rgb.start <= rgb.end
+            && ir.start <= ir.end
+            && self.0.is_none_or(|(previous_rgb, previous_ir)| {
+                rgb.start > previous_rgb.end && ir.start > previous_ir.end
+            });
+        if ordered {
+            self.0 = Some((rgb, ir));
+        }
+        ordered
+    }
+}
+
+fn transport_error(
+    mode: &CaptureModeSelection,
+    diagnostics: &dyn irlume_common::diagnostics::DiagnosticSink,
+    reason: RuntimeDegradation,
+    error: irlume_common::Error,
+) -> CapturePathError {
+    if matches!(
+        error,
+        irlume_common::Error::Preempted(_) | irlume_common::Error::DeadlineExpired
+    ) {
+        return CapturePathError::Other(error);
+    }
+    emit_capture_fallback(reason, diagnostics);
+    if let Some(key) = mode.runtime_key.as_deref() {
+        trip_runtime_capture_health(key, reason);
+    }
+    CapturePathError::ConcurrentPair(error)
+}
+
+/// One startup/rate boundary and one owned streaming scope per collection.
+/// Dependencies are injectable so real owner and collector behavior can be
+/// tested without opening cameras; a result cannot borrow either owner.
+pub(super) fn with_managed_pair<R, I, T>(
+    arm: impl FnOnce() -> Result<(R, I), CapturePathError>,
+    establish: impl FnOnce(&mut R, &mut I) -> Result<(), CapturePathError>,
+    collect: impl FnOnce(&mut R, &mut I) -> Result<T, CapturePathError>,
+    diagnostics: &dyn irlume_common::diagnostics::DiagnosticSink,
+) -> Result<T, CapturePathError> {
+    let pair = {
+        let _timing = TraceStageTimer::new(
+            diagnostics,
+            irlume_common::diagnostics::TraceStage::StreamArm,
+        );
+        arm()?
+    };
+    with_owned_pair(pair, diagnostics, |rgb, ir| {
+        {
+            let _timing = TraceStageTimer::new(
+                diagnostics,
+                irlume_common::diagnostics::TraceStage::RateEstablishment,
+            );
+            establish(rgb, ir)?;
+        }
+        collect(rgb, ir)
+    })
+}
+
+impl Engine {
+    /// Only the ordinary Live + eligible RGB preparation can produce Pending.
+    /// The callback includes capture, contract checks, and completed tail drains.
+    /// Returning Ready never authorizes looking for a better identity sample.
+    pub(super) fn collect_concurrent_pending_with(
+        &mut self,
+        deadline: Instant,
+        mut next: impl FnMut(&mut Self) -> Result<PreparedPairAuthentication, CapturePathError>,
+        mut now: impl FnMut() -> Instant,
+    ) -> Result<PreparedPairAuthentication, CapturePathError> {
+        let mut state = CollectionState::new(self);
+        for sample in 0..VIT_PAD_VOTE_N {
+            state.engine.check_request_active()?;
+            if now() >= deadline {
+                state.engine.last_attempt_situation = Some(AttemptSituation::TimedOut);
+                return Err(irlume_common::Error::DeadlineExpired.into());
+            }
+            let prepared = next(state.engine)?;
+            state.engine.check_request_cancelled()?;
+            let expired = now() >= deadline
+                || state
+                    .engine
+                    .authentication_deadline
+                    .is_some_and(|end| Instant::now() >= end);
+            if expired {
+                // Like the outer retry loop, preserve an already completed
+                // denial's accounting. Expiry permits no subsequent sample or
+                // identity admission; transport errors never reach this branch.
+                if matches!(&prepared, PreparedPairAuthentication::Refused(_)) {
+                    state.retain_facts = true;
+                    return Ok(prepared);
+                }
+                state.engine.last_attempt_situation = Some(AttemptSituation::TimedOut);
+                return Err(irlume_common::Error::DeadlineExpired.into());
+            }
+            if sample + 1 == VIT_PAD_VOTE_N
+                || !matches!(
+                    &prepared,
+                    PreparedPairAuthentication::Refused(Outcome {
+                        kind: OutcomeKind::RgbPadPending,
+                        ..
+                    })
+                )
+            {
+                state.retain_facts = true;
+                return Ok(prepared);
+            }
+            state.engine.note_capture_boundary();
+        }
+        unreachable!("the bounded final sample always returns its prepared result")
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn authenticate_managed_concurrent_once(
+        &mut self,
+        enrollment: &irlume_core::storage::Enrollment,
+        purpose: AuthenticationPurpose,
+        service: Option<&str>,
+        cameras: &(irlume_camera::RgbCamera, irlume_camera::IrCamera),
+        mode: &CaptureModeSelection,
+        deadline: Instant,
+        held_pair_failed: &mut bool,
+        diagnostics: &dyn irlume_common::diagnostics::DiagnosticSink,
+    ) -> irlume_common::Result<Outcome> {
+        // This outer owner also covers setup, stream destruction and admission.
+        let mut state = CollectionState::new(self);
+        let result = state.engine.managed_concurrent_attempt(
+            enrollment,
+            purpose,
+            service,
+            cameras,
+            mode,
+            deadline,
+            held_pair_failed,
+            diagnostics,
+        );
+        state.retain_facts = result.is_ok();
+        result
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn managed_concurrent_attempt(
+        &mut self,
+        enrollment: &irlume_core::storage::Enrollment,
+        purpose: AuthenticationPurpose,
+        service: Option<&str>,
+        cameras: &(irlume_camera::RgbCamera, irlume_camera::IrCamera),
+        mode: &CaptureModeSelection,
+        deadline: Instant,
+        held_pair_failed: &mut bool,
+        diagnostics: &dyn irlume_common::diagnostics::DiagnosticSink,
+    ) -> irlume_common::Result<Outcome> {
+        let prepared = (|| {
+            self.check_request_active()?;
+            let control = self.capture_control();
+            with_managed_pair(
+                || {
+                    arm_pair_transactionally(
+                        || cameras.0.session_with_control(&control),
+                        || cameras.1.session_for_pair_with_control(&control),
+                    )
+                    .map_err(|error| {
+                        concurrent_setup_error(
+                            Some(mode),
+                            diagnostics,
+                            RuntimeDegradation::PairArmFailure,
+                            error,
+                        )
+                    })
+                },
+                |rgb, ir| {
+                    irlume_camera::establish_pair_rate(rgb, ir).map_err(|error| {
+                        concurrent_setup_error(
+                            Some(mode),
+                            diagnostics,
+                            RuntimeDegradation::PairRateEstablishmentFailure,
+                            error,
+                        )
+                    })
+                },
+                |rgb, ir| {
+                    let mut windows = PairWindows::default();
+                    let mut sample = 0;
+                    self.collect_concurrent_pending_with(
+                        deadline,
+                        |engine| {
+                            sample += 1;
+                            let prepared = engine.prepare_managed_concurrent_sample(
+                                rgb,
+                                ir,
+                                mode,
+                                &mut windows,
+                                diagnostics,
+                            )?;
+                            // The final selected refusal is emitted by admission below;
+                            // intermediate Pending events describe continued evidence.
+                            if sample < VIT_PAD_VOTE_N {
+                                if let PreparedPairAuthentication::Refused(outcome) = &prepared {
+                                    if outcome.kind == OutcomeKind::RgbPadPending {
+                                        emit_authentication_refusal(diagnostics, outcome);
+                                    }
+                                }
+                            }
+                            Ok(prepared)
+                        },
+                        Instant::now,
+                    )
+                },
+                diagnostics,
+            )
+        })();
+        // The streaming owners and processing workers have finished before
+        // cancellation/deadline admission checks or any identity comparison.
+        self.check_request_cancelled()?;
+        if matches!(&prepared, Ok(PreparedPairAuthentication::Ready(_))) {
+            self.check_request_active()?;
+        }
+        self.finish_pair_authentication(
+            enrollment,
+            purpose,
+            service,
+            prepared,
+            Some(held_pair_failed),
+            diagnostics,
+        )
+    }
+
+    fn prepare_managed_concurrent_sample(
+        &mut self,
+        rgb: &mut irlume_camera::RgbSession<'_>,
+        ir: &mut irlume_camera::IrSession<'_>,
+        mode: &CaptureModeSelection,
+        windows: &mut PairWindows,
+        diagnostics: &dyn irlume_common::diagnostics::DiagnosticSink,
+    ) -> Result<PreparedPairAuthentication, CapturePathError> {
+        let (mut rgb_ms, mut ir_ms) = (0, 0);
+        // No recovery within an evidence transaction: either side failing
+        // invalidates both, and the existing outer fallback owns any reopen.
+        let (rgb_result, ir_result) = irlume_camera::capture_pair_with(
+            rgb,
+            ir,
+            |session| {
+                let started = Instant::now();
+                let frame = session.denoised();
+                rgb_ms = started.elapsed().as_millis();
+                frame
+            },
+            |session| {
+                let started = Instant::now();
+                let frame = session.capture_with_stats();
+                ir_ms = started.elapsed().as_millis();
+                frame
+            },
+        );
+        self.check_request_active()?;
+        // A simultaneous failure on the other stream cannot hide cancellation.
+        let errors = [rgb_result.as_ref().err(), ir_result.as_ref().err()];
+        if errors
+            .iter()
+            .flatten()
+            .any(|error| matches!(error, irlume_common::Error::Preempted(_)))
+        {
+            return Err(irlume_common::Error::Preempted("camera capture cancelled".into()).into());
+        }
+        if errors
+            .iter()
+            .flatten()
+            .any(|error| matches!(error, irlume_common::Error::DeadlineExpired))
+        {
+            return Err(irlume_common::Error::DeadlineExpired.into());
+        }
+        emit_trace_stage_ms(
+            diagnostics,
+            irlume_common::diagnostics::TraceStage::RgbCapture,
+            rgb_ms,
+        );
+        emit_trace_stage_ms(
+            diagnostics,
+            irlume_common::diagnostics::TraceStage::IrCapture,
+            ir_ms,
+        );
+        let capture_error = |error| {
+            transport_error(
+                mode,
+                diagnostics,
+                RuntimeDegradation::ConcurrentCaptureFailure,
+                error,
+            )
+        };
+        let rgb_frame = rgb_result.map_err(capture_error)?;
+        let (ir_frame, ir_stats) = ir_result.map_err(capture_error)?;
+        let contract = mode.runtime_contract.as_ref().ok_or_else(|| {
+            transport_error(
+                mode,
+                diagnostics,
+                RuntimeDegradation::MissingRuntimeContract,
+                irlume_common::Error::Hardware("managed pair has no runtime contract".into()),
+            )
+        })?;
+        let events = contract
+            .diagnostic_trace_events(&rgb_frame, &ir_frame)
+            .map_err(|violation| {
+                transport_error(
+                    mode,
+                    diagnostics,
+                    runtime_violation_degradation(violation),
+                    irlume_common::Error::Hardware(
+                        "managed pair failed its runtime contract".into(),
+                    ),
+                )
+            })?;
+        if !windows.advance(rgb_frame.captured, ir_frame.captured) {
+            return Err(transport_error(
+                mode,
+                diagnostics,
+                RuntimeDegradation::ContinuityLoss,
+                irlume_common::Error::Hardware(
+                    "managed pair acquisition windows did not advance".into(),
+                ),
+            ));
+        }
+        for event in events {
+            diagnostics.emit_trace(event);
+        }
+        // Transport and inference Results deliberately remain nested. A failed
+        // final drain discards prepared identity and the collection guard clears
+        // any PAD vote mutated by this callback. Held ownership disables reopen.
+        irlume_camera::process_pair_while_draining(rgb, ir, || {
+            self.check_request_active()?;
+            let detections = self.detect_rgb_assessment(&rgb_frame, Some(rgb_ms), diagnostics)?;
+            let evidence = self.assess_captured_pair(
+                rgb_frame,
+                ir_frame,
+                ir_stats,
+                detections,
+                PairAssessmentContext {
+                    sequential: false,
+                    pair_sequential_retried: false,
+                    rgb_hard_retried: false,
+                    held_sessions: true,
+                    ir_ms: Some(ir_ms),
+                    diagnostics,
+                },
+            )?;
+            self.prepare_pair_authentication_with(evidence, |engine, evidence| {
+                engine.materialize_pair_identity(evidence, diagnostics)
+            })
+            .map_err(CapturePathError::from)
+        })
+        .map_err(capture_error)?
+    }
+}

--- a/crates/irlume-auth/tests/attempt_situation_wiring.rs
+++ b/crates/irlume-auth/tests/attempt_situation_wiring.rs
@@ -19,8 +19,8 @@ fn every_failed_attempt_emits_exactly_one_situation_line() {
     let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/lib.rs");
     let text = std::fs::read_to_string(&src).expect("read irlume-auth/src/lib.rs");
 
-    // The snapshot is set where the assessment binds, so every Outcome the
-    // attempt returns reads facts from THIS attempt, never a stale one.
+    // Every outcome-producing route stores this assessment's facts. Eager
+    // RGB/legacy, early PAD refusal, and prepared identity have separate binds.
     let once_start = text
         .find("    fn authenticate_once(")
         .expect("authenticate_once exists");
@@ -33,9 +33,52 @@ fn every_failed_attempt_emits_exactly_one_situation_line() {
         .find("last_attempt_facts")
         .expect("the attempt stores its facts snapshot");
     let assessment_bound = once
-        .find("Ok(assessment) => assessment")
+        .find("Ok(a) => a")
         .expect("the assessment binds before the snapshot");
     assert!(snapshot > assessment_bound);
+    assert!(snapshot < once.find("self.authenticate_assessment(").unwrap());
+
+    let preparation_start = text
+        .find("    fn prepare_pair_authentication_with(")
+        .unwrap();
+    let finish_start = text.find("    fn finish_pair_authentication(").unwrap();
+    let preparation = &text[preparation_start..finish_start];
+    let pending_snapshot = preparation
+        .find("self.last_attempt_facts = AttemptFacts::from_assessment(&evidence.assessment)")
+        .unwrap();
+    assert!(
+        preparation
+            .find("if let Some(outcome) = pad_policy_refusal(")
+            .unwrap()
+            < pending_snapshot
+    );
+    assert!(
+        pending_snapshot
+            < preparation
+                .find("return Ok(PreparedPairAuthentication::Refused(outcome))")
+                .unwrap()
+    );
+
+    let finish_end = text[finish_start..]
+        .find("    fn authenticate_assessment(")
+        .unwrap()
+        + finish_start;
+    let finish = &text[finish_start..finish_end];
+    let ready_snapshot = finish
+        .find("self.last_attempt_facts = AttemptFacts::from_assessment(&a)")
+        .unwrap();
+    assert!(
+        finish
+            .find("PreparedPairAuthentication::Ready(a) =>")
+            .unwrap()
+            < ready_snapshot
+    );
+    assert!(
+        ready_snapshot
+            < finish
+                .find("self.authenticate_qualified_assessment(")
+                .unwrap()
+    );
 
     // The emission lives in the retry loop, guarded by !out.granted, so a
     // grant never logs a situation and every failure logs exactly one.

--- a/crates/irlume-auth/tests/held_pair_fallback_contract.rs
+++ b/crates/irlume-auth/tests/held_pair_fallback_contract.rs
@@ -12,20 +12,21 @@ fn function<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
 fn assert_scoped_pair_assessment(source: &str) {
     let assessment = function(
         source,
-        "    fn assess_with_fresh_pair(",
+        "    fn assess_with_fresh_pair_finish<T>(",
         "\n    fn assess_full_with_operation(",
     );
     let owner = assessment
         .find("with_owned_pair(pair,")
         .expect("own both sessions");
     let capture = assessment
-        .find("self.assess_full_with(Some((rgb, ir))")
+        .find("self.assess_full_with_finish(Some((rgb, ir))")
         .expect("paired assessment");
     assert!(
         owner < capture,
         "capture must finish inside the session owner scope"
     );
-    assert!(assessment.contains("Result<Assessment, CapturePathError>"));
+    assert!(assessment.contains("Result<T, CapturePathError>"));
+    assert!(assessment.contains("diagnostics, finish)"));
     assert!(assessment.contains("arm_pair_transactionally("));
     assert!(assessment.contains("establish_pair_rate(rgb, ir)"));
 }
@@ -36,7 +37,7 @@ fn held_concurrent_failure_is_returned_to_the_pair_owner() {
         .expect("read auth source");
     let assess = function(
         &source,
-        "    fn assess_full_with(",
+        "    fn assess_full_with_finish<T>(",
         "\n    pub fn authenticate(",
     );
 
@@ -65,7 +66,18 @@ fn authentication_fallback_drops_the_entire_held_pair_before_retry() {
         "    fn authenticate_once(",
         "\n    pub fn identify(",
     );
-    assert!(attempt.contains("self.assess_with_fresh_pair(rgb, ir, mode, operation, diagnostics)"));
+    assert!(attempt.contains("self.assess_with_fresh_pair_finish("));
+    assert!(attempt
+        .contains("self.assess_full_with_finish(None, mode, operation, diagnostics, finish)"));
+    let captured = attempt
+        .find("let prepared = if let Some((rgb, ir)) = cameras")
+        .unwrap();
+    let decision = attempt.find("self.finish_pair_authentication(").unwrap();
+    assert!(
+        captured < decision,
+        "identity admission follows the returning owner scope"
+    );
+    assert!(attempt[..captured].contains(".prepare_ordinary_pair_authentication_with("));
     assert!(!authenticate.contains("RgbSession"));
     assert!(!authenticate.contains("IrSession"));
     let fallback = authenticate
@@ -81,6 +93,40 @@ fn authentication_fallback_drops_the_entire_held_pair_before_retry() {
         "fallback must release handles before reopening"
     );
     assert!(fallback[..retry].contains("demote_after_concurrent_capture_failure"));
+}
+
+#[test]
+fn public_and_enrollment_pair_wrappers_still_finish_with_eager_identity() {
+    let source = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/src/lib.rs"))
+        .expect("read auth source");
+    for (start, end, finish) in [
+        (
+            "    fn assess_with_fresh_pair(",
+            "    fn assess_with_fresh_pair_finish<T>(",
+            "self.assess_with_fresh_pair_finish(",
+        ),
+        (
+            "    fn assess_full_with(",
+            "    fn assess_full_with_finish<T>(",
+            "self.assess_full_with_finish(",
+        ),
+    ] {
+        let wrapper = function(&source, start, end);
+        assert!(wrapper.contains("Result<Assessment, CapturePathError>"));
+        assert!(wrapper.contains(finish));
+        assert!(wrapper.contains(".materialize_pair_identity(evidence, diagnostics)"));
+        assert!(!wrapper.contains("prepare_pair_authentication_with"));
+        assert!(!wrapper.contains("qualify_rgb_pad_evidence"));
+    }
+    let capture = function(
+        &source,
+        "    fn assess_full_with_finish<T>(",
+        "    fn detect_rgb_assessment(",
+    );
+    assert!(
+        capture.find("self.assess_captured_pair(").unwrap()
+            < capture.find("finish(self, evidence)").unwrap()
+    );
 }
 
 #[test]

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -57,6 +57,8 @@ pub use ir_target::{configured_ir_target, IrCaptureTarget, IrTargetError};
 pub mod lease;
 mod lifecycle;
 mod media_graph;
+mod paired_processing;
+pub use paired_processing::process_pair_while_draining;
 mod rate_gate;
 mod sequential_batch;
 pub use sequential_batch::{
@@ -5774,6 +5776,25 @@ pub struct IrSession<'a> {
 }
 
 impl IrSession<'_> {
+    // Match capture_pair_with's tail service: discard pixels while retaining
+    // rate/continuity checks, metadata servicing and privacy teardown.
+    fn discard_frame(&mut self) -> irlume_common::Result<()> {
+        let result = drain_pair_frame(&mut self.stream, &self.cam.device);
+        let privacy_refused = self.stream.privacy_refused();
+        let result = finish_hidden_rate_fill(result, privacy_refused, || {
+            if let Some(log) = self.meta.as_mut() {
+                log.drain();
+            }
+        });
+        if self.stream.take_privacy_refusal() {
+            let refusal = result
+                .err()
+                .unwrap_or_else(|| Error::Hardware("IR privacy refused paired drain".into()));
+            return Err(self.stop_after_privacy_refusal(refusal));
+        }
+        result
+    }
+
     /// One IR capture: a burst, the gate frame, and the burst statistics.
     ///
     /// The gate frame is a lit strobe phase, and on a source whose ceiling is
@@ -6327,22 +6348,7 @@ pub fn capture_pair_with<R: Send, I: Send>(
         let ir_thread = scope.spawn(|| {
             let lease = ir.cam.lease.clone();
             lease.run_active(|| {
-                capture_and_drain(ir, &completed, capture_ir, |ir| {
-                    let result = drain_pair_frame(&mut ir.stream, &ir.cam.device);
-                    let privacy_refused = ir.stream.privacy_refused();
-                    let result = finish_hidden_rate_fill(result, privacy_refused, || {
-                        if let Some(log) = ir.meta.as_mut() {
-                            log.drain();
-                        }
-                    });
-                    if ir.stream.take_privacy_refusal() {
-                        let refusal = result.err().unwrap_or_else(|| {
-                            Error::Hardware("IR privacy refused paired drain".into())
-                        });
-                        return Err(ir.stop_after_privacy_refusal(refusal));
-                    }
-                    result
-                })
+                capture_and_drain(ir, &completed, capture_ir, |ir| ir.discard_frame())
             })
         });
         let lease = rgb.cam.lease.clone();
@@ -9681,6 +9687,9 @@ where
 
 #[cfg(test)]
 mod tests {
+    mod paired_processing_tests {
+        include!("paired_processing_tests.rs");
+    }
     mod capture_cancellation_tests {
         include!("capture_cancellation_tests.rs");
     }

--- a/crates/irlume-camera/src/paired_processing.rs
+++ b/crates/irlume-camera/src/paired_processing.rs
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+use crate::{IrSession, RgbSession, MAX_RATE_FILL_ATTEMPTS};
+use irlume_common::{Error, Result};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Process captured evidence on the calling thread while both queues are serviced.
+///
+/// Use after [`crate::capture_pair_with`] on the same held sessions. Each queue
+/// is drained independently, preserving delivered-rate, continuity, lease and
+/// IR metadata/privacy checks. Neither processing nor its result needs `Send`.
+/// An authentication result may remain nested inside the outer transport result.
+///
+/// Both scoped workers are joined, including their in-flight tail dequeues,
+/// before a result is returned. Caller-owned sessions remain held; this function
+/// neither captures a new pair nor recovers a failed stream. Cancellation is
+/// cooperative at returned driver-call boundaries and cannot interrupt the
+/// processing callback. Each worker has a bounded discard budget.
+///
+/// # Errors
+/// Returns cancellation, deadline, stale-lease or either worker's transport
+/// error, discarding even a successful processing result. The caller must also
+/// discard any authentication evidence the callback mutated outside its return
+/// value; this function cannot roll back callback side effects.
+///
+/// # Panics
+/// Resumes a processing or drain panic after both workers have been joined.
+pub fn process_pair_while_draining<T>(
+    rgb: &mut RgbSession<'_>,
+    ir: &mut IrSession<'_>,
+    process: impl FnOnce() -> T,
+) -> Result<T> {
+    check_pair(rgb, ir)?;
+    let rgb_lease = rgb.cam.lease.clone();
+    let ir_lease = ir.cam.lease.clone();
+    let result = process_with_pair_drains(
+        process,
+        || rgb_lease.run_active(|| rgb.discard_frame()),
+        || ir_lease.run_active(|| ir.discard_frame()),
+    );
+    finish_processing(result, || check_controls(rgb, ir), || check_leases(rgb, ir))
+}
+
+fn check_pair(rgb: &RgbSession<'_>, ir: &IrSession<'_>) -> Result<()> {
+    check_controls(rgb, ir)?;
+    check_leases(rgb, ir)
+}
+
+fn check_controls(rgb: &RgbSession<'_>, ir: &IrSession<'_>) -> Result<()> {
+    merge_checks(rgb.stream.control.check(), ir.stream.control.check())
+}
+
+fn check_leases(rgb: &RgbSession<'_>, ir: &IrSession<'_>) -> Result<()> {
+    rgb.cam
+        .lease
+        .require_endpoint(&rgb.cam.device)
+        .and_then(|()| ir.cam.lease.require_endpoint(&ir.cam.device))
+        .map_err(|error| Error::Hardware(error.to_string()))
+}
+
+// This final gate is also reached on transport failure so request control can
+// take precedence before the caller classifies a camera fault.
+pub(super) fn finish_processing<T>(
+    processed: Result<T>,
+    check_control: impl FnOnce() -> Result<()>,
+    check_lease: impl FnOnce() -> Result<()>,
+) -> Result<T> {
+    match (processed, check_control()) {
+        (Ok(result), Ok(())) => {
+            check_lease()?;
+            Ok(result)
+        }
+        (Err(transport), Err(control)) => Err(prefer_control_error(transport, control)),
+        (Err(transport), Ok(())) => Err(transport),
+        (Ok(_), Err(control)) => Err(control),
+    }
+}
+
+fn merge_checks(first: Result<()>, second: Result<()>) -> Result<()> {
+    match (first, second) {
+        (Err(first), Err(second)) => Err(prefer_control_error(first, second)),
+        (Err(error), _) | (_, Err(error)) => Err(error),
+        (Ok(()), Ok(())) => Ok(()),
+    }
+}
+
+fn prefer_control_error(first: Error, second: Error) -> Error {
+    // A request cancellation must not become a hardware fallback, even when
+    // the other worker observed its deadline or a transport error first.
+    match (first, second) {
+        (error @ Error::Preempted(_), _) | (_, error @ Error::Preempted(_)) => error,
+        (error @ Error::DeadlineExpired, _) | (_, error @ Error::DeadlineExpired) => error,
+        (first, _) => first,
+    }
+}
+
+struct Finished<'a>(&'a AtomicBool);
+
+impl Drop for Finished<'_> {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::Release);
+    }
+}
+
+pub(super) fn drain_until_finished(
+    finished: &AtomicBool,
+    mut drain: impl FnMut() -> Result<()>,
+) -> Result<()> {
+    // A transport error or panic must also release the companion worker.
+    let _finished = Finished(finished);
+    for _ in 0..2 * MAX_RATE_FILL_ATTEMPTS {
+        if finished.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        drain()?;
+    }
+    if finished.load(Ordering::Acquire) {
+        Ok(())
+    } else {
+        Err(Error::Hardware(
+            "paired processing exceeded its bounded drain".into(),
+        ))
+    }
+}
+
+pub(super) fn process_with_pair_drains<T>(
+    process: impl FnOnce() -> T,
+    rgb_drain: impl FnMut() -> Result<()> + Send,
+    ir_drain: impl FnMut() -> Result<()> + Send,
+) -> Result<T> {
+    let finished = AtomicBool::new(false);
+    std::thread::scope(|scope| {
+        // Declare before spawning: a failed second spawn must not strand the
+        // first worker while the scope waits for it to terminate.
+        let completion = Finished(&finished);
+        let rgb = scope.spawn(|| drain_until_finished(&finished, rgb_drain));
+        let ir = scope.spawn(|| drain_until_finished(&finished, ir_drain));
+        let processed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(process));
+        drop(completion);
+        let rgb = rgb.join();
+        let ir = ir.join();
+        // Join both before propagating either panic or error. A successful
+        // callback result is still discarded if an in-flight dequeue failed.
+        let result = processed.unwrap_or_else(|panic| std::panic::resume_unwind(panic));
+        let rgb = rgb.unwrap_or_else(|panic| std::panic::resume_unwind(panic));
+        let ir = ir.unwrap_or_else(|panic| std::panic::resume_unwind(panic));
+        merge_checks(rgb, ir)?;
+        Ok(result)
+    })
+}

--- a/crates/irlume-camera/src/paired_processing_tests.rs
+++ b/crates/irlume-camera/src/paired_processing_tests.rs
@@ -1,0 +1,325 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+use super::*;
+use std::cell::Cell;
+use std::rc::Rc;
+use std::sync::{atomic::{AtomicBool, AtomicUsize, Ordering}, mpsc, Arc};
+use std::time::Duration;
+
+use crate::paired_processing::{drain_until_finished, finish_processing, process_with_pair_drains};
+
+const WAIT: Duration = Duration::from_secs(2);
+
+#[test]
+fn processing_services_both_queues_independently_on_the_calling_thread() {
+    let caller = std::thread::current().id();
+    let local = Rc::new(Cell::new(0));
+    let captured = local.clone();
+    let (rgb_ready, wait_rgb) = mpsc::channel();
+    let (ir_ready, wait_ir) = mpsc::channel();
+    let (ready, waiting) = mpsc::channel();
+    let rgb_done = ready.clone();
+    let (mut first_rgb, mut first_ir) = (true, true);
+    let output = process_with_pair_drains(
+        || {
+            waiting.recv_timeout(WAIT).expect("RGB and IR must service independently");
+            waiting.recv_timeout(WAIT).expect("both queues must run during processing");
+            assert_eq!(std::thread::current().id(), caller);
+            captured.set(7);
+            captured
+        },
+        move || {
+            if std::mem::take(&mut first_rgb) {
+                rgb_ready.send(()).unwrap();
+                wait_ir.recv_timeout(WAIT).expect("IR cannot wait behind RGB");
+                rgb_done.send(()).unwrap();
+            }
+            std::thread::sleep(Duration::from_millis(1));
+            Ok(())
+        },
+        move || {
+            if std::mem::take(&mut first_ir) {
+                ir_ready.send(()).unwrap();
+                wait_rgb.recv_timeout(WAIT).expect("RGB cannot wait behind IR");
+                ready.send(()).unwrap();
+            }
+            std::thread::sleep(Duration::from_millis(1));
+            Ok(())
+        },
+    ).unwrap();
+    assert!(Rc::ptr_eq(&output, &local), "non-Send result stays on its caller");
+    assert_eq!(local.get(), 7);
+}
+
+struct Dropped(Rc<Cell<bool>>);
+impl Drop for Dropped {
+    fn drop(&mut self) { self.0.set(true); }
+}
+
+#[test]
+fn processing_rejects_success_after_either_in_flight_tail_failure() {
+    for fail_rgb in [true, false] {
+        let discarded = Rc::new(Cell::new(false));
+        let result_drop = discarded.clone();
+        let (started, waiting) = mpsc::channel();
+        let (finish, release) = mpsc::channel();
+        let fail = move || {
+            started.send(()).unwrap();
+            release.recv_timeout(WAIT).unwrap();
+            Err(Error::DeadlineExpired)
+        };
+        let healthy = || {
+            std::thread::sleep(Duration::from_millis(1));
+            Ok(())
+        };
+        let process = || {
+            waiting.recv_timeout(WAIT).expect("tail drain must be in flight");
+            finish.send(()).unwrap();
+            Dropped(result_drop)
+        };
+        let result = if fail_rgb {
+            process_with_pair_drains(process, fail, healthy)
+        } else {
+            process_with_pair_drains(process, healthy, fail)
+        };
+        assert!(matches!(result, Err(Error::DeadlineExpired)));
+        assert!(discarded.get(), "a successful prepared result must be discarded");
+    }
+}
+
+#[test]
+fn processing_keeps_inner_authentication_errors_separate() {
+    let output = finish_processing(
+        Ok(Err::<(), _>(Rc::new("inference failure"))),
+        || Ok(()),
+        || Ok(()),
+    ).unwrap();
+    assert_eq!(*output.unwrap_err(), "inference failure");
+}
+
+struct WorkerDropped(Arc<AtomicBool>);
+impl Drop for WorkerDropped {
+    fn drop(&mut self) { self.0.store(true, Ordering::SeqCst); }
+}
+
+#[test]
+fn processing_panic_joins_both_workers_before_unwinding() {
+    let (ready, waiting) = mpsc::channel();
+    let rgb_dropped = Arc::new(AtomicBool::new(false));
+    let ir_dropped = Arc::new(AtomicBool::new(false));
+    let make_drain = |ready: mpsc::Sender<()>, dropped| {
+        let owner = WorkerDropped(dropped);
+        let mut first = true;
+        move || {
+            let _owner = &owner;
+            if std::mem::take(&mut first) { ready.send(()).unwrap(); }
+            std::thread::sleep(Duration::from_millis(1));
+            Ok(())
+        }
+    };
+    let rgb = make_drain(ready.clone(), rgb_dropped.clone());
+    let ir = make_drain(ready, ir_dropped.clone());
+    let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let _ = process_with_pair_drains(
+            || {
+                waiting.recv_timeout(WAIT).unwrap();
+                waiting.recv_timeout(WAIT).unwrap();
+                panic!("processing defect");
+            }, rgb, ir,
+        );
+    }));
+    assert_eq!(panic.unwrap_err().downcast_ref::<&str>(), Some(&"processing defect"));
+    assert!(rgb_dropped.load(Ordering::SeqCst) && ir_dropped.load(Ordering::SeqCst));
+}
+
+#[test]
+fn processing_drain_panic_is_not_a_camera_result() {
+    for panic_rgb in [true, false] {
+        let (started, waiting) = mpsc::channel();
+        let companion_dropped = Arc::new(AtomicBool::new(false));
+        let owner = WorkerDropped(companion_dropped.clone());
+        let panicking = move || -> irlume_common::Result<()> {
+            started.send(()).unwrap();
+            panic!("drain defect");
+        };
+        let companion = move || {
+            let _owner = &owner;
+            std::thread::sleep(Duration::from_millis(1));
+            Ok(())
+        };
+        let process = || { waiting.recv_timeout(WAIT).unwrap(); 7 };
+        let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            if panic_rgb {
+                process_with_pair_drains(process, panicking, companion)
+            } else {
+                process_with_pair_drains(process, companion, panicking)
+            }
+        }));
+        assert_eq!(panic.unwrap_err().downcast_ref::<&str>(), Some(&"drain defect"));
+        assert!(companion_dropped.load(Ordering::SeqCst));
+    }
+}
+
+#[test]
+fn processing_bounds_discard_work_while_processing_continues() {
+    let (at_limit, waiting) = mpsc::channel();
+    struct NotifyOnDrop(mpsc::Sender<()>);
+    impl Drop for NotifyOnDrop {
+        fn drop(&mut self) { let _ = self.0.send(()); }
+    }
+    let finished_drain = NotifyOnDrop(at_limit);
+    let calls = Arc::new(AtomicUsize::new(0));
+    let count = calls.clone();
+    let result = process_with_pair_drains(
+        || { waiting.recv_timeout(WAIT).unwrap(); },
+        move || {
+            let _finished = &finished_drain;
+            count.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        },
+        || { std::thread::sleep(Duration::from_millis(1)); Ok(()) },
+    );
+    assert!(result.is_err(), "bounded transport work cannot become an accepted result");
+    assert_eq!(calls.load(Ordering::SeqCst), 2 * MAX_RATE_FILL_ATTEMPTS);
+}
+
+#[test]
+fn processing_preserves_the_real_drain_rate_and_continuity_refusals() {
+    for gap in [false, true] {
+        let mut stream = rate_fill_fixture(contracts::StreamRole::Ir, 100, if gap {66_667} else {200_000});
+        if gap {
+            stream.next().unwrap();
+            stream.stream_mut().unwrap().metadata.front_mut().unwrap().sequence += 1;
+        }
+        let (started, waiting) = mpsc::channel();
+        let output = process_with_pair_drains(
+            || { waiting.recv_timeout(WAIT).unwrap(); true },
+            move || {
+                started.send(()).unwrap();
+                drain_pair_frame(&mut stream, "fixture")
+            },
+            || { std::thread::sleep(Duration::from_millis(1)); Ok(()) },
+        );
+        if gap {
+            assert!(matches!(output, Err(Error::Hardware(ref message)) if message.contains("continuity")));
+        } else {
+            assert!(matches!(output, Err(Error::DeliveredRate(_))));
+        }
+    }
+}
+
+#[test]
+fn processing_preserves_cancellation_observed_by_the_tail_drain() {
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let signal = cancelled.clone();
+    let control = CaptureControl::new(no_progress(), Arc::new(move || signal.load(Ordering::SeqCst)));
+    let (started, waiting) = mpsc::channel();
+    let (release, released) = mpsc::channel();
+    let output = process_with_pair_drains(
+        || {
+            waiting.recv_timeout(WAIT).unwrap();
+            cancelled.store(true, Ordering::SeqCst);
+            release.send(()).unwrap();
+            true
+        },
+        move || { started.send(()).unwrap(); released.recv_timeout(WAIT).unwrap(); control.check() },
+        || { std::thread::sleep(Duration::from_millis(1)); Ok(()) },
+    );
+    assert!(matches!(output, Err(Error::Preempted(_))));
+}
+
+#[test]
+fn processing_prioritizes_cancellation_and_deadline_from_either_worker() {
+    for rgb_error in 0..3 {
+        for ir_error in 0..3 {
+            let (started, waiting) = mpsc::channel();
+            let (release_rgb, rgb_released) = mpsc::channel();
+            let (release_ir, ir_released) = mpsc::channel();
+            let make_drain = |started: mpsc::Sender<()>, released: mpsc::Receiver<()>, error| {
+                move || {
+                    started.send(()).unwrap();
+                    released.recv_timeout(WAIT).unwrap();
+                    match error {
+                        2 => Err(Error::Preempted("cancelled".into())),
+                        1 => Err(Error::DeadlineExpired),
+                        _ => Err(Error::Hardware("transport failure".into())),
+                    }
+                }
+            };
+            let output = process_with_pair_drains(
+                || {
+                    waiting.recv_timeout(WAIT).unwrap();
+                    waiting.recv_timeout(WAIT).unwrap();
+                    release_rgb.send(()).unwrap();
+                    release_ir.send(()).unwrap();
+                    7
+                },
+                make_drain(started.clone(), rgb_released, rgb_error),
+                make_drain(started, ir_released, ir_error),
+            );
+            match rgb_error.max(ir_error) {
+                2 => assert!(matches!(output, Err(Error::Preempted(_)))),
+                1 => assert!(matches!(output, Err(Error::DeadlineExpired))),
+                _ => assert!(matches!(output, Err(Error::Hardware(_)))),
+            }
+        }
+    }
+}
+
+#[test]
+fn processing_rechecks_final_control_even_after_transport_failure() {
+    let checked = Cell::new(false);
+    let output = finish_processing::<()>(
+        Err(Error::Hardware("tail transport failure".into())),
+        || { checked.set(true); Err(Error::Preempted("cancelled".into())) },
+        || panic!("a rejected result must not consult a stale lease"),
+    );
+    assert!(checked.get());
+    assert!(matches!(output, Err(Error::Preempted(_))));
+}
+
+#[test]
+fn processing_rejects_success_if_the_final_lease_is_stale() {
+    let discarded = Rc::new(Cell::new(false));
+    let output = finish_processing(
+        Ok(Dropped(discarded.clone())),
+        || Ok(()),
+        || Err(Error::Hardware("stale lease".into())),
+    );
+    assert!(matches!(output, Err(Error::Hardware(ref message)) if message == "stale lease"));
+    assert!(discarded.get());
+}
+
+#[test]
+fn processing_preserves_the_transport_cause_instead_of_a_stale_lease() {
+    let output = finish_processing::<()>(
+        Err(Error::Hardware("IR privacy refused paired drain".into())),
+        || Ok(()),
+        || panic!("stale lease must not replace the existing privacy failure"),
+    );
+    assert!(matches!(output, Err(Error::Hardware(ref message)) if message == "IR privacy refused paired drain"));
+}
+
+#[test]
+fn processing_accepts_completion_during_the_last_bounded_drain() {
+    let finished = AtomicBool::new(false);
+    let mut calls = 0;
+    let output = drain_until_finished(&finished, || {
+        calls += 1;
+        if calls == 2 * MAX_RATE_FILL_ATTEMPTS { finished.store(true, Ordering::Release); }
+        Ok(())
+    });
+    assert!(output.is_ok());
+    assert_eq!(calls, 2 * MAX_RATE_FILL_ATTEMPTS);
+}
+
+#[test]
+fn processing_preserves_prior_cancellation_over_a_final_deadline() {
+    let output = finish_processing::<()>(
+        Err(Error::Preempted("cancelled".into())),
+        || Err(Error::DeadlineExpired),
+        || panic!("a rejected result must not consult its lease"),
+    );
+    assert!(matches!(output, Err(Error::Preempted(_))));
+}

--- a/crates/irlume-cli/src/trace.rs
+++ b/crates/irlume-cli/src/trace.rs
@@ -6,7 +6,8 @@
 use irlume_common::artifact::SecureArtifact;
 use irlume_common::diagnostics::{
     parse_trace, TraceEventKind, TraceLimits, TraceRecord, TraceValidator,
-    DEFAULT_TRACE_DURATION_MS, MAX_TRACE_BYTES, MAX_TRACE_DURATION_MS, MAX_TRACE_LINE_BYTES,
+    CURRENT_TRACE_SCHEMA_VERSION, DEFAULT_TRACE_DURATION_MS, MAX_TRACE_BYTES,
+    MAX_TRACE_DURATION_MS, MAX_TRACE_LINE_BYTES,
 };
 use irlume_common::{Request, Response};
 use std::collections::BTreeMap;
@@ -68,6 +69,7 @@ fn record(output: &Path, duration: Duration) -> Result<PathBuf, String> {
         .map_err(|error| format!("connect: {error}"))?;
     let mut request = serde_json::to_vec(&Request::TraceSubscribe {
         duration_ms: requested_ms,
+        trace_schema: Some(CURRENT_TRACE_SCHEMA_VERSION),
     })
     .map_err(|error| format!("encode request: {error}"))?;
     request.push(b'\n');
@@ -338,7 +340,16 @@ fn render_timeline(records: &[TraceRecord]) -> String {
     }
 
     let mut output = String::new();
-    writeln!(output, "Irlume diagnostic trace schema 1").unwrap();
+    if let Some(record) = records.first() {
+        writeln!(
+            output,
+            "Irlume diagnostic trace schema {}",
+            record.trace_schema
+        )
+        .unwrap();
+    } else {
+        writeln!(output, "Irlume diagnostic trace (empty)").unwrap();
+    }
     writeln!(output, "Records: {}", records.len()).unwrap();
     writeln!(output, "Events dropped before recording: {dropped}").unwrap();
     for (operation_id, operation_records) in by_operation {
@@ -414,6 +425,11 @@ mod tests {
             serde_json::from_str::<Request>(&request_line).unwrap(),
             Request::TraceSubscribe { .. }
         ));
+        let requested: serde_json::Value = serde_json::from_str(&request_line).unwrap();
+        assert_eq!(
+            requested["TraceSubscribe"]["trace_schema"], 2,
+            "current CLI must negotiate the richer trace vocabulary"
+        );
         serde_json::to_writer(&mut stream, &Response::TraceAccepted { limits }).unwrap();
         stream.write_all(b"\n").unwrap();
         for record in records {
@@ -558,5 +574,158 @@ mod tests {
             .filter(|entry| entry.file_name().to_string_lossy().contains(".partial."))
             .count();
         assert_eq!(partials, 1);
+    }
+
+    #[test]
+    fn new_recorder_accepts_legacy_daemon_and_current_daemon_streams() {
+        let _guard = crate::testenv::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        for schema in [1, 2] {
+            let dir = sandbox("negotiated");
+            let socket = dir.join("daemon.sock");
+            let target = dir.join("capture.jsonl");
+            let limits = TraceLimits::bounded(10);
+            let mut records = vec![
+                fixture_record(
+                    0,
+                    TraceEventKind::TraceStarted {
+                        limits,
+                        warning: TraceWarning::PrivilegedDiagnosticOracle,
+                    },
+                    false,
+                ),
+                fixture_record(
+                    1,
+                    TraceEventKind::Finished {
+                        outcome: CategoricalOutcome::Completed,
+                    },
+                    true,
+                ),
+            ];
+            for record in &mut records {
+                record.trace_schema = schema;
+            }
+            let listener = UnixListener::bind(&socket).unwrap();
+            let server = std::thread::spawn(move || serve_fixture(listener, limits, records));
+            let previous = std::env::var_os("IRLUME_SOCKET");
+            std::env::set_var("IRLUME_SOCKET", &socket);
+            let published = record(&target, Duration::from_millis(10));
+            match previous {
+                Some(value) => std::env::set_var("IRLUME_SOCKET", value),
+                None => std::env::remove_var("IRLUME_SOCKET"),
+            }
+            server.join().unwrap();
+            assert_eq!(published.unwrap(), target);
+            let parsed = parse_trace(
+                BufReader::new(std::fs::File::open(&target).unwrap()),
+                limits,
+            )
+            .unwrap();
+            assert!(parsed
+                .records()
+                .iter()
+                .all(|record| record.trace_schema == schema));
+            assert!(render_timeline(parsed.records())
+                .starts_with(&format!("Irlume diagnostic trace schema {schema}\n")));
+            std::fs::remove_dir_all(dir).unwrap();
+        }
+    }
+
+    #[test]
+    fn invalid_version_stream_never_publishes_or_persists_the_bad_record() {
+        use irlume_common::diagnostics::TraceRefusalReason;
+        let _guard = crate::testenv::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        for mislabeled_event in [false, true] {
+            let dir = sandbox("schema-refusal");
+            let socket = dir.join("daemon.sock");
+            let target = dir.join("capture.jsonl");
+            let limits = TraceLimits::bounded(10);
+            let mut started = fixture_record(
+                0,
+                TraceEventKind::TraceStarted {
+                    limits,
+                    warning: TraceWarning::PrivilegedDiagnosticOracle,
+                },
+                false,
+            );
+            started.trace_schema = 1;
+            let mut invalid = fixture_record(
+                1,
+                if mislabeled_event {
+                    TraceEventKind::AuthenticationRefusal {
+                        reason: TraceRefusalReason::RgbPadPending,
+                    }
+                } else {
+                    TraceEventKind::Finished {
+                        outcome: CategoricalOutcome::Completed,
+                    }
+                },
+                !mislabeled_event,
+            );
+            invalid.trace_schema = if mislabeled_event { 1 } else { 2 };
+            let listener = UnixListener::bind(&socket).unwrap();
+            let server =
+                std::thread::spawn(move || serve_fixture(listener, limits, vec![started, invalid]));
+            let previous = std::env::var_os("IRLUME_SOCKET");
+            std::env::set_var("IRLUME_SOCKET", &socket);
+            let result = record(&target, Duration::from_millis(10));
+            match previous {
+                Some(value) => std::env::set_var("IRLUME_SOCKET", value),
+                None => std::env::remove_var("IRLUME_SOCKET"),
+            }
+            server.join().unwrap();
+            assert!(result.unwrap_err().contains("unsupported trace schema"));
+            assert!(!target.exists());
+            let partial = std::fs::read_dir(&dir)
+                .unwrap()
+                .filter_map(Result::ok)
+                .find(|entry| entry.file_name().to_string_lossy().contains(".partial."))
+                .unwrap();
+            let bytes = std::fs::read_to_string(partial.path()).unwrap();
+            assert_eq!(
+                bytes.lines().count(),
+                1,
+                "only validated records may be persisted"
+            );
+            std::fs::remove_dir_all(dir).unwrap();
+        }
+    }
+
+    #[test]
+    fn explanation_renders_v2_refusal_and_stage_labels_without_raw_reason_text() {
+        use irlume_common::diagnostics::{TraceRefusalReason, TraceStage};
+        let records = vec![
+            fixture_record(
+                0,
+                TraceEventKind::AuthenticationRefusal {
+                    reason: TraceRefusalReason::RgbPadPending,
+                },
+                false,
+            ),
+            fixture_record(
+                1,
+                TraceEventKind::StageTiming {
+                    stage: TraceStage::IdentityInference,
+                    elapsed_us: 12,
+                },
+                false,
+            ),
+            fixture_record(
+                2,
+                TraceEventKind::StageTiming {
+                    stage: TraceStage::StreamOwnerRelease,
+                    elapsed_us: 13,
+                },
+                false,
+            ),
+        ];
+        let rendered = render_timeline(&records);
+        assert!(rendered.starts_with("Irlume diagnostic trace schema 2\n"));
+        assert!(rendered.contains("AuthenticationRefusal { reason: RgbPadPending }"));
+        assert!(rendered.contains("IdentityInference"));
+        assert!(rendered.contains("StreamOwnerRelease"));
     }
 }

--- a/crates/irlume-common/src/diagnostics.rs
+++ b/crates/irlume-common/src/diagnostics.rs
@@ -12,7 +12,12 @@ pub const MAX_SHARE_SAFE_EVENTS: usize = 256;
 pub const MAX_SANITIZED_CAMERAS: usize = 8;
 pub const MAX_UNAVAILABLE_SECTIONS: usize = 16;
 pub const MAX_HISTORY_MS: u64 = 30 * 60 * 1_000;
-pub const TRACE_SCHEMA_VERSION: u32 = 1;
+/// The schema selected when a subscriber does not request a version.
+pub const LEGACY_TRACE_SCHEMA_VERSION: u32 = 1;
+/// Latest trace vocabulary, requested explicitly by current clients.
+pub const CURRENT_TRACE_SCHEMA_VERSION: u32 = 2;
+/// Current schema for callers constructing new records, not a subscription default.
+pub const TRACE_SCHEMA_VERSION: u32 = CURRENT_TRACE_SCHEMA_VERSION;
 pub const DEFAULT_TRACE_DURATION_MS: u64 = 60_000;
 pub const MAX_TRACE_DURATION_MS: u64 = 5 * 60_000;
 pub const MAX_TRACE_EVENTS: u64 = 50_000;
@@ -694,8 +699,22 @@ diagnostic_enum!(TraceStage {
     IrCapture,
     Detection,
     Liveness,
+    IdentityInference,
+    StreamOwnerRelease,
     Matching,
     EmitterRestore,
+});
+diagnostic_enum!(TraceRefusalReason {
+    RgbPadPending,
+    NoFace,
+    Uncertain,
+    SpoofNoIrFace,
+    Spoof,
+    BelowThreshold,
+    SetupUnavailable,
+    DeadlineExpired,
+    RuntimeUnavailable,
+    OtherDeny,
 });
 diagnostic_enum!(TraceMetric {
     DeliveredFramesPerSecond,
@@ -816,12 +835,35 @@ pub enum TraceEventKind {
         verdict: TraceVerdict,
         measurements: Vec<TraceMeasurement>,
     },
+    AuthenticationRefusal {
+        reason: TraceRefusalReason,
+    },
     EventsDropped {
         count: u64,
     },
     Finished {
         outcome: CategoricalOutcome,
     },
+}
+
+impl TraceEventKind {
+    /// Whether this closed event vocabulary is available in the selected
+    /// schema. Legacy subscribers omit newer events before queue accounting.
+    #[must_use]
+    pub const fn supports_schema(&self, schema: u32) -> bool {
+        match schema {
+            LEGACY_TRACE_SCHEMA_VERSION => !matches!(
+                self,
+                Self::AuthenticationRefusal { .. }
+                    | Self::StageTiming {
+                        stage: TraceStage::IdentityInference | TraceStage::StreamOwnerRelease,
+                        ..
+                    }
+            ),
+            CURRENT_TRACE_SCHEMA_VERSION => true,
+            _ => false,
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -849,6 +891,7 @@ pub struct TraceValidator {
     total_bytes: u64,
     records: u64,
     terminal_seen: bool,
+    trace_schema: Option<u32>,
 }
 
 impl TraceValidator {
@@ -866,6 +909,7 @@ impl TraceValidator {
             total_bytes: 0,
             records: 0,
             terminal_seen: false,
+            trace_schema: None,
         })
     }
 
@@ -891,13 +935,18 @@ impl TraceValidator {
             return Err(TraceParseError::Terminal);
         }
         let record: TraceRecord = serde_json::from_slice(line).map_err(TraceParseError::Json)?;
-        if record.trace_schema != TRACE_SCHEMA_VERSION {
+        if !record.event.supports_schema(record.trace_schema)
+            || self
+                .trace_schema
+                .is_some_and(|schema| schema != record.trace_schema)
+        {
             return Err(TraceParseError::Schema);
         }
         if record.sequence != self.records {
             return Err(TraceParseError::Sequence);
         }
         validate_trace_event(&record.event)?;
+        self.trace_schema = Some(record.trace_schema);
         self.terminal_seen = record.terminal;
         if record.terminal && !matches!(record.event, TraceEventKind::Finished { .. }) {
             return Err(TraceParseError::Terminal);
@@ -1411,6 +1460,111 @@ mod tests {
             bytes.push(b'\n');
         }
         bytes
+    }
+
+    #[test]
+    fn trace_subscription_preserves_explicit_schema_and_legacy_omission() {
+        let legacy = serde_json::json!({"TraceSubscribe": {"duration_ms": 1000}});
+        let request: Request = serde_json::from_value(legacy.clone()).unwrap();
+        assert_eq!(serde_json::to_value(request).unwrap(), legacy);
+        for schema in [1, 2, 99] {
+            let wire = serde_json::json!({
+                "TraceSubscribe": {"duration_ms": 1000, "trace_schema": schema}
+            });
+            let request: Request = serde_json::from_value(wire.clone()).unwrap();
+            assert_eq!(serde_json::to_value(request).unwrap(), wire);
+        }
+    }
+
+    #[test]
+    fn trace_parser_accepts_both_wire_versions_but_never_mixes_them() {
+        let limits = TraceLimits::bounded(1000);
+        let mut records = vec![
+            trace_record(
+                0,
+                TraceEventKind::TraceStarted {
+                    limits,
+                    warning: TraceWarning::PrivilegedDiagnosticOracle,
+                },
+                false,
+            ),
+            trace_record(
+                1,
+                TraceEventKind::Finished {
+                    outcome: CategoricalOutcome::Completed,
+                },
+                true,
+            ),
+        ];
+        for schema in [1, 2] {
+            for record in &mut records {
+                record.trace_schema = schema;
+            }
+            assert!(
+                parse_trace(std::io::Cursor::new(trace_jsonl(&records)), limits).is_ok(),
+                "valid schema {schema} must remain readable"
+            );
+            records[1].trace_schema = if schema == 1 { 2 } else { 1 };
+            assert!(matches!(
+                parse_trace(std::io::Cursor::new(trace_jsonl(&records)), limits),
+                Err(TraceParseError::Schema)
+            ));
+        }
+        for schema in [0, 3, u32::MAX] {
+            records[0].trace_schema = schema;
+            assert!(matches!(
+                parse_trace(std::io::Cursor::new(trace_jsonl(&records)), limits),
+                Err(TraceParseError::Schema)
+            ));
+        }
+    }
+
+    #[test]
+    fn trace_v2_closed_refusals_and_timings_are_not_valid_v1_records() {
+        let limits = TraceLimits::bounded(1000);
+        let mut events = vec![
+            serde_json::json!({"event":"stage_timing", "stage":"identity_inference", "elapsed_us":12}),
+            serde_json::json!({"event":"stage_timing", "stage":"stream_owner_release", "elapsed_us":13}),
+        ];
+        for reason in [
+            "rgb_pad_pending",
+            "no_face",
+            "uncertain",
+            "spoof_no_ir_face",
+            "spoof",
+            "below_threshold",
+            "setup_unavailable",
+            "deadline_expired",
+            "runtime_unavailable",
+            "other_deny",
+        ] {
+            events.push(serde_json::json!({"event":"authentication_refusal", "reason":reason}));
+        }
+        for event in events {
+            let typed = serde_json::from_value::<TraceEventKind>(event.clone())
+                .expect("schema 2 closed event vocabulary must deserialize");
+            assert_eq!(serde_json::to_value(&typed).unwrap(), event);
+            for schema in [1, 2] {
+                let mut record = trace_record(0, typed.clone(), false);
+                record.trace_schema = schema;
+                let mut validator = TraceValidator::new(limits).unwrap();
+                let result = validator.push_line(&serde_json::to_vec(&record).unwrap());
+                assert_eq!(result.is_ok(), schema == 2, "{event} under schema {schema}");
+                if schema == 1 {
+                    assert!(matches!(result, Err(TraceParseError::Schema)));
+                }
+            }
+        }
+        for reason in [
+            serde_json::json!("unrestricted prose"),
+            serde_json::json!(5),
+            serde_json::Value::Null,
+        ] {
+            assert!(serde_json::from_value::<TraceEventKind>(serde_json::json!({
+                "event":"authentication_refusal", "reason":reason,
+            }))
+            .is_err());
+        }
     }
 
     #[test]

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -692,7 +692,13 @@ pub enum Request {
     /// Explicit root-only bounded camera probe for a support report.
     SupportProbe { since_ms: u64 },
     /// Root-only subscription to one bounded daemon-authored diagnostic trace.
-    TraceSubscribe { duration_ms: u64 },
+    TraceSubscribe {
+        duration_ms: u64,
+        /// Omission selects legacy trace schema 1. Unsupported explicit
+        /// versions are refused by the daemon before subscription.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        trace_schema: Option<u32>,
+    },
     /// Liveness/health ping.
     Ping,
     /// Daemon self-report: what it actually has loaded and which camera tier it

--- a/crates/irlume-daemon/src/diagnostics.rs
+++ b/crates/irlume-daemon/src/diagnostics.rs
@@ -6,8 +6,8 @@
 use irlume_common::diagnostics::{
     CaptureStatus, CategoricalOutcome, DiagnosticSink, OperationClass, OperationId,
     SanitizedCameraContext, ShareSafeEvent, ShareSafeEventKind, SupportSnapshot, TraceEventKind,
-    TraceLimits, TraceRecord, TraceWarning, MAX_HISTORY_MS, MAX_SHARE_SAFE_EVENTS,
-    MAX_TRACE_LINE_BYTES, TRACE_SCHEMA_VERSION,
+    TraceLimits, TraceRecord, TraceWarning, CURRENT_TRACE_SCHEMA_VERSION,
+    LEGACY_TRACE_SCHEMA_VERSION, MAX_HISTORY_MS, MAX_SHARE_SAFE_EVENTS, MAX_TRACE_LINE_BYTES,
 };
 use sha2::{Digest as _, Sha256};
 use std::collections::VecDeque;
@@ -55,6 +55,7 @@ struct TraceSubscriber {
     inner: Mutex<TraceInner>,
     limits: TraceLimits,
     started_ms: u64,
+    trace_schema: u32,
 }
 
 struct TraceInner {
@@ -74,6 +75,7 @@ pub(crate) struct TraceSubscription {
 pub(crate) enum TraceSubscribeError {
     NotRoot,
     Busy,
+    UnsupportedSchema,
 }
 
 #[derive(Default)]
@@ -175,18 +177,32 @@ impl DiagnosticState {
         &self,
         peer_uid: u32,
         duration_ms: u64,
+        trace_schema: Option<u32>,
     ) -> Result<TraceSubscription, TraceSubscribeError> {
-        self.subscribe_trace_with_capacity(peer_uid, duration_ms, TRACE_CHANNEL_CAPACITY)
+        self.subscribe_trace_with_capacity(
+            peer_uid,
+            duration_ms,
+            trace_schema,
+            TRACE_CHANNEL_CAPACITY,
+        )
     }
 
     fn subscribe_trace_with_capacity(
         &self,
         peer_uid: u32,
         duration_ms: u64,
+        trace_schema: Option<u32>,
         capacity: usize,
     ) -> Result<TraceSubscription, TraceSubscribeError> {
         if peer_uid != 0 {
             return Err(TraceSubscribeError::NotRoot);
+        }
+        let trace_schema = trace_schema.unwrap_or(LEGACY_TRACE_SCHEMA_VERSION);
+        if !matches!(
+            trace_schema,
+            LEGACY_TRACE_SCHEMA_VERSION | CURRENT_TRACE_SCHEMA_VERSION
+        ) {
+            return Err(TraceSubscribeError::UnsupportedSchema);
         }
         let mut active = self
             .shared
@@ -209,6 +225,7 @@ impl DiagnosticState {
             }),
             limits,
             started_ms: monotonic_ms(),
+            trace_schema,
         });
         *active = Some(Arc::downgrade(&subscriber));
         drop(active);
@@ -319,6 +336,11 @@ impl DiagnosticState {
 
 impl TraceSubscriber {
     fn emit(&self, operation_id: OperationId, operation: OperationClass, kind: TraceEventKind) {
+        // Vocabulary negotiation is not backpressure: omitted newer events
+        // must not occupy capacity, flush drop markers, or consume sequence IDs.
+        if !kind.supports_schema(self.trace_schema) {
+            return;
+        }
         let mut inner = self
             .inner
             .lock()
@@ -403,7 +425,7 @@ impl TraceSubscriber {
     ) -> TraceRecord {
         let monotonic_ms = monotonic_ms();
         TraceRecord {
-            trace_schema: TRACE_SCHEMA_VERSION,
+            trace_schema: self.trace_schema,
             sequence,
             monotonic_us: monotonic_ms
                 .saturating_sub(self.started_ms)
@@ -731,22 +753,150 @@ mod tests {
     fn trace_subscription_is_root_only_and_single_owner() {
         let state = DiagnosticState::default();
         assert!(matches!(
-            state.subscribe_trace(1_000, 60_000),
+            state.subscribe_trace(1_000, 60_000, None),
             Err(TraceSubscribeError::NotRoot)
         ));
-        let subscription = state.subscribe_trace(0, 60_000).unwrap();
+        let subscription = state.subscribe_trace(0, 60_000, None).unwrap();
         assert!(matches!(
-            state.subscribe_trace(0, 60_000),
+            state.subscribe_trace(0, 60_000, None),
             Err(TraceSubscribeError::Busy)
         ));
         drop(subscription);
-        assert!(state.subscribe_trace(0, 60_000).is_ok());
+        assert!(state.subscribe_trace(0, 60_000, None).is_ok());
+    }
+
+    #[test]
+    fn trace_negotiation_defaults_to_legacy_and_rejects_unknown_versions_without_ownership() {
+        let state = DiagnosticState::default();
+        for unsupported in [0, 3, u32::MAX] {
+            assert!(matches!(
+                state.subscribe_trace(0, 60_000, Some(unsupported)),
+                Err(TraceSubscribeError::UnsupportedSchema)
+            ));
+        }
+        for (requested, expected) in [(None, 1), (Some(1), 1), (Some(2), 2)] {
+            let subscription = state.subscribe_trace(0, 60_000, requested).unwrap();
+            let mut records: Vec<_> = subscription.receiver.try_iter().collect();
+            records.extend(subscription.finish(CategoricalOutcome::Completed));
+            assert_eq!(records.len(), 2);
+            assert!(records.iter().all(|record| record.trace_schema == expected));
+        }
+    }
+
+    #[test]
+    fn modern_trace_delivers_refusal_and_identity_release_timings() {
+        use irlume_common::diagnostics::{TraceRefusalReason, TraceStage};
+        let state = DiagnosticState::default();
+        let subscription = state.subscribe_trace(0, 60_000, Some(2)).unwrap();
+        let operation = state.begin(OperationClass::Authentication);
+        let expected = [
+            TraceEventKind::AuthenticationRefusal {
+                reason: TraceRefusalReason::RgbPadPending,
+            },
+            TraceEventKind::StageTiming {
+                stage: TraceStage::IdentityInference,
+                elapsed_us: 12,
+            },
+            TraceEventKind::StageTiming {
+                stage: TraceStage::StreamOwnerRelease,
+                elapsed_us: 34,
+            },
+        ];
+        for event in &expected {
+            operation.emit_trace(event.clone());
+        }
+        let mut records: Vec<_> = subscription.receiver.try_iter().collect();
+        records.extend(subscription.finish(CategoricalOutcome::Completed));
+        assert_eq!(records.len(), 5);
+        assert!(records.iter().all(|record| record.trace_schema == 2));
+        for (record, expected) in records[1..4].iter().zip(expected) {
+            assert_eq!(record.event, expected);
+            assert_eq!(record.operation_id, operation.operation_id);
+            assert_eq!(record.operation, OperationClass::Authentication);
+        }
+        assert!(records
+            .iter()
+            .enumerate()
+            .all(|(index, record)| record.sequence == index as u64));
+        assert!(records.last().unwrap().terminal);
+    }
+
+    #[test]
+    fn legacy_trace_omits_new_events_before_queue_drop_and_sequence_accounting() {
+        use irlume_common::diagnostics::{TraceRefusalReason, TraceStage};
+        let state = DiagnosticState::default();
+        // The initial record fills this queue. New vocabulary must neither
+        // consume capacity nor be misreported as a lost legacy record.
+        let subscription = state
+            .subscribe_trace_with_capacity(0, 60_000, None, 1)
+            .unwrap();
+        let operation = state.begin(OperationClass::Authentication);
+        for _ in 0..100 {
+            operation.emit_trace(TraceEventKind::AuthenticationRefusal {
+                reason: TraceRefusalReason::RgbPadPending,
+            });
+            for stage in [
+                TraceStage::IdentityInference,
+                TraceStage::StreamOwnerRelease,
+            ] {
+                operation.emit_trace(TraceEventKind::StageTiming {
+                    stage,
+                    elapsed_us: 12,
+                });
+            }
+        }
+        let mut records: Vec<_> = subscription.receiver.try_iter().collect();
+        // Ordinary events still take the next sequence and remain deliverable.
+        operation.emit(selected());
+        records.extend(subscription.receiver.try_iter());
+        records.extend(subscription.finish(CategoricalOutcome::Completed));
+        assert_eq!(records.len(), 3);
+        assert!(records.iter().all(|record| record.trace_schema == 1));
+        assert!(matches!(records[1].event, TraceEventKind::Shared { .. }));
+        assert!(records
+            .iter()
+            .enumerate()
+            .all(|(index, record)| record.sequence == index as u64));
+        assert!(!records
+            .iter()
+            .any(|record| matches!(record.event, TraceEventKind::EventsDropped { .. })));
+        assert!(records.last().unwrap().terminal);
+    }
+
+    #[test]
+    fn legacy_trace_omissions_do_not_flush_or_inflate_real_pending_drops() {
+        use irlume_common::diagnostics::TraceRefusalReason;
+        let state = DiagnosticState::default();
+        let subscription = state
+            .subscribe_trace_with_capacity(0, 60_000, None, 1)
+            .unwrap();
+        let operation = state.begin(OperationClass::Authentication);
+        operation.emit(selected()); // one real event lost while trace_started fills the queue
+        let mut records: Vec<_> = subscription.receiver.try_iter().collect();
+        for _ in 0..100 {
+            operation.emit_trace(TraceEventKind::AuthenticationRefusal {
+                reason: TraceRefusalReason::RgbPadPending,
+            });
+        }
+        assert!(
+            subscription.receiver.try_iter().next().is_none(),
+            "filtered vocabulary must not flush a pending legacy drop marker"
+        );
+        records.extend(subscription.finish(CategoricalOutcome::Completed));
+        assert_eq!(records.len(), 3);
+        assert!(matches!(
+            records[1].event,
+            TraceEventKind::EventsDropped { count: 1 }
+        ));
+        assert_eq!(records[2].sequence, 2);
     }
 
     #[test]
     fn slow_trace_reader_never_blocks_producers_and_gets_an_explicit_drop_marker() {
         let state = DiagnosticState::default();
-        let subscription = state.subscribe_trace_with_capacity(0, 60_000, 2).unwrap();
+        let subscription = state
+            .subscribe_trace_with_capacity(0, 60_000, None, 2)
+            .unwrap();
         let operation = state.begin(OperationClass::Authentication);
         let started = std::time::Instant::now();
         for _ in 0..10_000 {
@@ -779,7 +929,7 @@ mod tests {
     #[test]
     fn trace_projects_share_safe_events_with_the_originating_operation_id() {
         let state = DiagnosticState::default();
-        let subscription = state.subscribe_trace(0, 60_000).unwrap();
+        let subscription = state.subscribe_trace(0, 60_000, None).unwrap();
         let operation = state.begin(OperationClass::Enrollment);
         operation.emit(selected());
         operation.finish(CategoricalOutcome::Completed);

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -2792,11 +2792,21 @@ fn serve_peer(
             // camera operation. Serve it on this connection thread before
             // model readiness and before the arbiter so subscribing can never
             // queue behind, cancel, or take ownership from authentication.
-            if let Request::TraceSubscribe { duration_ms } = &req {
+            if let Request::TraceSubscribe {
+                duration_ms,
+                trace_schema,
+            } = &req
+            {
                 if let Some(resp) = pregate(&req, &peer) {
                     return respond(stream, &resp);
                 }
-                return serve_trace(stream, diagnostic_state, peer.uid, *duration_ms);
+                return serve_trace(
+                    stream,
+                    diagnostic_state,
+                    peer.uid,
+                    *duration_ms,
+                    *trace_schema,
+                );
             }
             // The recent-event ring and saved sensor policy exist independently
             // of model/camera readiness. Keep those observations available during
@@ -2964,8 +2974,9 @@ fn serve_trace(
     diagnostic_state: &diagnostics::DiagnosticState,
     peer_uid: u32,
     duration_ms: u64,
+    trace_schema: Option<u32>,
 ) -> std::io::Result<()> {
-    let subscription = match diagnostic_state.subscribe_trace(peer_uid, duration_ms) {
+    let subscription = match diagnostic_state.subscribe_trace(peer_uid, duration_ms, trace_schema) {
         Ok(subscription) => subscription,
         Err(diagnostics::TraceSubscribeError::NotRoot) => {
             return respond(
@@ -2977,6 +2988,12 @@ fn serve_trace(
             return respond(
                 stream,
                 &Response::Error("a diagnostic trace is already active".into()),
+            );
+        }
+        Err(diagnostics::TraceSubscribeError::UnsupportedSchema) => {
+            return respond(
+                stream,
+                &Response::Error("unsupported diagnostic trace schema".into()),
             );
         }
     };
@@ -7662,7 +7679,7 @@ mod tests {
         CameraDiagnostics => Request::CameraDiagnostics,
         SupportSnapshot => Request::SupportSnapshot { since_ms: 60_000 },
         SupportProbe => Request::SupportProbe { since_ms: 60_000 },
-        TraceSubscribe => Request::TraceSubscribe { duration_ms: 60_000 },
+        TraceSubscribe => Request::TraceSubscribe { duration_ms: 60_000, trace_schema: None },
         // The user-bearing form, so the traversal walk covers it.
         PositionSample => Request::PositionSample { user: Some(u()) },
         PositionSession => Request::PositionSession { user: Some(u()) },
@@ -9722,32 +9739,57 @@ mod tests {
 
     #[test]
     fn trace_stream_acknowledges_bounds_then_emits_a_complete_parseable_jsonl_trace() {
+        for (requested, expected) in [(None, 1), (Some(1), 1), (Some(2), 2)] {
+            let (server, mut client) = UnixStream::pair().unwrap();
+            let state = diagnostics::DiagnosticState::default();
+            let limits = irlume_common::diagnostics::TraceLimits::bounded(1);
+            let thread =
+                std::thread::spawn(move || serve_trace(server, &state, 0, 1, requested).unwrap());
+
+            let mut payload = String::new();
+            client.read_to_string(&mut payload).unwrap();
+            thread.join().unwrap();
+            let (accepted, trace) = payload.split_once('\n').unwrap();
+            assert!(matches!(
+                serde_json::from_str::<Response>(accepted).unwrap(),
+                Response::TraceAccepted { limits: actual } if actual == limits
+            ));
+            let parsed = irlume_common::diagnostics::parse_trace(
+                std::io::BufReader::new(trace.as_bytes()),
+                limits,
+            )
+            .unwrap();
+            assert!(matches!(
+                parsed.records().first(),
+                Some(irlume_common::diagnostics::TraceRecord {
+                    event: irlume_common::diagnostics::TraceEventKind::TraceStarted { .. },
+                    ..
+                })
+            ));
+            assert!(parsed.records().last().unwrap().terminal);
+            assert!(parsed
+                .records()
+                .iter()
+                .all(|record| record.trace_schema == expected));
+        }
+    }
+
+    #[test]
+    fn trace_stream_rejects_unsupported_schema_before_acceptance() {
         let (server, mut client) = UnixStream::pair().unwrap();
         let state = diagnostics::DiagnosticState::default();
-        let limits = irlume_common::diagnostics::TraceLimits::bounded(1);
-        let thread = std::thread::spawn(move || serve_trace(server, &state, 0, 1).unwrap());
-
+        let thread = std::thread::spawn(move || {
+            serve_trace(server, &state, 0, 1, Some(99)).unwrap();
+            assert!(state.subscribe_trace(0, 1, Some(2)).is_ok());
+        });
         let mut payload = String::new();
         client.read_to_string(&mut payload).unwrap();
         thread.join().unwrap();
-        let (accepted, trace) = payload.split_once('\n').unwrap();
+        assert_eq!(payload.lines().count(), 1);
         assert!(matches!(
-            serde_json::from_str::<Response>(accepted).unwrap(),
-            Response::TraceAccepted { limits: actual } if actual == limits
+            serde_json::from_str::<Response>(payload.trim()).unwrap(),
+            Response::Error(message) if message == "unsupported diagnostic trace schema"
         ));
-        let parsed = irlume_common::diagnostics::parse_trace(
-            std::io::BufReader::new(trace.as_bytes()),
-            limits,
-        )
-        .unwrap();
-        assert!(matches!(
-            parsed.records().first(),
-            Some(irlume_common::diagnostics::TraceRecord {
-                event: irlume_common::diagnostics::TraceEventKind::TraceStarted { .. },
-                ..
-            })
-        ));
-        assert!(parsed.records().last().unwrap().terminal);
     }
 
     #[test]

--- a/crates/irlume-daemon/src/retry_throttle.rs
+++ b/crates/irlume-daemon/src/retry_throttle.rs
@@ -479,6 +479,7 @@ impl Store {
             match outcome.kind {
                 OutcomeKind::NoFace
                 | OutcomeKind::Uncertain
+                | OutcomeKind::RgbPadPending
                 | OutcomeKind::SpoofNoIrFace
                 | OutcomeKind::SetupUnavailable => return Ok(()),
                 OutcomeKind::Granted
@@ -604,6 +605,7 @@ impl FaceAttempt {
         match outcome.kind {
             OutcomeKind::NoFace
             | OutcomeKind::Uncertain
+            | OutcomeKind::RgbPadPending
             | OutcomeKind::SpoofNoIrFace
             | OutcomeKind::SetupUnavailable => (),
             OutcomeKind::Granted

--- a/crates/irlume-daemon/src/retry_throttle/tests.rs
+++ b/crates/irlume-daemon/src/retry_throttle/tests.rs
@@ -168,6 +168,7 @@ fn rate_throttle_outcome_classes_preserve_rejection_policy() {
         (Kind::Granted, false),
         (Kind::NoFace, false),
         (Kind::Uncertain, false),
+        (Kind::RgbPadPending, false),
         (Kind::SpoofNoIrFace, false),
         (Kind::SetupUnavailable, false),
         (Kind::Spoof, true),
@@ -196,7 +197,11 @@ fn rate_throttle_outcome_classes_preserve_rejection_policy() {
         );
         if matches!(
             kind,
-            Kind::NoFace | Kind::Uncertain | Kind::SpoofNoIrFace | Kind::SetupUnavailable
+            Kind::NoFace
+                | Kind::Uncertain
+                | Kind::RgbPadPending
+                | Kind::SpoofNoIrFace
+                | Kind::SetupUnavailable
         ) {
             assert!(
                 !f.path().exists(),
@@ -226,6 +231,54 @@ fn terminal_diagnostic_classes_preserve_existing_other_deny_accounting() {
             assert_eq!(old.check(), classified.check());
         }
     }
+}
+
+#[test]
+fn pending_pad_preserves_uncertain_strikes_and_cumulative_request_charge() {
+    for strikes in [0, 2, 3] {
+        let old = Fixture::new();
+        let pending = Fixture::new();
+        for _ in 0..strikes {
+            old.record(Kind::Spoof);
+            pending.record(Kind::Spoof);
+        }
+        old.record(Kind::Uncertain);
+        pending.record(Kind::RgbPadPending);
+        if strikes == 0 {
+            assert!(!old.path().exists() && !pending.path().exists());
+        } else {
+            assert_eq!(old.bytes(), pending.bytes());
+        }
+        assert_eq!(old.check(), pending.check());
+    }
+    cumulative::TIME.set(100);
+    let old = Fixture::new();
+    let pending = Fixture::new();
+    old.record(Kind::Spoof);
+    pending.record(Kind::Spoof);
+    for count in 1..=50 {
+        cumulative::start_attempt(&old)
+            .unwrap()
+            .unwrap()
+            .denied(&outcome(Kind::Uncertain))
+            .unwrap();
+        cumulative::start_attempt(&pending)
+            .unwrap()
+            .unwrap()
+            .denied(&outcome(Kind::RgbPadPending))
+            .unwrap();
+        assert_eq!(old.bytes(), pending.bytes(), "request {count}");
+        let saved = pending.saved();
+        assert_eq!(
+            saved.strikes, 1,
+            "incomplete PAD neither adds nor clears strikes"
+        );
+        let budget = saved.budget.unwrap();
+        assert_eq!(budget.unsuccessful_requests, count);
+        assert!(!budget.pending);
+    }
+    assert!(cumulative::start_attempt(&old).unwrap().is_none());
+    assert!(cumulative::start_attempt(&pending).unwrap().is_none());
 }
 
 #[test]

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -51,6 +51,31 @@ contain exact liveness and match measurements, but never frames, crops,
 landmarks, embeddings, credentials, account/profile names, or raw emitter
 payloads.
 
+The recorder requests trace schema 2. A current daemon honors explicit schema
+1 or 2; a request without `trace_schema` retains schema 1 for older recorders.
+An older daemon ignores the optional request field and continues producing
+schema 1, which the current reader also accepts. Each stream uses one schema
+throughout; unsupported versions, version changes within a stream and
+schema-2-only events marked as schema 1 are rejected.
+
+Schema 2 adds `identity_inference` and `stream_owner_release` stage timings,
+and an `authentication_refusal` event whose `reason` is one of:
+`rgb_pad_pending`, `no_face`, `uncertain`, `spoof_no_ir_face`, `spoof`,
+`below_threshold`, `setup_unavailable`, `deadline_expired`,
+`runtime_unavailable`, or `other_deny`. These are fixed labels, with no raw
+reason text, account names or matching measurements. `rgb_pad_pending` means
+that the existing RGB PAD vote is incomplete; it is not an identity mismatch.
+`identity_inference` measures one identity-materialization call, including
+alignment, RGB TTA embedding, IR embedding and adapter application when those
+inputs exist; it is not a count of individual model invocations.
+`stream_owner_release` measures the wall time spent dropping both owned
+streaming sessions, not an observation that the optical emitter is off.
+Neither stage measures first-frame or desktop-unlock latency. The internal
+pending-PAD distinction preserves the existing client reason, situation,
+presence-retry and account-throttling behavior. Schema 1 subscribers omit
+these new records before queue, sequence and drop accounting, so the omission
+does not generate `events_dropped`.
+
 For a public issue, start with `irlume support-report`. Its default action is
 read-only and camera-free, and its `.txt` output is structurally share-safe and
 meant to be inspected before sharing. `support-report --probe` is a separate

--- a/docs/adr/0008-privacy-bounded-diagnostics.md
+++ b/docs/adr/0008-privacy-bounded-diagnostics.md
@@ -171,6 +171,16 @@ consumer. Event emission is a non-blocking side channel with a bounded queue.
 Losing trace events can reduce diagnostic completeness but cannot affect an
 authentication result, camera lease, emitter restoration, or fallback.
 
+Trace schema 2 is explicitly negotiated with the optional `trace_schema`
+subscription field. Omission selects legacy schema 1; unsupported requests are
+refused. Current readers accept either version and require a single version
+throughout the stream. Schema 2 adds closed authentication-refusal labels and
+identity-inference / stream-owner-release timings; schema 1 subscribers filter
+these additions before queue capacity, sequence and dropped-event accounting.
+The unchanged acceptance response reports bounds, while each trace record,
+including `trace_started`, identifies the negotiated version. An older daemon
+can ignore the optional request field and continue emitting schema 1.
+
 Exact match and liveness measurements are permitted only in the root-owned
 trace because they can provide iterative feedback to an attacker. The trace
 header warns about that oracle. Frames, crops, landmarks, embeddings,

--- a/docs/adr/0020-managed-concurrent-pad-collection.md
+++ b/docs/adr/0020-managed-concurrent-pad-collection.md
@@ -1,0 +1,83 @@
+# ADR-0020: Service concurrent camera queues while collecting PAD evidence
+
+**Status:** Proposed; implementation and hardware validation in progress
+**Date:** 2026-09-11
+**Related:** [ADR-0013](0013-ship-pad-models-default-on.md),
+[ADR-0014](0014-schedule-aware-pairing-budget.md),
+[ADR-0019](0019-fail-closed-pad-availability.md)
+
+## Context
+
+RGB PAD requires five fresh scores before its median can support admission.
+Ordinary concurrent authentication opens new streams and establishes their
+delivery rate for each retry. In the September 11 ASUS experiment, individual
+rate establishment intervals were about 3.13 seconds. Neither tested ordinary
+concurrent revision completed the required evidence within its request budget.
+Deferring unnecessary identity work alone did not establish a login speedup.
+
+Holding streaming sessions across inference avoids repeated startup work only
+if their queues continue to be consumed. Idle queues can overflow and invalidate
+delivery evidence. Alternating blocking reads can also throttle the faster
+camera behind its slower companion. Sequential grouped authentication has a
+different capture schedule and admission policy, so its evaluator cannot simply
+be applied to concurrent frames.
+
+## Decision
+
+Keep transport servicing in `irlume-camera` and the bounded evidence collection
+policy in `irlume-auth`. A paired processing operation borrows both held stream
+owners, services each independently on a scoped thread, and runs inference on
+the calling thread. Its transport result contains the processing result; model
+errors do not become camera-degradation events. Every servicing worker joins
+before a result can escape, including after failure or unwinding.
+
+An eligible concurrent login operation opens one pair and establishes its full
+existing rate window. It captures and processes at most five fresh pairs. The
+collector continues only for Live evidence with an eligible RGB face whose PAD
+state is pending. Every sample is qualified once. Any other result ends that
+collection under ordinary outcome precedence. Only the final admissible sample
+is used for identity; the collector does not try later samples for a better
+identity score.
+
+Eligibility requires the live runtime pair contract, enabled IR and both PAD
+models, non-demoted concurrent authority, and the existing login/lock operation
+and grace-window scope. Stored measured concurrent qualification permits
+automatic selection. The existing explicit concurrent override can exercise
+this path under the same runtime validation without changing stored
+qualification. Grouped sequential, IR-only, RGB-only, enrollment and support
+operations retain their separate capture paths.
+
+Identity deferral is confined to this managed collector. Ordinary RGB+IR
+attempts, including sequential fallback and operations outside the eligibility
+scope, retain eager identity materialization before PAD qualification. They
+keep their existing identity-error precedence and retry-cost behavior. The
+earlier experiment that deferred ordinary attempts is not part of this scope.
+
+Every analyzed pair must satisfy the existing runtime contract and concurrent
+pairing rules. Successive acquisition windows must advance without overlap or
+replay; intervening validated discarded frames need not become PAD samples.
+Evidence cannot cross recovery, fallback or requests. Any transport failure,
+including a failure during the final dequeue after successful processing,
+invalidates the prepared result and clears the collection's votes.
+
+Streaming owners are released before final admission. The original request
+deadline applies throughout. The retry estimator measures the complete
+collection, including inference and cleanup, and retains the existing
+sequential fallback cost floor. The rate window, PAD operating points,
+concurrent skew limit and identity thresholds do not change.
+
+## Consequences
+
+- Startup validation may be paid once for several PAD samples, but successful
+  authentication and refusal latency must be measured before claiming a gain.
+- Independent servicing adds two temporary scoped workers during processing.
+  It avoids detached workers and retained queues between requests.
+- A processing callback can mutate pending evidence before a tail failure is
+  known. Authentication must discard that state as well as the returned value;
+  dropping the value alone is insufficient.
+- Cancellation remains cooperative at driver and inference boundaries. Joining
+  workers guarantees ownership cleanup, not forced termination of a blocking
+  model call or a hard cancellation-latency bound.
+- Deterministic transport, provenance, policy and cleanup tests complement
+  attended hardware comparisons. They do not establish camera stability or
+  additional spoof resistance on their own.


### PR DESCRIPTION
## What & why

Concurrent RGB+IR authentication can exhaust its retry budget while the RGB PAD model is still accumulating evidence. This change services one bounded camera pair while collecting up to five fresh PAD samples, then materializes identity for the final admissible sample. Ordinary authentication retains eager identity preparation.

The change carries typed PAD-pending results through the managed path and adds source-bound diagnostic events for collection order, camera ownership and mode selection. Existing liveness decisions, matching thresholds, rate policy and installed sensor policy remain in place. Cancellation and error paths retain bounded collection and camera cleanup. Trace schema 2 is opt-in; omitted version requests retain the existing version-1 stream.

The publication commit `4e24e1c63efea7601637035ce0914036b1952361` has the identical source tree `3ad14d8a024a99fd7d6798168384b11b9842c846` measured as signed candidate `a9a7a4c`.

## Testing

Validation on signed candidate `a9a7a4ce245509d2c819c87006bb9410ffdb8d95`:

- Workspace: 2,308 passed, 107 existing ignored; optional IR: 278 passed, 3 ignored; camera timing: 693 passed, 27 ignored. Suites overlap.
- Formatting, workspace and IR Clippy, workspace and IR documentation checks passed. Scoped behavioral regression tests and independent source reviews passed.
- ASUS UX5406S, charger connected and Balanced mode: complete A-B-B-A-A-B-B-A reference comparison, four candidate grants versus four baseline denials. Candidate median 9.802172 seconds. All four candidate traces support one camera setup, five PAD samples, one final identity materialization and no fallback.
- Separate controls: candidate grouped sequential grant at 12.030978 seconds and IR-only grant at 3.667821 seconds; cancellation released camera ownership and no-face attempts denied. Detailed methods, baselines and limitations are in the accompanying hardware comment.

The reference baseline is `23a8187a` plus diagnostics (`5b056d1`), built with the same locked dependencies and release recipe. Different authentication outcomes prevent a successful-login speedup percentage. An earlier load-rejected series and all pilots remain separate. All 22 started scoped hardware attempts restored the original daemon and all 26 protected files. No installed-policy change is included.

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` clean
- [x] Docs updated: DEBUGGING guide and ADRs 0008/0020
- [x] Hardware-validated on ASUS UX5406S; boundaries and limitations documented
