### PR TITLE
feat(tui): add a live desktop interface and automatic device refresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -489,7 +489,10 @@ jobs:
       # existed to resync drifted version fields, and the 0.7.0 audit found the
       # PPA lane missing the reconcile timer entirely.
       - name: packaging parity (units in every lane, versions agree)
-        run: ./scripts/check-packaging-parity.sh
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends desktop-file-utils
+          ./scripts/check-packaging-parity.sh
 
       # Nothing validated the AppArmor profiles until 0.9.0, and they are the
       # only confinement on the Debian/Ubuntu lane. A profile that fails to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Added
 
+- Application-menu launcher for the TUI, using the desktop's terminal as the
+  normal user, across Fedora, Arch, Debian, PPA, Nix and source installs.
+- TUI Sections chooser (F3), keyboard page controls (F6), theme-aware state
+  badges, and bounded session Activity with timestamps and full wrapped history
+  (Shift+L). First-run guidance and long dialogs support keyboard scrolling.
+- An 80×24 minimum window size, with a resize-only notice and disabled hidden
+  controls below either dimension. Resizing preserves the current page or dialog.
+- Current observations (F4), with live daemon work, queued requests, automatic
+  background qualification, and separate observation ages and failure states.
 - Explicit experimental IR-only policy (`irlume auth sensor ir-only --yes`),
   with dual RGB+IR remaining the default. Requires enrollment-bound IR capture,
   fresh emitter evidence and IR PAD; it does not establish deployment qualification.
@@ -41,6 +50,14 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Fixed
 
+- Refresh TUI camera choices on device changes, reject a switch whose device
+  changed during confirmation, and show failed or expired observations as
+  unavailable. Live daemon worker status remains observable during TUI dialogs.
+- Keep TUI enrollment instructions visible in supported terminal sizes, make Cancel and
+  quit controls clickable, and preserve reading position when Activity reflows.
+- Report TUI worker loss as stale state or an unknown outcome, disclose camera
+  diagnostics capture, and avoid copying unexpected protocol payloads into
+  activity messages. Unknown login wiring no longer appears ready.
 - Make the emitter undo-record regression independent of root permission bypass,
   so the Arch container tests the same save-failure invariant as ordinary CI.
 - Fail release verification on incomplete assets, verify Arch packages alongside

--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ irlume doctor    # what your hardware supports
 irlume tui       # guided enrollment and wiring
 ```
 
+Or open **Irlume** from your application menu. It runs the same TUI as your
+normal user in the terminal selected by your desktop. Privileged changes ask
+for authorization when you choose them. If your desktop cannot select a
+terminal, run `irlume tui` in one you opened yourself.
+
 **You need** x86-64 Linux with systemd and PAM. A TPM 2.0 is strongly recommended.
 Most cameras work and set your tier (an IR node must offer an 8-bit grey format; see [Platforms](docs/PLATFORMS.md)): **IR** → secure login · **RGB** → screen
 unlock · **fingerprint** → companion factor.

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -22,6 +22,7 @@ pub use irlume_camera::capture_qualification::{
     QualificationResolution, QualificationStore, QualificationStoreError, SequentialReason,
 };
 pub use irlume_camera::lease;
+pub use irlume_camera::{camera_inventory_snapshot, initialize_camera_monitor};
 /// Enumerate the Hello camera pairs. Re-exported for the daemon's
 /// camera-class `ListCameras` arm: clients must not enumerate for themselves
 /// (#187), so this is the only path to a listing.

--- a/crates/irlume-camera/src/backend.rs
+++ b/crates/irlume-camera/src/backend.rs
@@ -3,6 +3,9 @@
 
 //! Crate-private capture-backend ownership and operation routing.
 
+use irlume_common::live_camera::{
+    CameraInventoryReason, CameraInventorySnapshot, CameraInventoryState,
+};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Instant;
 
@@ -52,6 +55,41 @@ impl CameraSupervisor {
         }
     }
 
+    fn inventory_snapshot(&self) -> CameraInventorySnapshot {
+        match self.inventory.lock() {
+            Ok(inventory) => inventory.snapshot(),
+            Err(_) => CameraInventorySnapshot {
+                state: CameraInventoryState::Unavailable,
+                reason: Some(CameraInventoryReason::Inventory),
+                ..Default::default()
+            },
+        }
+    }
+
+    pub(crate) fn mark_inventory_unavailable(
+        &self,
+        reason: CameraInventoryReason,
+    ) -> Result<(), CameraInventoryError> {
+        self.inventory
+            .lock()
+            .map_err(|_| CameraInventoryError::Poisoned)?
+            .mark_unavailable(reason);
+        Ok(())
+    }
+
+    pub(crate) fn retire_inventory_unavailable(
+        &self,
+        reason: CameraInventoryReason,
+    ) -> Result<(), CameraInventoryError> {
+        let mut inventory = self
+            .inventory
+            .lock()
+            .map_err(|_| CameraInventoryError::Poisoned)?;
+        inventory.retire_unavailable(reason);
+        Ok(())
+    }
+
+    #[cfg(test)]
     pub(crate) fn reconcile_inventory(
         &self,
         observations: Vec<CameraObservation>,
@@ -256,6 +294,17 @@ impl CameraBackend for UvcV4l2Backend {
 
 static DEFAULT_CAMERA_SUPERVISOR: OnceLock<Arc<CameraSupervisor>> = OnceLock::new();
 
+fn snapshot_from_slot(slot: &OnceLock<Arc<CameraSupervisor>>) -> CameraInventorySnapshot {
+    slot.get()
+        .map_or_else(CameraInventorySnapshot::default, |supervisor| {
+            supervisor.inventory_snapshot()
+        })
+}
+
+pub(crate) fn camera_inventory_snapshot() -> CameraInventorySnapshot {
+    snapshot_from_slot(&DEFAULT_CAMERA_SUPERVISOR)
+}
+
 pub(crate) fn default_camera_supervisor() -> &'static CameraSupervisor {
     DEFAULT_CAMERA_SUPERVISOR
         .get_or_init(|| {
@@ -371,6 +420,71 @@ pub(crate) mod tests {
                 .expect("recording lock poisoned")
                 .push(call.into());
         }
+    }
+
+    #[test]
+    fn live_inventory_getter_does_not_initialize_or_call_backend() {
+        let slot = OnceLock::new();
+        assert_eq!(
+            snapshot_from_slot(&slot),
+            CameraInventorySnapshot::default()
+        );
+        assert!(
+            slot.get().is_none(),
+            "reading status must not initialize a supervisor"
+        );
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let supervisor = Arc::new(CameraSupervisor::new(RecordingBackend {
+            calls: calls.clone(),
+        }));
+        seed_test_endpoints(&supervisor, &["/dev/video0"]);
+        assert!(slot.set(supervisor).is_ok());
+        let snapshot = snapshot_from_slot(&slot);
+        assert_eq!(snapshot.state, CameraInventoryState::Current);
+        assert_eq!(snapshot.candidates[0].endpoint_paths, ["/dev/video0"]);
+        assert!(
+            calls.lock().unwrap().is_empty(),
+            "status called a discovery/open delegate"
+        );
+    }
+
+    #[test]
+    fn live_inventory_poisoned_mutex_is_unavailable_not_a_recovered_old_snapshot() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let supervisor = Arc::new(CameraSupervisor::new(RecordingBackend { calls }));
+        seed_test_endpoints(&supervisor, &["/dev/video0"]);
+        let poison = supervisor.clone();
+        let _ = std::thread::spawn(move || {
+            let _guard = poison.inventory.lock().unwrap();
+            panic!("synthetic poison");
+        })
+        .join();
+        let snapshot = supervisor.inventory_snapshot();
+        assert_eq!(snapshot.state, CameraInventoryState::Unavailable);
+        assert_eq!(snapshot.reason, Some(CameraInventoryReason::Inventory));
+        assert!(snapshot.candidates.is_empty());
+    }
+
+    #[test]
+    fn live_inventory_snapshot_does_not_acquire_or_extend_an_operation_permit() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let supervisor = CameraSupervisor::new(RecordingBackend { calls });
+        seed_test_endpoints(&supervisor, &["/dev/video0"]);
+        let operation = supervisor
+            .acquire_operation(&["/dev/video0"], CameraOperationKind::Setup, Instant::now())
+            .unwrap();
+        let snapshot = supervisor.inventory_snapshot();
+        drop(operation);
+        let next = supervisor.acquire_operation(
+            &["/dev/video0"],
+            CameraOperationKind::Diagnostics,
+            Instant::now(),
+        );
+        assert!(
+            next.is_ok(),
+            "retaining the snapshot must not retain the permit"
+        );
+        assert_eq!(snapshot.state, CameraInventoryState::Current);
     }
 
     impl CameraBackend for RecordingBackend {

--- a/crates/irlume-camera/src/inventory.rs
+++ b/crates/irlume-camera/src/inventory.rs
@@ -8,6 +8,12 @@
 )]
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::time::Instant;
+
+use irlume_common::live_camera::{
+    CameraCandidate, CameraInventoryReason, CameraInventorySnapshot, CameraInventoryState,
+    MAX_CAMERA_CANDIDATES, MAX_CAMERA_ENDPOINTS, MAX_CAMERA_ENDPOINT_BYTES,
+};
 
 use crate::contracts::{
     BackendKind, CameraCapabilities, CameraDescriptor, CameraGeneration, CameraInstanceId,
@@ -195,6 +201,11 @@ pub(crate) struct CameraInventory {
     retired_instance_ids: BTreeSet<CameraInstanceId>,
     invalidated_instance_ids: BTreeSet<CameraInstanceId>,
     instance_id_source: InstanceIdSource,
+    supervisor_id: CameraInstanceId,
+    revision: u64,
+    publication_state: CameraInventoryState,
+    publication_reason: Option<CameraInventoryReason>,
+    observed_at: Option<Instant>,
 }
 
 impl CameraInventory {
@@ -209,7 +220,110 @@ impl CameraInventory {
             retired_instance_ids: BTreeSet::new(),
             invalidated_instance_ids: BTreeSet::new(),
             instance_id_source,
+            supervisor_id: CameraInstanceId::generate(),
+            revision: 0,
+            publication_state: CameraInventoryState::Uninitialized,
+            publication_reason: None,
+            observed_at: None,
         }
+    }
+
+    fn advance_revision(&mut self) {
+        if let Some(next) = self.revision.checked_add(1) {
+            self.revision = next;
+        } else {
+            // A revision must never alias one published earlier by this producer.
+            self.supervisor_id = CameraInstanceId::generate();
+            self.revision = 1;
+        }
+    }
+
+    fn mark_refreshing(&mut self) {
+        if self.publication_state != CameraInventoryState::Refreshing {
+            self.advance_revision();
+        }
+        self.publication_state = CameraInventoryState::Refreshing;
+        self.publication_reason = None;
+    }
+
+    pub(crate) fn mark_unavailable(&mut self, reason: CameraInventoryReason) {
+        self.invalidated_instance_ids.extend(
+            self.active
+                .values()
+                .map(|entry| entry.descriptor.camera_instance_id().clone()),
+        );
+        if self.publication_state != CameraInventoryState::Unavailable
+            || self.publication_reason != Some(reason)
+        {
+            self.advance_revision();
+        }
+        self.publication_state = CameraInventoryState::Unavailable;
+        self.publication_reason = Some(reason);
+    }
+
+    pub(crate) fn retire_unavailable(&mut self, reason: CameraInventoryReason) {
+        // A failed census is not a new successful empty observation. Retire
+        // identities without resetting the age of the last complete census.
+        let topologies = self.active.keys().cloned().collect();
+        self.retire_topologies(&topologies);
+        self.mark_unavailable(reason);
+    }
+
+    /// Copy a bounded view while holding the inventory lock. No lease, backend,
+    /// filesystem or monitor operation is reachable from this projection.
+    pub(crate) fn snapshot(&self) -> CameraInventorySnapshot {
+        if self.publication_state == CameraInventoryState::Uninitialized {
+            return CameraInventorySnapshot::default();
+        }
+        let mut result = CameraInventorySnapshot {
+            state: self.publication_state,
+            supervisor_id: Some(self.supervisor_id.as_str().to_owned()),
+            revision: self.revision,
+            observed_ago_ms: self
+                .observed_at
+                .map(|at| at.elapsed().as_millis().min(u128::from(u64::MAX)) as u64),
+            reason: self.publication_reason,
+            candidates: Vec::new(),
+        };
+        if result.state != CameraInventoryState::Unavailable {
+            for entry in self.active.values().filter(|entry| {
+                !self
+                    .invalidated_instance_ids
+                    .contains(entry.descriptor.camera_instance_id())
+            }) {
+                if result.candidates.len() == MAX_CAMERA_CANDIDATES
+                    || entry.observation.endpoint_paths.len() > MAX_CAMERA_ENDPOINTS
+                    || entry
+                        .observation
+                        .endpoint_paths
+                        .iter()
+                        .any(|path| path.len() > MAX_CAMERA_ENDPOINT_BYTES)
+                {
+                    result.state = CameraInventoryState::Unavailable;
+                    result.reason = Some(CameraInventoryReason::Bounds);
+                    result.candidates.clear();
+                    break;
+                }
+                let candidate = CameraCandidate {
+                    instance_id: entry.descriptor.camera_instance_id().as_str().to_owned(),
+                    generation: entry.descriptor.generation().get(),
+                    endpoint_paths: entry.observation.endpoint_paths.clone(),
+                };
+                if candidate.validate().is_err() {
+                    result.state = CameraInventoryState::Unavailable;
+                    result.reason = Some(CameraInventoryReason::Bounds);
+                    result.candidates.clear();
+                    break;
+                }
+                result.candidates.push(candidate);
+            }
+        }
+        if result.validate().is_err() {
+            result.state = CameraInventoryState::Unavailable;
+            result.reason = Some(CameraInventoryReason::Bounds);
+            result.candidates.clear();
+        }
+        result
     }
 
     fn mint_unique_instance_id(
@@ -337,10 +451,17 @@ impl CameraInventory {
         self.tombstones = next_tombstones;
         self.retired_instance_ids = next_retired_instance_ids;
         self.invalidated_instance_ids.clear();
+        if self.publication_state != CameraInventoryState::Current || !events.is_empty() {
+            self.advance_revision();
+        }
+        self.publication_state = CameraInventoryState::Current;
+        self.publication_reason = None;
+        self.observed_at = Some(Instant::now());
         Ok((events, true))
     }
 
     pub(crate) fn invalidate_all(&mut self) {
+        self.mark_refreshing();
         self.invalidated_instance_ids = self
             .active
             .values()
@@ -349,6 +470,8 @@ impl CameraInventory {
     }
 
     pub(crate) fn invalidate_topologies(&mut self, topologies: &BTreeSet<String>) {
+        // Even an empty affected set may describe a newly added camera.
+        self.mark_refreshing();
         self.invalidated_instance_ids.extend(
             topologies
                 .iter()
@@ -361,6 +484,12 @@ impl CameraInventory {
         &mut self,
         topologies: &BTreeSet<String>,
     ) -> Vec<CameraInventoryEvent> {
+        if topologies
+            .iter()
+            .any(|topology| self.active.contains_key(topology))
+        {
+            self.mark_refreshing();
+        }
         let mut events = Vec::new();
         for topology in topologies {
             let Some(entry) = self.active.remove(topology) else {
@@ -498,10 +627,7 @@ impl CameraInventory {
                     descriptor,
                 },
             )]),
-            tombstones: BTreeSet::new(),
-            retired_instance_ids: BTreeSet::new(),
-            invalidated_instance_ids: BTreeSet::new(),
-            instance_id_source: Box::new(move || replacement_id.clone()),
+            ..Self::with_instance_id_source(Box::new(move || replacement_id.clone()))
         }
     }
 
@@ -560,6 +686,135 @@ mod tests {
                 .map(|endpoint| (*endpoint).to_owned())
                 .collect(),
         )
+    }
+
+    #[test]
+    fn live_inventory_empty_unknown_failed_and_recovered_are_distinct() {
+        let mut inventory = CameraInventory::new();
+        assert_eq!(inventory.snapshot(), CameraInventorySnapshot::default());
+        inventory.reconcile(vec![]).unwrap();
+        let empty = inventory.snapshot();
+        assert_eq!(empty.state, CameraInventoryState::Current);
+        assert!(empty.candidates.is_empty());
+        assert!(empty.observed_ago_ms.is_some());
+        inventory.mark_unavailable(CameraInventoryReason::Monitor);
+        let failed = inventory.snapshot();
+        assert_eq!(failed.state, CameraInventoryState::Unavailable);
+        assert!(failed.revision > empty.revision);
+        inventory.invalidate_all();
+        assert_eq!(inventory.snapshot().state, CameraInventoryState::Refreshing);
+        inventory.reconcile(vec![]).unwrap();
+        let recovered = inventory.snapshot();
+        assert_eq!(recovered.state, CameraInventoryState::Current);
+        assert_eq!(recovered.supervisor_id, empty.supervisor_id);
+        assert!(recovered.revision > failed.revision);
+    }
+
+    #[test]
+    fn live_inventory_invalidates_before_rescan_and_never_publishes_provisional_nodes() {
+        let mut inventory = CameraInventory::new();
+        let camera =
+            observation_with_endpoints("/devices/test/camera", &["/dev/video0", "/dev/video2"]);
+        inventory.reconcile(vec![camera.clone()]).unwrap();
+        let old = inventory.snapshot();
+        inventory.invalidate_all();
+        let invalid = inventory.snapshot();
+        assert_eq!(invalid.state, CameraInventoryState::Refreshing);
+        assert!(invalid.candidates.is_empty());
+        assert!(invalid.revision > old.revision);
+        let (_, committed) = inventory
+            .reconcile_guarded(vec![camera.clone()], || false)
+            .unwrap();
+        assert!(!committed);
+        assert_eq!(inventory.snapshot().state, CameraInventoryState::Refreshing);
+        assert!(inventory.snapshot().candidates.is_empty());
+        inventory.reconcile(vec![camera]).unwrap();
+        let new = inventory.snapshot();
+        assert_eq!(new.candidates[0].instance_id, old.candidates[0].instance_id);
+        assert!(new.candidates[0].generation > old.candidates[0].generation);
+        assert_eq!(
+            new.candidates[0].endpoint_paths,
+            ["/dev/video0", "/dev/video2"]
+        );
+        let json = serde_json::to_value(&new.candidates[0]).unwrap();
+        assert!(json.get("role").is_none());
+        assert!(json.get("streaming").is_none());
+    }
+
+    #[test]
+    fn live_inventory_remove_readd_and_restart_cannot_alias_selection() {
+        let mut inventory = CameraInventory::new();
+        let camera = observation_with_endpoints("/devices/test/camera", &["/dev/video0"]);
+        inventory.reconcile(vec![camera.clone()]).unwrap();
+        let old = inventory.snapshot();
+        inventory.reconcile(vec![]).unwrap();
+        inventory.reconcile(vec![camera.clone()]).unwrap();
+        assert_ne!(
+            inventory.snapshot().candidates[0].instance_id,
+            old.candidates[0].instance_id
+        );
+        let mut restarted = CameraInventory::new();
+        restarted.reconcile(vec![camera]).unwrap();
+        assert_ne!(restarted.snapshot().supervisor_id, old.supervisor_id);
+        inventory.revision = u64::MAX;
+        let before = inventory.snapshot().supervisor_id;
+        inventory.invalidate_all();
+        assert_ne!(inventory.snapshot().supervisor_id, before);
+        assert_eq!(inventory.snapshot().revision, 1);
+    }
+
+    #[test]
+    fn live_inventory_healthy_quiet_age_is_not_failure_or_a_new_epoch() {
+        let mut inventory = CameraInventory::new();
+        inventory.reconcile(vec![]).unwrap();
+        let original = inventory.snapshot();
+        inventory.observed_at = Instant::now().checked_sub(std::time::Duration::from_secs(7200));
+        let quiet = inventory.snapshot();
+        assert_eq!(quiet.state, CameraInventoryState::Current);
+        assert_eq!(quiet.revision, original.revision);
+        assert!(quiet.observed_ago_ms.unwrap() >= 7_200_000);
+        inventory.reconcile(vec![]).unwrap();
+        assert_eq!(inventory.snapshot().revision, original.revision);
+        assert!(inventory.snapshot().observed_ago_ms.unwrap() < 1000);
+    }
+
+    #[test]
+    fn live_inventory_failed_scan_preserves_last_successful_observation_age() {
+        let mut inventory = CameraInventory::new();
+        inventory
+            .reconcile(vec![observation_with_endpoints(
+                "/devices/test/camera",
+                &["/dev/video0"],
+            )])
+            .unwrap();
+        inventory.observed_at = Instant::now().checked_sub(std::time::Duration::from_secs(60));
+        inventory.retire_unavailable(CameraInventoryReason::Snapshot);
+        let snapshot = inventory.snapshot();
+        assert_eq!(snapshot.state, CameraInventoryState::Unavailable);
+        assert!(snapshot.candidates.is_empty());
+        assert!(snapshot.observed_ago_ms.unwrap() >= 60_000);
+    }
+
+    #[test]
+    fn live_inventory_overflow_is_unavailable_never_truncated_current() {
+        let mut inventory = CameraInventory::new();
+        inventory
+            .reconcile(
+                (0..=MAX_CAMERA_CANDIDATES)
+                    .map(|n| {
+                        observation_with_endpoints(
+                            &format!("/devices/test/camera{n}"),
+                            &[&format!("/dev/video{n}")],
+                        )
+                    })
+                    .collect(),
+            )
+            .unwrap();
+        let snapshot = inventory.snapshot();
+        assert_eq!(snapshot.state, CameraInventoryState::Unavailable);
+        assert_eq!(snapshot.reason, Some(CameraInventoryReason::Bounds));
+        assert!(snapshot.candidates.is_empty());
+        assert!(snapshot.validate().is_ok());
     }
 
     #[test]

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -56,6 +56,20 @@ mod ir_target;
 pub use ir_target::{configured_ir_target, IrCaptureTarget, IrTargetError};
 pub mod lease;
 mod lifecycle;
+
+/// Copy the already-published UVC connection inventory. This never initializes
+/// the supervisor, probes devices, acquires a lease, or starts monitor work.
+#[must_use]
+pub fn camera_inventory_snapshot() -> irlume_common::live_camera::CameraInventorySnapshot {
+    backend::camera_inventory_snapshot()
+}
+
+/// Explicit daemon startup hook for passive connection monitoring. The existing
+/// supervisor is reused; status requests must call `camera_inventory_snapshot`
+/// instead. Monitoring reads sysfs/media topology without opening video nodes.
+pub fn initialize_camera_monitor() {
+    let _ = backend::default_camera_supervisor();
+}
 mod media_graph;
 mod paired_processing;
 pub use paired_processing::process_pair_while_draining;

--- a/crates/irlume-camera/src/lifecycle.rs
+++ b/crates/irlume-camera/src/lifecycle.rs
@@ -7,6 +7,7 @@
 //! comes from a complete sysfs/media snapshot taken after the monitor is already
 //! listening. Neither enumeration nor monitoring opens a video node.
 
+use irlume_common::live_camera::CameraInventoryReason;
 #[cfg(test)]
 use std::collections::VecDeque;
 use std::collections::{BTreeMap, BTreeSet};
@@ -27,6 +28,8 @@ const MAX_COALESCE_POLLS: usize = 16;
 const MAX_EVENTS_PER_POLL: usize = 4096;
 const COALESCE_QUIET: Duration = Duration::from_millis(50);
 const MONITOR_WAIT: Duration = Duration::from_secs(60 * 60);
+const INITIAL_RETRY_DELAY: Duration = Duration::from_secs(1);
+const MAX_RETRY_DELAY: Duration = Duration::from_secs(30);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum DeviceEventKind {
@@ -138,6 +141,12 @@ trait SnapshotSource {
 trait InventorySink {
     fn invalidate_all(&self) -> Result<(), CameraInventoryError>;
 
+    fn mark_unavailable(&self, reason: CameraInventoryReason) -> Result<(), CameraInventoryError>;
+
+    /// Retire lost continuity and publish failure under one inventory lock.
+    fn retire_unavailable(&self, reason: CameraInventoryReason)
+        -> Result<(), CameraInventoryError>;
+
     fn invalidate_topologies(
         &self,
         topologies: &BTreeSet<String>,
@@ -146,11 +155,6 @@ trait InventorySink {
     fn retire_topologies(
         &self,
         topologies: &BTreeSet<String>,
-    ) -> Result<Vec<CameraInventoryEvent>, CameraInventoryError>;
-
-    fn reconcile(
-        &self,
-        observations: Vec<CameraObservation>,
     ) -> Result<Vec<CameraInventoryEvent>, CameraInventoryError>;
 
     fn reconcile_guarded<F>(
@@ -167,6 +171,17 @@ impl InventorySink for CameraSupervisor {
         self.invalidate_inventory()
     }
 
+    fn mark_unavailable(&self, reason: CameraInventoryReason) -> Result<(), CameraInventoryError> {
+        self.mark_inventory_unavailable(reason)
+    }
+
+    fn retire_unavailable(
+        &self,
+        reason: CameraInventoryReason,
+    ) -> Result<(), CameraInventoryError> {
+        self.retire_inventory_unavailable(reason)
+    }
+
     fn invalidate_topologies(
         &self,
         topologies: &BTreeSet<String>,
@@ -179,13 +194,6 @@ impl InventorySink for CameraSupervisor {
         topologies: &BTreeSet<String>,
     ) -> Result<Vec<CameraInventoryEvent>, CameraInventoryError> {
         self.retire_inventory_topologies(topologies)
-    }
-
-    fn reconcile(
-        &self,
-        observations: Vec<CameraObservation>,
-    ) -> Result<Vec<CameraInventoryEvent>, CameraInventoryError> {
-        self.reconcile_inventory(observations)
     }
 
     fn reconcile_guarded<F>(
@@ -214,6 +222,9 @@ impl<S: SnapshotSource, E: DeviceEventSource> LifecycleCoordinator<S, E> {
         &mut self,
         inventory: &impl InventorySink,
     ) -> Result<Vec<CameraInventoryEvent>, LifecycleError> {
+        inventory
+            .invalidate_all()
+            .map_err(LifecycleError::Inventory)?;
         self.publish_quiet_snapshot(inventory, Vec::new())
     }
 
@@ -335,7 +346,14 @@ impl<S: SnapshotSource, E: DeviceEventSource> LifecycleCoordinator<S, E> {
 }
 
 fn fail_closed(inventory: &impl InventorySink, error: LifecycleError) -> LifecycleError {
-    match inventory.reconcile(Vec::new()) {
+    let reason = match error {
+        LifecycleError::Monitor(_) => CameraInventoryReason::Monitor,
+        LifecycleError::Snapshot(_)
+        | LifecycleError::UnstableSnapshot
+        | LifecycleError::EventStorm => CameraInventoryReason::Snapshot,
+        LifecycleError::Inventory(_) => CameraInventoryReason::Inventory,
+    };
+    match inventory.retire_unavailable(reason) {
         Ok(_) => error,
         Err(inventory_error) => LifecycleError::Inventory(inventory_error),
     }
@@ -681,7 +699,9 @@ impl<'a, I: InventorySink> WorkerExitGuard<'a, I> {
 
 impl<I: InventorySink> Drop for WorkerExitGuard<'_, I> {
     fn drop(&mut self) {
-        let _ = self.0.invalidate_all();
+        let _ = self
+            .0
+            .mark_unavailable(CameraInventoryReason::WorkerStopped);
     }
 }
 
@@ -689,40 +709,93 @@ impl<I: InventorySink> Drop for WorkerExitGuard<'_, I> {
 /// owns the monitor socket for the supervisor lifetime; dropping the process is
 /// the only normal shutdown path for this process-scoped inventory.
 pub(crate) fn spawn(supervisor: Weak<CameraSupervisor>) -> Result<(), LifecycleError> {
-    let mut coordinator =
-        bind_monitor_before_snapshot(UdevEventSource::new, SysfsSnapshotSource::default)?;
     let Some(supervisor) = supervisor.upgrade() else {
         return Ok(());
     };
-    coordinator.initialize(supervisor.as_ref())?;
+    let mut coordinator = match start_coordinator(
+        supervisor.as_ref(),
+        UdevEventSource::new,
+        SysfsSnapshotSource::default,
+    ) {
+        Ok(coordinator) => Some(coordinator),
+        Err(error) => {
+            eprintln!("irlume: camera lifecycle initialization deferred: {error}");
+            None
+        }
+    };
     let worker_supervisor = supervisor.clone();
     let spawned = std::thread::Builder::new()
         .name("irlume-camera-udev".into())
         .spawn(move || {
             let _exit_guard = WorkerExitGuard::new(worker_supervisor.as_ref());
+            let mut delay = INITIAL_RETRY_DELAY;
+            let mut recovering = coordinator.is_none();
             loop {
-                if let Err(error) =
-                    coordinator.process_next(worker_supervisor.as_ref(), MONITOR_WAIT)
-                {
-                    if worker_retries_after(&error) {
-                        eprintln!(
-                            "irlume: camera lifecycle rescan deferred after a bounded event burst: \
-                             {error}"
-                        );
+                if recovering {
+                    // One bounded attempt per backoff; no RPC starts or drains
+                    // this work. Healthy, quiet monitoring never polls video nodes.
+                    std::thread::sleep(delay);
+                    delay = next_retry_delay(delay);
+                    let attempt = if let Some(current) = coordinator.as_mut() {
+                        current.initialize(worker_supervisor.as_ref()).map(|_| ())
+                    } else {
+                        start_coordinator(
+                            worker_supervisor.as_ref(),
+                            UdevEventSource::new,
+                            SysfsSnapshotSource::default,
+                        )
+                        .map(|new| coordinator = Some(new))
+                    };
+                    if let Err(error) = attempt {
+                        if !worker_retries_after(&error) {
+                            coordinator = None;
+                        }
                         continue;
                     }
-                    eprintln!("irlume: camera lifecycle monitor stopped: {error}");
+                    recovering = false;
+                    delay = INITIAL_RETRY_DELAY;
+                }
+                let Some(current) = coordinator.as_mut() else {
                     return;
+                };
+                if let Err(error) = current.process_next(worker_supervisor.as_ref(), MONITOR_WAIT) {
+                    eprintln!(
+                        "irlume: camera lifecycle observation unavailable, retrying: {error}"
+                    );
+                    if matches!(
+                        error,
+                        LifecycleError::Inventory(CameraInventoryError::Poisoned)
+                    ) {
+                        return;
+                    }
+                    if !worker_retries_after(&error) {
+                        coordinator = None;
+                    }
+                    recovering = true;
                 }
             }
         });
     finish_spawn(supervisor.as_ref(), spawned)
 }
 
+fn next_retry_delay(previous: Duration) -> Duration {
+    previous.saturating_mul(2).min(MAX_RETRY_DELAY)
+}
+
+fn start_coordinator<S: SnapshotSource, E: DeviceEventSource>(
+    inventory: &impl InventorySink,
+    bind: impl FnOnce() -> Result<E, LifecycleError>,
+    snapshots: impl FnOnce() -> S,
+) -> Result<LifecycleCoordinator<S, E>, LifecycleError> {
+    let mut coordinator = bind_monitor_before_snapshot(bind, snapshots)
+        .map_err(|error| fail_closed(inventory, error))?;
+    coordinator.initialize(inventory)?;
+    Ok(coordinator)
+}
+
 /// A quiet-snapshot bound is a fail-closed publication result, not loss of the
-/// monitor itself. Keep the inventory invalidated and retain the udev socket so
-/// a later remove/add event can rebuild it. Socket and inventory failures do
-/// not have that guarantee and still terminate the worker.
+/// monitor itself. Keep its socket for a delayed retry even without a new event.
+/// Other failures require binding a new socket before a fresh census.
 fn worker_retries_after(error: &LifecycleError) -> bool {
     matches!(
         error,
@@ -738,7 +811,7 @@ fn finish_spawn<I: InventorySink>(
         Ok(_) => Ok(()),
         Err(error) => {
             inventory
-                .invalidate_all()
+                .mark_unavailable(CameraInventoryReason::WorkerStopped)
                 .map_err(LifecycleError::Inventory)?;
             Err(LifecycleError::Monitor(error.to_string()))
         }
@@ -764,11 +837,35 @@ mod tests {
         ) -> Result<(), CameraInventoryError> {
             self.0.lock().unwrap().validate(descriptor)
         }
+
+        fn reconcile(
+            &self,
+            observations: Vec<CameraObservation>,
+        ) -> Result<Vec<CameraInventoryEvent>, CameraInventoryError> {
+            self.0.lock().unwrap().reconcile(observations)
+        }
     }
 
     impl InventorySink for TestInventory {
         fn invalidate_all(&self) -> Result<(), CameraInventoryError> {
             self.0.lock().unwrap().invalidate_all();
+            Ok(())
+        }
+
+        fn mark_unavailable(
+            &self,
+            reason: CameraInventoryReason,
+        ) -> Result<(), CameraInventoryError> {
+            self.0.lock().unwrap().mark_unavailable(reason);
+            Ok(())
+        }
+
+        fn retire_unavailable(
+            &self,
+            reason: CameraInventoryReason,
+        ) -> Result<(), CameraInventoryError> {
+            let mut inventory = self.0.lock().unwrap();
+            inventory.retire_unavailable(reason);
             Ok(())
         }
 
@@ -785,13 +882,6 @@ mod tests {
             topologies: &BTreeSet<String>,
         ) -> Result<Vec<CameraInventoryEvent>, CameraInventoryError> {
             Ok(self.0.lock().unwrap().retire_topologies(topologies))
-        }
-
-        fn reconcile(
-            &self,
-            observations: Vec<CameraObservation>,
-        ) -> Result<Vec<CameraInventoryEvent>, CameraInventoryError> {
-            self.0.lock().unwrap().reconcile(observations)
         }
 
         fn reconcile_guarded<F>(
@@ -836,6 +926,90 @@ mod tests {
             CameraCapabilities::new(vec![StreamRole::Rgb], Default::default(), Vec::new()).unwrap(),
             vec![evidence.into()],
         )
+    }
+
+    #[test]
+    fn live_inventory_rebind_recovers_without_another_hotplug_event_and_retires_old_identity() {
+        use irlume_common::live_camera::CameraInventoryState;
+        let inventory = TestInventory::new();
+        let camera = CameraObservation::with_lifecycle_evidence_and_endpoints(
+            BackendKind::UvcV4l2,
+            PhysicalCameraId::new("/devices/test/camera", None).unwrap(),
+            CameraCapabilities::default(),
+            vec!["fixture".into()],
+            vec!["/dev/video0".into()],
+        );
+        let mut initial = start_coordinator(
+            &inventory,
+            || {
+                Ok(FakeEvents(VecDeque::from([
+                    Ok(vec![]),
+                    Ok(vec![]),
+                    Err(LifecycleError::Monitor("lost".into())),
+                ])))
+            },
+            || FakeSnapshots(VecDeque::from([Ok(vec![camera.clone()])])),
+        )
+        .unwrap();
+        let before = inventory.0.lock().unwrap().snapshot();
+        assert!(initial.process_next(&inventory, Duration::ZERO).is_err());
+        let failed = inventory.0.lock().unwrap().snapshot();
+        assert_eq!(failed.state, CameraInventoryState::Unavailable);
+        assert!(failed.candidates.is_empty());
+        let _rebound = start_coordinator(
+            &inventory,
+            || Ok(FakeEvents(VecDeque::from([Ok(vec![]), Ok(vec![])]))),
+            || FakeSnapshots(VecDeque::from([Ok(vec![camera])])),
+        )
+        .unwrap();
+        let after = inventory.0.lock().unwrap().snapshot();
+        assert_eq!(after.state, CameraInventoryState::Current);
+        assert_eq!(after.supervisor_id, before.supervisor_id);
+        assert!(after.revision > failed.revision);
+        assert_ne!(
+            after.candidates[0].instance_id,
+            before.candidates[0].instance_id
+        );
+    }
+
+    #[test]
+    fn live_inventory_failed_initial_bind_can_recover_to_authoritative_empty() {
+        use irlume_common::live_camera::CameraInventoryState;
+        let inventory = TestInventory::new();
+        let failed = start_coordinator(
+            &inventory,
+            || Err::<FakeEvents, _>(LifecycleError::Monitor("synthetic bind error".into())),
+            || panic!("a failed bind must not construct or scan sysfs"),
+        );
+        // Specify the snapshot source without executing a real constructor.
+        let _: Result<LifecycleCoordinator<FakeSnapshots, FakeEvents>, _> = failed;
+        let unavailable = inventory.0.lock().unwrap().snapshot();
+        assert_eq!(unavailable.state, CameraInventoryState::Unavailable);
+        assert_eq!(unavailable.reason, Some(CameraInventoryReason::Monitor));
+        assert!(unavailable.observed_ago_ms.is_none());
+        let _recovered = start_coordinator(
+            &inventory,
+            || Ok(FakeEvents(VecDeque::from([Ok(vec![]), Ok(vec![])]))),
+            || FakeSnapshots(VecDeque::from([Ok(vec![])])),
+        )
+        .unwrap();
+        let current = inventory.0.lock().unwrap().snapshot();
+        assert_eq!(current.state, CameraInventoryState::Current);
+        assert!(current.candidates.is_empty());
+        assert!(current.observed_ago_ms.is_some());
+    }
+
+    #[test]
+    fn live_inventory_retry_delay_is_positive_exponential_and_capped() {
+        let mut delay = INITIAL_RETRY_DELAY;
+        assert_eq!(delay, Duration::from_secs(1));
+        let mut observed = Vec::new();
+        for _ in 0..10 {
+            observed.push(delay.as_secs());
+            delay = next_retry_delay(delay);
+        }
+        assert_eq!(observed, [1, 2, 4, 8, 16, 30, 30, 30, 30, 30]);
+        assert_eq!(next_retry_delay(Duration::MAX), MAX_RETRY_DELAY);
     }
 
     fn hint(kind: DeviceEventKind) -> DeviceEventHint {

--- a/crates/irlume-cli/src/main.rs
+++ b/crates/irlume-cli/src/main.rs
@@ -687,20 +687,42 @@ fn profiles(sub: Option<&str>, args: &[String]) -> std::process::ExitCode {
 /// (the daemon writes /etc/irlume/cameras.conf); the TUI camera picker runs this
 /// via sudo, and headless setups call it directly.
 fn set_cameras(args: &[String]) -> std::process::ExitCode {
+    let request = match set_cameras_request(args) {
+        Ok(request) => request,
+        Err(reason) => {
+            eprintln!("{reason}\nusage: irlume set-cameras <rgb-node> <ir-node> [--expected-camera JSON]   (root)");
+            return std::process::ExitCode::from(2);
+        }
+    };
+    // A guarded request is never retried as the legacy unguarded operation.
+    // Older daemons must refuse rather than silently ignore camera continuity.
+    report_ok_response("set-cameras", daemon_request(&request))
+}
+
+fn set_cameras_request(args: &[String]) -> Result<irlume_common::Request, &'static str> {
     use irlume_common::Request;
     let (Some(rgb), Some(ir)) = (args.get(1), args.get(2)) else {
-        eprintln!(
-            "usage: irlume set-cameras <rgb-node> <ir-node>   (root; e.g. /dev/video0 /dev/video2)"
-        );
-        return std::process::ExitCode::from(2);
+        return Err("both camera paths are required");
     };
-    report_ok_response(
-        "set-cameras",
-        daemon_request(&Request::SetCameras {
+    match args.len() {
+        3 => Ok(Request::SetCameras {
             rgb: rgb.clone(),
             ir: ir.clone(),
         }),
-    )
+        5 if args[3] == "--expected-camera" => {
+            let expected =
+                serde_json::from_str::<irlume_common::live_camera::CameraSelection>(&args[4])
+                    .map_err(|_| {
+                        "invalid expected camera identity; select the camera again in the TUI"
+                    })?;
+            Ok(Request::SetCamerasIfCurrent {
+                rgb: rgb.clone(),
+                ir: ir.clone(),
+                expected,
+            })
+        }
+        _ => Err("unexpected or incomplete camera-selection arguments"),
+    }
 }
 
 /// Report the daemon's answer to a request whose success case is
@@ -4425,6 +4447,61 @@ mod tests {
 
     fn argv(args: &[&str]) -> Vec<String> {
         args.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn set_cameras_preserves_legacy_request_and_carries_guard_without_fallback() {
+        let plain = argv(&["set-cameras", "/dev/video40", "/dev/video42"]);
+        assert!(
+            matches!(set_cameras_request(&plain), Ok(irlume_common::Request::SetCameras { rgb, ir })
+            if rgb == "/dev/video40" && ir == "/dev/video42")
+        );
+        let guard = serde_json::json!({
+            "supervisor_id":"11111111111111111111111111111111",
+            "candidate":{"instance_id":"22222222222222222222222222222222",
+                "generation":7, "endpoint_paths":["/dev/video40","/dev/video42"]}
+        })
+        .to_string();
+        let mut guarded = plain;
+        guarded.extend(["--expected-camera".into(), guard]);
+        let request = set_cameras_request(&guarded).unwrap();
+        assert!(
+            matches!(request, irlume_common::Request::SetCamerasIfCurrent { ref rgb, ref ir, ref expected }
+            if rgb == "/dev/video40" && ir == "/dev/video42" && expected.candidate.generation == 7)
+        );
+        let encoded = serde_json::to_value(&request).unwrap();
+        assert!(encoded.get("SetCamerasIfCurrent").is_some());
+        assert!(encoded.get("SetCameras").is_none());
+    }
+
+    #[test]
+    fn set_cameras_refuses_missing_malformed_or_unknown_guard_arguments() {
+        for args in [
+            argv(&["set-cameras"]),
+            argv(&[
+                "set-cameras",
+                "/dev/video40",
+                "/dev/video42",
+                "--expected-camera",
+            ]),
+            argv(&[
+                "set-cameras",
+                "/dev/video40",
+                "/dev/video42",
+                "--expected-camera",
+                "{}",
+            ]),
+            argv(&[
+                "set-cameras",
+                "/dev/video40",
+                "/dev/video42",
+                "--unknown",
+                "{}",
+            ]),
+            argv(&["set-cameras", "/dev/video40", "/dev/video42", "unexpected"]),
+        ] {
+            assert!(set_cameras_request(&args).is_err());
+        }
     }
 
     // ---- the shared flags-first subcommand scanner ----

--- a/crates/irlume-cli/src/tui.rs
+++ b/crates/irlume-cli/src/tui.rs
@@ -11,6 +11,9 @@
 //! show). A thin client: all work happens in the daemon.
 
 mod actions;
+mod activity;
+mod freshness;
+use freshness::{Freshness, Source, Worker};
 
 use ratatui::crossterm::event::{self, Event, KeyCode, KeyEventKind};
 use ratatui::layout::{Constraint, Layout, Rect};
@@ -20,73 +23,58 @@ use ratatui::widgets::{Block, BorderType, Clear, List, ListItem, ListState, Para
 use ratatui::Frame;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{mpsc, Arc};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use irlume_common::{PositionReport, ProfileSummary, Request, Response};
 
-/// Semantic color slots, resolved once at startup down a capability ladder:
-/// NO_COLOR (no-color.org) gets none and the glyphs carry all state; plain
-/// terminals get ANSI names so the USER'S terminal theme is the palette
-/// (light themes stay readable); truecolor terminals get the soft irlume
-/// palette as polish. Every use is a semantic slot (accent/ok/warn/err),
-/// never decoration, so the ladder degrades without losing information.
+/// Semantic foregrounds use the user's ANSI palette on both light and dark
+/// terminals. Leave backgrounds at their terminal defaults; fixed RGB pastels
+/// cannot assume the background is dark. Glyphs and words also carry state.
 struct Theme {
     accent: Color,
     blue: Color,
     ok: Color,
     err: Color,
     warn: Color,
-    /// Key-chip style for the footer (`[w]`, `[?]`…): colored chip normally,
-    /// REVERSED under NO_COLOR (a black-on-Reset chip would be invisible).
     chip: Style,
 }
 
 fn th() -> &'static Theme {
     static T: std::sync::OnceLock<Theme> = std::sync::OnceLock::new();
     T.get_or_init(|| {
-        if std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty()) {
-            return Theme {
-                accent: Color::Reset,
-                blue: Color::Reset,
-                ok: Color::Reset,
-                err: Color::Reset,
-                warn: Color::Reset,
-                chip: Style::new().add_modifier(Modifier::REVERSED),
-            };
-        }
-        let truecolor = std::env::var("COLORTERM")
-            .map(|v| v.contains("truecolor") || v.contains("24bit"))
-            .unwrap_or(false);
-        if truecolor {
-            let accent = Color::Rgb(0x6c, 0xb6, 0xff);
-            Theme {
-                accent,
-                blue: Color::Rgb(0x4a, 0x90, 0xd9),
-                ok: Color::Rgb(0x73, 0xc9, 0x91),
-                err: Color::Rgb(0xe8, 0x7a, 0x7a),
-                warn: Color::Rgb(0xe6, 0xc0, 0x7a),
-                chip: Style::new().fg(Color::Black).bg(accent),
-            }
-        } else {
-            Theme {
-                accent: Color::Cyan,
-                blue: Color::Blue,
-                ok: Color::Green,
-                err: Color::Red,
-                warn: Color::Yellow,
-                chip: Style::new().fg(Color::Black).bg(Color::Cyan),
-            }
+        let monochrome = std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty());
+        let color = |value| if monochrome { Color::Reset } else { value };
+        Theme {
+            accent: color(Color::Cyan),
+            blue: color(Color::Blue),
+            ok: color(Color::Green),
+            err: color(Color::Red),
+            warn: color(Color::Yellow),
+            chip: Style::new().add_modifier(Modifier::REVERSED | Modifier::BOLD),
         }
     })
 }
 
-/// Selection uses the terminal's own foreground/background relationship, so it
-/// remains legible on light, dark, ANSI-only, and NO_COLOR terminals.
+/// Reverse the terminal's own foreground/background for a visible focus cue.
 fn selected_style() -> Style {
-    Style::new()
-        .fg(th().accent)
-        .add_modifier(Modifier::BOLD)
-        .add_modifier(Modifier::REVERSED)
+    Style::new().add_modifier(Modifier::BOLD | Modifier::REVERSED)
+}
+
+/// A setting state always has a readable word and glyph, including NO_COLOR.
+fn setting_badge(state: Option<bool>) -> Span<'static> {
+    let (label, color) = match state {
+        Some(true) => ("● ON", th().ok),
+        Some(false) => ("○ OFF", Color::Reset),
+        None => ("◐ UNKNOWN", th().warn),
+    };
+    Span::styled(label, Style::new().fg(color).add_modifier(Modifier::BOLD))
+}
+
+const MIN_WINDOW_COLS: u16 = 80;
+const MIN_WINDOW_ROWS: u16 = 24;
+
+fn window_fits(area: Rect) -> bool {
+    area.width >= MIN_WINDOW_COLS && area.height >= MIN_WINDOW_ROWS
 }
 
 const SPIN: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
@@ -188,6 +176,7 @@ enum Click {
     Key(KeyCode),
     DialogKey(KeyCode),
     ActionRow(usize),
+    SectionRow(usize),
     Hub(usize),
     /// Select a row in the current screen's list. The screen is intentionally
     /// resolved when the click is handled: targets are cleared and rebuilt on
@@ -246,7 +235,7 @@ enum Suspend {
     SelinuxLoad,
     /// Switch the active camera pair; root op (writes /etc), so it suspends to
     /// `sudo irlume set-cameras <rgb> <ir>`.
-    SetCameras(String, String),
+    SetCameras(String, String, irlume_common::live_camera::CameraSelection),
     /// Set up the IR emitter; root op, suspends to `sudo irlume ir-setup`.
     IrSetup,
     /// Measure whether the camera can stream RGB and IR at once and persist
@@ -313,6 +302,7 @@ enum Suspend {
 enum ConfirmAct {
     Daemon(Request),
     Sus(Suspend),
+    CameraQualification,
 }
 
 /// A y/n confirm with a SPECIFIC verb on the affirmative (GNOME HIG: "Label
@@ -387,6 +377,7 @@ enum ResumeEnroll {
 }
 
 /// One Repair-tab diagnostic row.
+#[derive(Clone)]
 struct Check {
     label: String,
     sev: Sev,
@@ -534,68 +525,114 @@ struct Op {
     rx: mpsc::Receiver<(bool, String)>,
 }
 
-/// Camera metadata gathered off the event thread; failed fields retain their previous values.
+/// Camera roles gathered off the event thread and bound to a passive inventory epoch.
 #[derive(Default)]
 struct CameraListing {
     pairs: Option<Vec<irlume_common::CameraPairInfo>>,
-    mode: Option<String>,
 }
 
 impl CameraListing {
     fn gather() -> Self {
-        let mut listing = Self::default();
-        if let Ok(Response::Cameras(pairs)) = crate::daemon_poll(&Request::ListCameras) {
-            listing.pairs = Some(pairs);
+        Self {
+            pairs: match crate::daemon_poll(&Request::ListCameras) {
+                Ok(Response::Cameras(pairs)) => Some(pairs),
+                _ => None,
+            },
         }
-        // The same camera-class slot as the listing above: the arbiter
-        // serializes this against captures, and it is refreshed on screen
-        // entry (not per frame). A refusal or older daemon leaves the last
-        // answer in place — unknown is not "default".
-        if let Ok(Response::CaptureModeStatus {
-            mode,
-            source,
-            qualification_state,
-            qualification_reason,
-            runtime_degradation,
-            ..
-        }) = crate::daemon_poll(&Request::CaptureModeStatus)
-        {
-            // The qualification state tells the user WHY their camera is in
-            // this mode: "measured_sequential" (the camera cannot sustain
-            // concurrent) reads very differently from
-            // "unqualified_context_changed" (kernel or USB changed; re-tune).
-            // Both are actionable facts the bare mode string hides (#586
-            // audit: a user who never runs camera-mode or doctor has no way
-            // to learn their qualification is stale).
-            let mut text = format!("{mode} (source: {source})");
-            if !qualification_state.is_empty() {
-                text.push_str("; qualification: ");
-                text.push_str(&qualification_state);
-                if let Some(reason) = &qualification_reason {
-                    text.push_str(" (");
-                    text.push_str(reason);
-                    text.push(')');
-                }
-            }
-            if let Some(why) = runtime_degradation {
-                text.push_str("; degraded: ");
-                text.push_str(&why);
-            }
-            listing.mode = Some(text);
-        }
-        listing
     }
+}
+
+fn gather_capture_qualification() -> Option<String> {
+    let Ok(Response::CaptureModeStatus {
+        mode,
+        source,
+        qualification_state,
+        qualification_reason,
+        runtime_degradation,
+        ..
+    }) = crate::daemon_poll(&Request::CaptureModeStatus)
+    else {
+        return None;
+    };
+    let mut text = format!("{mode} (source: {source}); qualification: {qualification_state}");
+    if let Some(reason) = qualification_reason {
+        text.push_str(&format!(" ({reason})"));
+    }
+    if let Some(reason) = runtime_degradation {
+        text.push_str(&format!("; degraded: {reason}"));
+    }
+    Some(text)
+}
+
+fn receive_finished<T>(receiver: &Option<mpsc::Receiver<T>>) -> Option<Result<T, ()>> {
+    match receiver.as_ref()?.try_recv() {
+        Ok(value) => Some(Ok(value)),
+        Err(mpsc::TryRecvError::Empty) => None,
+        Err(mpsc::TryRecvError::Disconnected) => Some(Err(())),
+    }
+}
+
+fn live_kind_label(kind: irlume_common::live::LiveOperationKind) -> &'static str {
+    use irlume_common::live::LiveOperationKind as K;
+    match kind {
+        K::Authentication => "authentication",
+        K::WalletAuthentication => "wallet authentication",
+        K::Enrollment => "enrollment",
+        K::Framing => "framing guide",
+        K::Identification => "recognition test",
+        K::CameraEnumeration => "camera inspection",
+        K::CameraSetup => "camera setup",
+        K::CaptureQualification => "capture qualification",
+        K::CameraDiagnostics => "camera diagnostics",
+        K::ProfileRead => "reading profiles",
+        K::ProfileUpdate => "updating profiles",
+        K::SensorReadiness => "sensor readiness",
+        K::WalletRead => "reading wallet status",
+        K::WalletUpdate => "updating wallet",
+        K::RecoveryUpdate => "updating recovery",
+        K::Compatibility => "compatibility work",
+        K::Status => "status",
+        K::Unknown => "unknown work",
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct CameraEpoch {
+    supervisor: String,
+    revision: u64,
+}
+
+#[derive(Clone)]
+struct CameraChoice {
+    supervisor: String,
+    candidate: irlume_common::live_camera::CameraCandidate,
+    rgb: String,
+    ir: String,
 }
 
 /// TUI state. `Option` fields act as modal overlays; when several are
 /// `Some`, `on_key` consumes input in this order (first match wins):
-/// `error` (any key dismisses) > `more_actions` (search/navigation) > `enroll` (Esc only) > `op` (q/Esc only) >
+/// `error` (reading keys scroll; other keys dismiss) > `more_actions` (search/navigation) > `enroll` (Esc only) > `op` (q/Esc only) >
 /// `input` (text entry) > `confirm` (y/n) > `enroll_merge` (y/n) > normal
 /// screen keys. `suspend` is not a key state: the main loop takes it after
 /// each key/tick, leaves the TUI, and runs the command. PageUp/PageDown
 /// scroll the Activity panel in every state except text entry.
 struct App {
     user: String,
+    freshness: Freshness,
+    clock_override: Option<Instant>,
+    usable_sources: [bool; 13],
+    show_live: bool,
+    live: Option<irlume_common::live::LiveStatusSnapshot>,
+    live_load: Option<mpsc::Receiver<Result<irlume_common::live::LiveStatusSnapshot, String>>>,
+    live_epoch: Option<(irlume_common::diagnostics::OperationId, u64)>,
+    camera_epoch: Option<CameraEpoch>,
+    classified_epoch: Option<CameraEpoch>,
+    camera_confirmation: Option<CameraChoice>,
+    selected_camera_choice: Option<Option<CameraChoice>>,
+    selected_profile_identity: Option<Option<(String, Option<String>)>>,
+    qualification_load: Option<mpsc::Receiver<Option<String>>>,
+    identify_checked_at: Option<Instant>,
     screen: usize,
     sel: usize,
     profiles: Vec<ProfileSummary>,
@@ -632,7 +669,7 @@ struct App {
     /// `None` = not fetched / daemon refused: drawn as unknown, never blank.
     capture_mode: Option<String>,
     camera_load: Option<mpsc::Receiver<CameraListing>>,
-    activity: Vec<(char, String)>,
+    activity: activity::Activity,
     input: Option<(String, String, Pending)>,
     confirm: Option<Confirm>,
     /// True while mouse capture is released so the terminal's own selection
@@ -641,6 +678,8 @@ struct App {
     /// Clickable content regions recorded each frame by `draw`, consulted by
     /// `on_click`. Interior mutability because `draw` takes `&self`.
     click_targets: std::cell::RefCell<Vec<(Rect, Click)>>,
+    /// Input must match a fully drawn window, including after a resize.
+    window_area: std::cell::Cell<Option<Rect>>,
     /// Last rendered dialog bounds and scroll limit; controls stay outside the body.
     dialog_view: std::cell::Cell<(Rect, u16)>,
     dialog_scroll: std::cell::Cell<u16>,
@@ -649,6 +688,12 @@ struct App {
     /// The [?] full-keymap overlay (tier two of the disclosure ladder).
     show_help: bool,
     more_actions: Option<(String, usize)>,
+    /// The compact section chooser uses the same visible navigation order.
+    sections: Option<usize>,
+    /// Screen and selected action index; stale focus never carries to a new page.
+    action_focus: Option<(usize, usize)>,
+    /// Reveal a newly focused action once, leaving subsequent wheel scroll free.
+    action_reveal: std::cell::Cell<bool>,
     /// Selected row of the Welcome hub (Enter jumps to its screen).
     hub_sel: usize,
     op: Option<Op>,
@@ -697,6 +742,8 @@ struct App {
     /// Whether the activity history is expanded. The default is a one-line
     /// recent-status strip so content keeps the vertical space.
     activity_open: bool,
+    /// Full-height, session-only history; opening it performs no I/O.
+    activity_history_open: bool,
     /// Disable repeating motion while preserving static status/progress.
     /// Set by `IRLUME_REDUCE_MOTION` for terminals or users that prefer it.
     reduce_motion: bool,
@@ -708,6 +755,8 @@ struct App {
     advanced: bool,
     /// Detected face-hardware capabilities (drives `visible` + the recommendation).
     caps: irlume_camera::Caps,
+    reported_caps: irlume_camera::Caps,
+    known_uvc_paths: Vec<String>,
     /// A fingerprint reader is present.
     fp_present: bool,
     fp_known: bool,
@@ -789,6 +838,9 @@ struct PamCache {
 /// deterministic under test for the first time.
 #[derive(Default, Clone)]
 struct Probes {
+    runtime_checks: Vec<Check>,
+    fprintd_wired: bool,
+    foreign_pam: Vec<&'static str>,
     caps: irlume_camera::Caps,
     /// Whether `caps` came from an actual device probe. False means the
     /// daemon was up and the probe was skipped to avoid opening nodes it may
@@ -797,6 +849,7 @@ struct Probes {
     caps_probed: bool,
     /// None is an unavailable observation, not a missing reader.
     fp_present: Option<bool>,
+    fp_enrollment_observed: bool,
     fp: FpInfo,
     pam_cache: PamCache,
     fp_coverage: Vec<(&'static str, &'static str, bool)>,
@@ -824,6 +877,71 @@ struct Probes {
 }
 
 impl Probes {
+    fn runtime_fallback_checks() -> Vec<Check> {
+        let mut v = Vec::new();
+        let mk = |label: &str, sev, detail: String, fix| Check {
+            label: label.into(),
+            sev,
+            detail,
+            fix,
+        };
+        let ort = std::env::var("ORT_DYLIB_PATH")
+            .ok()
+            .filter(|p| std::path::Path::new(p).exists())
+            .is_some()
+            || ORT_FALLBACK_PATHS
+                .iter()
+                .any(|p| std::path::Path::new(p).exists());
+        v.push(ort_fallback_check(ort));
+        v.push(tflite_fallback_check(
+            std::env::var(irlume_vision::tflite::TFLITE_LIB_ENV)
+                .ok()
+                .as_deref(),
+            |p| p.exists(),
+        ));
+
+        // Resolve models the way the daemon does (env → /usr/share/irlume/models
+        // → repo cwd), NOT just cwd-relative; a packaged install keeps them in
+        // /usr/share and the TUI is rarely launched from the repo.
+        let m1 = crate::commands::resolve_model("glintr100.onnx", "IRLUME_MODEL").is_some();
+        let m2 =
+            crate::commands::resolve_model("face_detection_yunet_2023mar.onnx", "IRLUME_DET_MODEL")
+                .is_some();
+        v.push(mk(
+            "Models",
+            if m1 && m2 { Sev::Ok } else { Sev::Fail },
+            if m1 && m2 {
+                "YuNet + AuraFace present".into()
+            } else {
+                "not found (daemon down; local probe)".into()
+            },
+            if m1 && m2 {
+                Fix::None
+            } else {
+                Fix::Manual(
+                    "install the irlume package (models ship in /usr/share/irlume/models)".into(),
+                )
+            },
+        ));
+        v
+    }
+
+    fn foreign_pam_modules() -> Vec<&'static str> {
+        let contents: Vec<_> = ["/etc/pam.d/common-auth", "/etc/pam.d/system-auth"]
+            .iter()
+            .filter_map(|path| std::fs::read_to_string(path).ok())
+            .collect();
+        ["howdy", "linhello"]
+            .into_iter()
+            .filter(|needle| {
+                contents.iter().any(|text| {
+                    text.lines()
+                        .any(|line| crate::pamwire::directive(line).contains(needle))
+                })
+            })
+            .collect()
+    }
+
     /// The full sweep, verbatim from the code that used to run inline. Runs
     /// on a worker thread; everything here may block on D-Bus activation, a
     /// subprocess, or a device open without costing the UI a frame.
@@ -839,13 +957,20 @@ impl Probes {
             std::time::Instant::now() + Duration::from_millis(1500),
         );
         let fp_present = fp_observed == Some(true);
+        let listed = if fp_present {
+            Some(irlume_fingerprint::list_fingers(user))
+        } else {
+            None
+        };
+        let fp_enrollment_observed =
+            matches!(&listed, Some(irlume_fingerprint::ListOutcome::Fingers(_)))
+                || fp_observed == Some(false);
         let fp = FpInfo {
             available: fp_present,
             device: fp_present.then(irlume_fingerprint::device_name).flatten(),
-            enrolled: if fp_present {
-                irlume_fingerprint::enrolled_fingers(user)
-            } else {
-                Vec::new()
+            enrolled: match listed {
+                Some(irlume_fingerprint::ListOutcome::Fingers(fingers)) => fingers,
+                _ => Vec::new(),
             },
             method: irlume_core::policy::method().as_str().to_string(),
         };
@@ -861,9 +986,15 @@ impl Probes {
             handoffs: crate::pamwire::keyring_handoff_warnings(),
         };
         Probes {
+            runtime_checks: Self::runtime_fallback_checks(),
+            fprintd_wired: crate::fingerprint::pam_fprintd_wired_pub(
+                &crate::fingerprint::PamSearchPath::live(),
+            ),
+            foreign_pam: Self::foreign_pam_modules(),
             caps,
             caps_probed: false,
             fp_present: fp_observed,
+            fp_enrollment_observed,
             reader_stuck: fp_present && irlume_fingerprint::reader_stuck(user),
             fp,
             fp_coverage: if fp_present {
@@ -900,6 +1031,7 @@ impl Probes {
 /// poll budget is 1.5s per request, and paying that between keystrokes is
 /// what made the whole TUI feel wedged whenever the daemon was.
 struct LightState {
+    observed_at: [Option<Instant>; 4],
     daemon_up: bool,
     /// The classified Ping outcome behind `daemon_up`. Kept alongside the
     /// bool because Repair needs four answers where the gating logic needs
@@ -918,7 +1050,7 @@ impl LightState {
     /// Verbatim the reads `refresh_light` used to make inline, EXCEPT that
     /// it no longer enumerates cameras at all: the daemon answers Health for
     /// capabilities and ListCameras for the picker (#187).
-    fn gather(user: &str, prev_armed: Option<bool>) -> Self {
+    fn gather(user: &str, _prev_armed: Option<bool>) -> Self {
         // The raw client call, not `daemon_poll`: classification needs the
         // errno kind and daemon_poll flattens errors to String.
         let reach =
@@ -933,17 +1065,19 @@ impl LightState {
         // come from Health, the picker's listing from ListCameras, and both
         // are serialized against captures on the daemon's side.
         let mut out = LightState {
+            observed_at: [None; 4],
             daemon_up,
             reach,
             health: None,
             preferences: None,
-            keyring_armed: prev_armed,
+            keyring_armed: None,
             keyring_policy: None,
             keyring_kind: None,
             recovery: None,
         };
         if daemon_up || reach == crate::commands::DaemonReach::Starting {
             out.preferences = crate::preferences::daemon_state();
+            out.observed_at[1] = out.preferences.map(|_| Instant::now());
         }
         if !daemon_up {
             return out;
@@ -972,6 +1106,7 @@ impl LightState {
             }),
             _ => None, // older daemon / daemon down → Repair falls back to local probes
         };
+        out.observed_at[0] = out.health.as_ref().map(|_| Instant::now());
         // Routine status reads envelope metadata only. An older daemon falls
         // back to the armed bit, never to implicit live PCR diagnosis.
         match crate::daemon_poll(&Request::KeyringMetadata {
@@ -992,10 +1127,11 @@ impl LightState {
                     user: user.to_string(),
                 }) {
                     Ok(Response::HasPassword(b)) => Some(b),
-                    _ => prev_armed,
+                    _ => None,
                 };
             }
         }
+        out.observed_at[2] = out.keyring_armed.map(|_| Instant::now());
         if let Ok(Response::RecoveryStatus {
             encrypted,
             recovery_set,
@@ -1004,6 +1140,7 @@ impl LightState {
         }) = crate::daemon_poll(&Request::RecoveryStatus {
             user: user.to_string(),
         }) {
+            out.observed_at[3] = Some(Instant::now());
             out.recovery = Some(RecoveryInfo {
                 encrypted,
                 key_present,
@@ -1040,6 +1177,535 @@ pub fn run(args: &[String]) -> std::io::Result<()> {
 }
 
 impl App {
+    fn now(&self) -> Instant {
+        self.clock_override.unwrap_or_else(Instant::now)
+    }
+
+    fn source_usable(&self, source: Source) -> bool {
+        self.freshness.usable(source, self.now())
+    }
+
+    fn source_status(&self, source: Source) -> String {
+        self.freshness
+            .observation(source)
+            .describe(self.now(), source.max_age(), false)
+    }
+
+    #[cfg(test)]
+    fn mark_fixture_observations_fresh(&mut self, now: Instant) {
+        for source in Source::ALL {
+            self.freshness.observation_mut(source).record(true, now);
+        }
+    }
+
+    fn clear_source(&mut self, source: Source) {
+        match source {
+            Source::Live => self.live = None,
+            Source::Health => self.health = None,
+            Source::Preferences => self.preferences = None,
+            Source::Wallet => {
+                self.keyring_armed = None;
+                self.keyring_policy = None;
+                self.keyring_kind = None;
+            }
+            Source::Recovery => self.recovery = None,
+            Source::Profiles => {
+                if (self.profiles_loaded || !self.profiles.is_empty())
+                    && self.selected_profile_identity.is_none()
+                {
+                    self.selected_profile_identity = Some(self.selected_profile_row());
+                }
+                self.profiles.clear();
+                self.profiles_loaded = false;
+            }
+            Source::Cameras => {
+                if (self.pairs_known || !self.pairs.is_empty())
+                    && self.selected_camera_choice.is_none()
+                {
+                    self.selected_camera_choice = Some(
+                        self.pairs
+                            .get(self.cam_sel)
+                            .and_then(|pair| self.camera_choice(&pair.rgb, &pair.ir)),
+                    );
+                }
+                self.pairs.clear();
+                self.pairs_known = false;
+                self.cam_sel = 0;
+            }
+            Source::CameraPrivacy => {} // the renderer gates this mutable inspection field
+            Source::Qualification => {} // retained only as explicitly historical text
+            Source::Machine => {
+                self.probes_landed = false;
+                self.pam_cache = PamCache::default();
+            }
+            Source::FingerprintReader => {
+                self.fp_known = false;
+            }
+            Source::Fingerprint => {
+                self.fp.enrolled.clear();
+            }
+            Source::Apps => {
+                self.heavy = None;
+                self.heavy_known = false;
+            }
+        }
+    }
+
+    fn invalidate_source(&mut self, source: Source) {
+        self.freshness.observation_mut(source).invalidate();
+        self.clear_source(source);
+    }
+
+    fn invalidate_daemon_observations(&mut self) {
+        for source in [
+            Source::Health,
+            Source::Preferences,
+            Source::Wallet,
+            Source::Recovery,
+            Source::Profiles,
+            Source::Qualification,
+        ] {
+            self.invalidate_source(source);
+        }
+        for worker in [Worker::Light, Worker::Profiles, Worker::Qualification] {
+            self.freshness.cycle_mut(worker).invalidate();
+        }
+        self.invalidate_keyring_diagnostic();
+    }
+
+    fn current_inventory(&self) -> Option<&irlume_common::live_camera::CameraInventorySnapshot> {
+        use irlume_common::live_camera::CameraInventoryState;
+        self.live
+            .as_ref()
+            .filter(|_| self.source_usable(Source::Live))
+            .map(|live| &live.cameras)
+            .filter(|inventory| inventory.state == CameraInventoryState::Current)
+    }
+
+    fn face_camera_presence(&self) -> Option<bool> {
+        let health = self
+            .health
+            .as_ref()
+            .filter(|_| self.source_usable(Source::Health))?;
+        let rgb = health.rgb_dev.as_deref()?;
+        let inventory = self.current_inventory()?;
+        if inventory
+            .candidates
+            .iter()
+            .any(|candidate| candidate.endpoint_paths.iter().any(|path| path == rgb))
+        {
+            Some(true)
+        } else if self.known_uvc_paths.iter().any(|path| path == rgb) {
+            Some(false)
+        } else {
+            // The passive inventory covers UVC. A platform/libcamera backend
+            // absent from it is unobserved, not proven disconnected.
+            None
+        }
+    }
+
+    fn update_camera_availability(&mut self) {
+        let rgb = self.face_camera_presence() == Some(true);
+        let ir_pair = rgb
+            && self.health.as_ref().is_some_and(|health| {
+                health.tier == "secure"
+                    && health
+                        .rgb_dev
+                        .as_deref()
+                        .zip(health.ir_dev.as_deref())
+                        .is_some_and(|(rgb, ir)| self.camera_choice(rgb, ir).is_some())
+            });
+        self.caps = irlume_camera::Caps { rgb, ir_pair };
+    }
+
+    fn refresh_qualification(&mut self) {
+        if self.qualification_load.is_some() {
+            return;
+        }
+        self.freshness.cycle_mut(Worker::Qualification).begin();
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(gather_capture_qualification());
+        });
+        self.qualification_load = Some(rx);
+    }
+
+    fn camera_choice(&self, rgb: &str, ir: &str) -> Option<CameraChoice> {
+        let inventory = self.current_inventory()?;
+        let candidate = inventory.candidates.iter().find(|candidate| {
+            candidate.endpoint_paths.iter().any(|path| path == rgb)
+                && candidate.endpoint_paths.iter().any(|path| path == ir)
+        })?;
+        Some(CameraChoice {
+            supervisor: inventory.supervisor_id.clone()?,
+            candidate: candidate.clone(),
+            rgb: rgb.into(),
+            ir: ir.into(),
+        })
+    }
+
+    fn camera_choice_current(&self, choice: &CameraChoice) -> bool {
+        self.camera_choice(&choice.rgb, &choice.ir)
+            .is_some_and(|current| {
+                current.supervisor == choice.supervisor && current.candidate == choice.candidate
+            })
+    }
+
+    fn check_camera_confirmation(&mut self) {
+        if self
+            .camera_confirmation
+            .as_ref()
+            .is_some_and(|choice| !self.camera_choice_current(choice))
+        {
+            self.camera_confirmation = None;
+            if matches!(
+                self.confirm,
+                Some((_, _, ConfirmAct::Sus(Suspend::SetCameras(..))))
+            ) {
+                self.confirm = None;
+                self.set_error("Camera connection changed or its current inventory is unavailable. Select the camera again before switching.");
+            }
+        }
+    }
+
+    fn apply_live_snapshot(
+        &mut self,
+        snapshot: irlume_common::live::LiveStatusSnapshot,
+        now: Instant,
+    ) {
+        let epoch = (snapshot.daemon_instance, snapshot.state_revision);
+        if self
+            .live_epoch
+            .as_ref()
+            .is_some_and(|prior| prior != &epoch)
+        {
+            self.invalidate_daemon_observations();
+        }
+        self.live_epoch = Some(epoch);
+        self.daemon_up = matches!(
+            snapshot.stage,
+            irlume_common::live::LiveStage::Ready | irlume_common::live::LiveStage::Rebuilding
+        );
+        self.daemon_reach = if self.daemon_up {
+            crate::commands::DaemonReach::Running
+        } else {
+            crate::commands::DaemonReach::Starting
+        };
+        let camera_epoch = if snapshot.cameras.state
+            == irlume_common::live_camera::CameraInventoryState::Current
+        {
+            snapshot
+                .cameras
+                .supervisor_id
+                .clone()
+                .map(|supervisor| CameraEpoch {
+                    supervisor,
+                    revision: snapshot.cameras.revision,
+                })
+        } else {
+            None
+        };
+        if self.camera_epoch != camera_epoch {
+            self.invalidate_source(Source::Cameras);
+            self.invalidate_source(Source::CameraPrivacy);
+            self.invalidate_source(Source::Qualification);
+            self.freshness.cycle_mut(Worker::Cameras).invalidate();
+            self.freshness.cycle_mut(Worker::Qualification).invalidate();
+            self.classified_epoch = None;
+            self.camera_epoch = camera_epoch;
+        }
+        if snapshot.cameras.state == irlume_common::live_camera::CameraInventoryState::Current {
+            // Retain only the two configured endpoints needed to distinguish a
+            // previously observed UVC removal from an unmonitored backend.
+            if let Some(health) = &self.health {
+                let configured: Vec<_> =
+                    health.rgb_dev.iter().chain(health.ir_dev.iter()).collect();
+                self.known_uvc_paths
+                    .retain(|path| configured.contains(&path));
+                for path in configured {
+                    if snapshot
+                        .cameras
+                        .candidates
+                        .iter()
+                        .any(|candidate| candidate.endpoint_paths.contains(path))
+                        && !self.known_uvc_paths.contains(path)
+                    {
+                        self.known_uvc_paths.push(path.clone());
+                    }
+                }
+            }
+        }
+        self.live = Some(snapshot);
+        self.freshness
+            .observation_mut(Source::Live)
+            .record(true, now);
+        self.check_camera_confirmation();
+        self.update_camera_availability();
+        self.run_checks();
+        self.recompute_visible();
+    }
+
+    fn refresh_live(&mut self) {
+        if self.live_load.is_some() {
+            return;
+        }
+        self.freshness.cycle_mut(Worker::Live).begin();
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let result = match crate::daemon_poll(&Request::LiveStatus) {
+                Ok(Response::LiveStatus(snapshot)) => Ok(*snapshot),
+                Ok(_) => Err("live status is unavailable from this daemon".into()),
+                Err(_) => Err("live status is unavailable".into()),
+            };
+            let _ = tx.send(result);
+        });
+        self.live_load = Some(rx);
+    }
+
+    fn live_summary(&self) -> String {
+        use irlume_common::live::LiveStage;
+        let Some(live) = self
+            .live
+            .as_ref()
+            .filter(|_| self.source_usable(Source::Live))
+        else {
+            return "Daemon activity unavailable".into();
+        };
+        let stage = match live.stage {
+            LiveStage::Starting => "starting",
+            LiveStage::Ready => "ready",
+            LiveStage::Rebuilding => "rebuilding",
+            LiveStage::Stopping => "stopping",
+            LiveStage::Unknown => "state unknown",
+        };
+        if !live.tracking_available {
+            return format!("Daemon {stage}; activity unavailable");
+        }
+        let waiting: u128 = live
+            .waiting
+            .iter()
+            .map(|entry| u128::from(entry.count))
+            .sum();
+        if let Some(worker) = &live.worker {
+            format!(
+                "Daemon {stage}: {} · {}s{} · {waiting} waiting · {} background",
+                live_kind_label(worker.kind),
+                worker.elapsed_ms / 1000,
+                if worker.cancellation_requested {
+                    "; stop requested"
+                } else {
+                    ""
+                },
+                live.background.len()
+            )
+        } else if !live.background.is_empty() {
+            let work = &live.background[0];
+            format!(
+                "Daemon {stage}: background {} · {}s{} · {} other background · {waiting} waiting",
+                live_kind_label(work.kind),
+                work.elapsed_ms / 1000,
+                if work.cancellation_requested {
+                    "; stop requested"
+                } else {
+                    ""
+                },
+                live.background.len() - 1
+            )
+        } else if live.stage == LiveStage::Ready && waiting == 0 {
+            "Daemon ready · worker idle (Irlume only)".into()
+        } else {
+            format!("Daemon {stage} · {waiting} waiting")
+        }
+    }
+
+    fn live_details(&self) -> String {
+        let mut lines = vec![self.live_summary(), self.source_status(Source::Live),
+            "This observes Irlume's worker and known automatic tasks, not every application or physical camera power.".into()];
+        if let Some(live) = self
+            .live
+            .as_ref()
+            .filter(|_| self.source_usable(Source::Live))
+        {
+            if live.tracking_available {
+                for waiting in &live.waiting {
+                    lines.push(format!(
+                        "Waiting: {} × {}",
+                        waiting.count,
+                        live_kind_label(waiting.kind)
+                    ));
+                }
+            }
+            if live.tracking_available {
+                for work in &live.background {
+                    lines.push(format!(
+                        "Background: {} · {}s{}",
+                        live_kind_label(work.kind),
+                        work.elapsed_ms / 1000,
+                        if work.cancellation_requested {
+                            "; stop requested"
+                        } else {
+                            ""
+                        }
+                    ));
+                }
+            }
+            lines.push(String::new());
+            lines.push(match self.current_inventory() {
+                Some(inventory) => format!(
+                    "UVC inventory: {} connected candidate(s); roles require inspection",
+                    inventory.candidates.len()
+                ),
+                None => "UVC inventory unavailable; no absence or idle state is inferred".into(),
+            });
+            if let Some(inventory) = self.current_inventory() {
+                for camera in &inventory.candidates {
+                    lines.push(format!("  {}", camera.endpoint_paths.join(" + ")));
+                }
+            }
+        }
+        lines.push("\nSource observations".into());
+        for (source, label) in [
+            (Source::Health, "Engine configuration"),
+            (Source::Preferences, "Preferences"),
+            (Source::Wallet, "Wallet metadata"),
+            (Source::Recovery, "Recovery"),
+            (Source::Profiles, "Faces"),
+            (Source::Cameras, "Camera role inspection"),
+            (Source::CameraPrivacy, "Camera privacy inspection"),
+            (Source::Qualification, "Historical qualification"),
+            (Source::Machine, "Machine setup"),
+            (Source::FingerprintReader, "Fingerprint reader"),
+            (Source::Fingerprint, "Fingerprint enrollment"),
+            (Source::Apps, "Applications"),
+        ] {
+            lines.push(format!("{label}: {}", self.source_status(source)));
+        }
+        lines.push("\nSession action history is separate (L). PCR and recognition results are explicit historical checks, not live guarantees.".into());
+        lines.join("\n")
+    }
+
+    fn page_observation(&self) -> String {
+        let sources: &[Source] = match self.screen {
+            SC_PROFILES => &[Source::Profiles],
+            SC_CAMERAS => &[Source::Live, Source::Cameras, Source::CameraPrivacy],
+            SC_RECOVERY => &[Source::Recovery],
+            SC_KEYRING => &[Source::Wallet, Source::Machine],
+            SC_FINGERPRINT => &[Source::FingerprintReader, Source::Fingerprint],
+            SC_SETTINGS => &[Source::Preferences],
+            SC_PAM => &[Source::Machine, Source::Apps],
+            SC_REPAIR => &[Source::Health, Source::Machine, Source::Profiles],
+            SC_IDENTIFY => return "last test only · F4 current status".into(),
+            _ => &[Source::Health, Source::Profiles, Source::Machine],
+        };
+        if sources.iter().any(|source| !self.source_usable(*source)) {
+            "some observations unavailable · F4 details".into()
+        } else {
+            let age = sources
+                .iter()
+                .filter_map(|source| self.freshness.observation(*source).last_success)
+                .map(|at| self.now().saturating_duration_since(at).as_secs())
+                .max()
+                .unwrap_or(0);
+            format!("observations ≤{age}s old · F4 details")
+        }
+    }
+
+    fn background_idle(&self) -> bool {
+        self.op.is_none()
+            && self.enroll.is_none()
+            && self.input.is_none()
+            && self.confirm.is_none()
+            && self.enroll_merge.is_none()
+            && self.suspend.is_none()
+    }
+
+    fn profiles_refresh_due(&self, now: Instant, daemon_idle: bool) -> bool {
+        self.background_idle()
+            && daemon_idle
+            && (self.freshness.cycle(Worker::Profiles).pending()
+                || (matches!(self.screen, SC_WELCOME | SC_PROFILES | SC_REPAIR | SC_DONE)
+                    && self
+                        .freshness
+                        .cycle(Worker::Profiles)
+                        .due(now, Duration::from_secs(30))))
+    }
+
+    fn cameras_refresh_due(&self, daemon_idle: bool) -> bool {
+        daemon_idle
+            && self.background_idle()
+            && self.screen == SC_CAMERAS
+            && self.current_inventory().is_some()
+            && self.camera_epoch.is_some()
+            && (self.classified_epoch != self.camera_epoch
+                || self.freshness.cycle(Worker::Cameras).pending())
+            && self.camera_load.is_none()
+    }
+
+    fn refresh_due(&mut self, now: Instant) {
+        if self
+            .freshness
+            .cycle(Worker::Live)
+            .due(now, Duration::from_secs(1))
+        {
+            self.refresh_live();
+        }
+        if !self.background_idle() {
+            return;
+        }
+        if self
+            .freshness
+            .cycle(Worker::Light)
+            .due(now, Duration::from_millis(LIGHT_REFRESH_MS))
+        {
+            self.refresh_light();
+        }
+        if self
+            .freshness
+            .cycle(Worker::Machine)
+            .due(now, Duration::from_millis(HEAVY_REFRESH_MS))
+        {
+            self.request_probes();
+        }
+        if self.freshness.cycle(Worker::Apps).due(now, Self::HEAVY_TTL) {
+            self.refresh_heavy();
+        }
+        let daemon_idle = self
+            .live
+            .as_ref()
+            .filter(|_| self.source_usable(Source::Live))
+            .is_some_and(|live| {
+                live.stage == irlume_common::live::LiveStage::Ready
+                    && live.tracking_available
+                    && live.worker.is_none()
+                    && live.background.is_empty()
+                    && live.waiting.is_empty()
+            });
+        if self.profiles_refresh_due(now, daemon_idle) {
+            self.refresh_profiles();
+        }
+        if self.cameras_refresh_due(daemon_idle) {
+            self.refresh_camera_listing();
+        }
+    }
+
+    fn expire_observations(&mut self, now: Instant) {
+        let mut changed = false;
+        for source in Source::ALL {
+            let usable = self.freshness.usable(source, now);
+            changed |= self.usable_sources[source as usize] != usable;
+            self.usable_sources[source as usize] = usable;
+            if !usable {
+                self.clear_source(source);
+            }
+        }
+        self.check_camera_confirmation();
+        self.update_camera_availability();
+        if changed {
+            self.run_checks();
+            self.recompute_visible();
+        }
+    }
+
     /// `user` is resolved by the caller through `crate::user_arg`, NOT from
     /// $USER here.
     ///
@@ -1080,6 +1746,20 @@ impl App {
         let screen = visible.first().copied().unwrap_or(0);
         Self {
             user,
+            freshness: Freshness::default(),
+            clock_override: None,
+            usable_sources: [false; 13],
+            show_live: false,
+            live: None,
+            live_load: None,
+            live_epoch: None,
+            camera_epoch: None,
+            classified_epoch: None,
+            camera_confirmation: None,
+            selected_camera_choice: None,
+            selected_profile_identity: None,
+            qualification_load: None,
+            identify_checked_at: None,
             screen,
             sel: 0,
             profiles: Vec::new(),
@@ -1099,16 +1779,20 @@ impl App {
             pairs_known: false,
             capture_mode: None,
             camera_load: None,
-            activity: Vec::new(),
+            activity: activity::Activity::default(),
             input: None,
             confirm: None,
             mouse_select: false,
             click_targets: std::cell::RefCell::new(Vec::new()),
+            window_area: std::cell::Cell::new(None),
             dialog_view: std::cell::Cell::new((Rect::default(), 0)),
             dialog_scroll: std::cell::Cell::new(0),
             page_view: std::cell::Cell::new((usize::MAX, Rect::default(), 0, 0)),
             show_help: false,
             more_actions: None,
+            sections: None,
+            action_focus: None,
+            action_reveal: std::cell::Cell::new(false),
             hub_sel: 0,
             op: None,
             enroll: None,
@@ -1133,9 +1817,12 @@ impl App {
             preferences: None,
             act_scroll: 0,
             activity_open: false,
+            activity_history_open: false,
             reduce_motion: std::env::var_os("IRLUME_REDUCE_MOTION")
                 .is_some_and(|v| !v.is_empty() && v != "0"),
             visible,
+            reported_caps: caps,
+            known_uvc_paths: Vec::new(),
             caps,
             fp_present,
             fp_known: false,
@@ -1196,20 +1883,45 @@ impl App {
     /// Re-derive tab visibility from live state; keeps the current screen when
     /// it survives, else snaps to the nearest visible step.
     fn recompute_visible(&mut self) {
+        let chosen_screen = self
+            .sections
+            .and_then(|index| self.visible.get(index))
+            .copied();
         // The hub lists the VISIBLE screens, so this is where its list can
         // shrink ([v] leaves advanced view, a probe lands, the daemon goes
         // away). `move_sel` wraps modulo the current length, so a stale index
         // fixes itself on the next arrow, but until then no row is highlighted
         // and Enter silently opens nothing: an advertised key doing nothing,
         // which is the shape this pass keeps finding.
+        let navigation_caps = irlume_camera::Caps {
+            rgb: self.caps.rgb || self.reported_caps.rgb,
+            ir_pair: self.caps.ir_pair || self.reported_caps.ir_pair,
+        };
         self.visible = Self::compute_visible(
-            &self.caps,
+            &navigation_caps,
             VisibilityInputs {
                 fp_present: self.fp_present,
                 advanced: self.advanced,
             },
             &self.repair,
         );
+        if (self.screen == SC_CAMERAS || self.current_inventory().is_some())
+            && !self.visible.contains(&SC_CAMERAS)
+        {
+            let insert_at = self
+                .visible
+                .iter()
+                .position(|screen| *screen == SC_IDENTIFY || *screen == SC_SETTINGS)
+                .unwrap_or(self.visible.len());
+            self.visible.insert(insert_at, SC_CAMERAS);
+        }
+        if self.visible.is_empty() {
+            self.sections = None;
+        } else if let Some(selected) = &mut self.sections {
+            *selected = chosen_screen
+                .and_then(|screen| self.visible.iter().position(|&visible| visible == screen))
+                .unwrap_or((*selected).min(self.visible.len() - 1));
+        }
         if !self.visible.contains(&self.screen) {
             let cur = self.screen;
             self.screen = self
@@ -1250,30 +1962,34 @@ impl App {
 
     /// Capability-aware recommended unlock method (item: "suggest the best one").
     fn recommended(&self) -> &'static str {
-        match (self.caps.ir_pair, self.caps.rgb, self.fp_present) {
+        if self.face_camera_presence().is_none() && !self.source_usable(Source::FingerprintReader) {
+            return "Hardware availability unknown; password remains available";
+        }
+        match (
+            self.caps.ir_pair,
+            self.caps.rgb,
+            self.fp_present && self.source_usable(Source::FingerprintReader),
+        ) {
             // "in the dark", never "dark mode": IR needs no visible light,
             // but "dark mode" reads as a UI theme.
             (true, _, _) => "Face (IR) · secure: login, sudo, lock screen, in the dark",
             (false, true, true) => "Fingerprint (secure), or Face (RGB) for lock-screen only",
             (false, true, false) => "Face (RGB) · convenience: lock-screen unlock only",
             (false, false, true) => "Fingerprint",
-            (false, false, false) => "Password only (no supported biometric hardware)",
+            (false, false, false) => {
+                "Password remains available; biometric availability unconfirmed"
+            }
         }
     }
 
     fn log(&mut self, g: char, m: impl Into<String>) {
-        self.activity.push((g, m.into()));
+        self.activity.push(g, m.into());
         // If the user has scrolled up to read history, hold their view in place
         // as new lines arrive (instead of yanking them to the bottom).
         if self.act_scroll > 0 {
             self.act_scroll += 1;
         }
-        let n = self.activity.len();
-        if n > 200 {
-            let d = n - 200;
-            self.activity.drain(0..d);
-            self.act_scroll = self.act_scroll.saturating_sub(d);
-        }
+        self.act_scroll = self.act_scroll.min(self.act_max());
     }
 
     /// Record a failure: log it AND raise the dismissible error banner so the
@@ -1293,6 +2009,7 @@ impl App {
         if self.light_load.is_some() {
             return;
         }
+        self.freshness.cycle_mut(Worker::Light).begin();
         let (tx, rx) = mpsc::channel();
         let user = self.user.clone();
         let prev_armed = self.keyring_armed;
@@ -1308,13 +2025,17 @@ impl App {
     /// serializes it against captures exactly like an enrollment: the
     /// enumeration still opens nodes, but only ever on the one thread that
     /// owns them (#187). A refusal (an authentication holds the camera) or
-    /// any transport error leaves the previous listing in place rather than
-    /// blanking it, because neither is an observation that the cameras are
-    /// gone.
+    /// any transport error makes role inspection unavailable. Passive inventory
+    /// remains the authority for attachment, independently of classification.
     fn refresh_camera_listing(&mut self) {
+        if self.current_inventory().is_none() {
+            return;
+        }
         if self.camera_load.is_some() {
             return;
         }
+        self.classified_epoch = self.camera_epoch.clone();
+        self.freshness.cycle_mut(Worker::Cameras).begin();
         let (tx, rx) = mpsc::channel();
         std::thread::spawn(move || {
             let _ = tx.send(CameraListing::gather());
@@ -1322,11 +2043,9 @@ impl App {
         self.camera_load = Some(rx);
     }
 
-    /// Capabilities as the DAEMON reports them, for use whenever it is
-    /// reachable (#187): it already has the cameras open, so it can say what
-    /// they are without the TUI opening anything. `tier` is the daemon's own
-    /// hardware classification; only the secure tier means a usable IR pair,
-    /// and any reported RGB device means RGB capture works.
+    /// Engine/configuration capabilities as reported by the daemon. Current
+    /// presence is checked independently against passive inventory; this alone
+    /// is not evidence of an open device or usable capture.
     fn caps_from_health(h: &HealthInfo) -> irlume_camera::Caps {
         irlume_camera::Caps {
             ir_pair: h.tier == "secure",
@@ -1337,6 +2056,25 @@ impl App {
     /// Land a background light poll: the daemon reads plus the selection
     /// clamps the inline version used to apply.
     fn apply_light(&mut self, l: LightState) {
+        let became_up = !self.daemon_up && l.daemon_up;
+        for (index, source) in [
+            Source::Health,
+            Source::Preferences,
+            Source::Wallet,
+            Source::Recovery,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            self.freshness.observation_mut(source).record(
+                l.observed_at[index].is_some(),
+                l.observed_at[index].unwrap_or_else(Instant::now),
+            );
+            if l.observed_at[index].is_none() {
+                self.clear_source(source);
+            }
+        }
+
         if (self.daemon_up && !l.daemon_up)
             || (self.keyring_armed.is_some()
                 && (self.keyring_armed != l.keyring_armed
@@ -1353,31 +2091,23 @@ impl App {
         self.preferences = l.preferences;
         // The daemon is the authority on cameras while it is reachable.
         if let Some(h) = self.health.as_ref() {
-            self.caps = Self::caps_from_health(h);
+            self.reported_caps = Self::caps_from_health(h);
         }
         if l.daemon_up {
             self.keyring_armed = l.keyring_armed;
             self.keyring_policy = l.keyring_policy;
             self.keyring_kind = l.keyring_kind;
-            if l.recovery.is_some() {
-                self.recovery = l.recovery;
-            }
+            self.recovery = l.recovery;
         }
         // The daemon just became reachable and no list was ever loaded (the
         // startup attempt may have raced a still-booting daemon): fetch it
         // now instead of waiting for a tab visit.
-        if self.daemon_up && !self.profiles_loaded && self.enroll_error.is_none() {
+        if became_up && !self.source_usable(Source::Profiles) && self.enroll_error.is_none() {
             self.refresh_profiles();
         }
-        let max = self.rows().len().max(1);
-        // One past the list is an intentionally cleared selection after a removal.
-        if self.sel > max {
-            self.sel = max - 1;
-        }
-        let pairs = self.pairs.len().max(1);
-        if self.cam_sel >= pairs {
-            self.cam_sel = pairs - 1;
-        }
+        // A status reply cannot select a different profile or camera. List
+        // publication preserves stable identities and deliberately allows an
+        // unselected sentinel after the previous target disappeared.
     }
 
     /// Request the FULL machine sweep (fingerprint via fprintd, the PAM and
@@ -1388,6 +2118,7 @@ impl App {
         if self.probes_load.is_some() {
             return;
         }
+        self.freshness.cycle_mut(Worker::Machine).begin();
         let (tx, rx) = mpsc::channel();
         let user = self.user.clone();
         std::thread::spawn(move || {
@@ -1416,6 +2147,7 @@ impl App {
         if self.profiles_load.is_some() {
             return;
         }
+        self.freshness.cycle_mut(Worker::Profiles).begin();
         let (tx, rx) = mpsc::channel();
         let user = self.user.clone();
         std::thread::spawn(move || {
@@ -1492,11 +2224,21 @@ impl App {
     /// refresh_profiles needs), profiles load, THEN recompute_checks runs so
     /// run_checks sees the fresh profile list (not the stale/empty one).
     /// Full refresh: request daemon state, enrollment state, and the complete
-    /// machine snapshot. Existing landed state stays visible until the
-    /// replacements arrive through `poll()`; recomputing here would copy a
-    /// default (unlanded) snapshot over real observations and hide screens.
+    /// machine snapshot. Invalidate old observations and discard pre-mutation
+    /// worker replies; replacements arrive through `poll()` without blocking input.
     fn refresh(&mut self) {
-        self.invalidate_keyring_diagnostic();
+        self.invalidate_daemon_observations();
+        for source in [
+            Source::Machine,
+            Source::FingerprintReader,
+            Source::Fingerprint,
+            Source::Apps,
+        ] {
+            self.invalidate_source(source);
+        }
+        self.freshness.cycle_mut(Worker::Machine).invalidate();
+        self.freshness.cycle_mut(Worker::Apps).invalidate();
+        self.refresh_live();
         self.refresh_light();
         self.refresh_profiles();
         self.request_probes();
@@ -1573,7 +2315,49 @@ impl App {
                     Fix::Root(RootFix::RestartDaemon),
                 ),
             };
+            let (sev, detail, fix) = if let Some(live) = self
+                .live
+                .as_ref()
+                .filter(|_| self.source_usable(Source::Live))
+            {
+                let sev = if live.stage == irlume_common::live::LiveStage::Ready
+                    && live.tracking_available
+                {
+                    Sev::Ok
+                } else if live.stage == irlume_common::live::LiveStage::Unknown
+                    || !live.tracking_available
+                {
+                    Sev::Unknown
+                } else {
+                    Sev::Warn
+                };
+                (sev, self.live_summary(), Fix::None)
+            } else if !self.source_usable(Source::Health) && self.daemon_reach == R::Running {
+                (
+                    Sev::Unknown,
+                    "daemon observations unavailable; last reachability result was running".into(),
+                    Fix::None,
+                )
+            } else {
+                (
+                    sev,
+                    format!("{detail}; current worker status unavailable"),
+                    fix,
+                )
+            };
             v.push(mk("Daemon (irlumed)", sev, detail, fix));
+        }
+
+        if !self.source_usable(Source::Machine) {
+            v.push(mk(
+                "Setup observations",
+                Sev::Unknown,
+                self.source_status(Source::Machine),
+                Fix::None,
+            ));
+            self.repair = v;
+            self.repair_sel = self.repair_sel.min(self.repair.len().saturating_sub(1));
+            return;
         }
 
         // ONNX Runtime + Models: the daemon is the ground truth: if it answers
@@ -1694,20 +2478,41 @@ impl App {
                 },
             ));
             // Camera row from the daemon's validated tier (never the raw fallback).
-            let priv_on = self.pairs.iter().any(|p| p.privacy);
+            let priv_on = self.current_inventory().is_some()
+                && self.source_usable(Source::CameraPrivacy)
+                && self.pairs.iter().any(|p| p.privacy);
             let (csev, cdetail, cfix) = match h.tier.as_str() {
-                _ if priv_on => (Sev::Warn, "camera present, but a privacy switch is ON".to_string(),
-                    Fix::Manual("turn off the camera privacy switch".into())),
-                "secure" => (Sev::Ok,
-                    format!("RGB + IR ({} + {}): secure tier",
-                        h.rgb_dev.as_deref().unwrap_or("?"), h.ir_dev.as_deref().unwrap_or("?")),
-                    Fix::None),
-                "convenience" => (Sev::Warn,
-                    format!("RGB-only ({}), convenience tier: face unlocks the screen only, never sudo/login",
-                        h.rgb_dev.as_deref().unwrap_or("?")),
-                    Fix::None),
-                _ => (Sev::Warn, "no camera: face auth unavailable (password/fingerprint only)".to_string(),
-                    Fix::None),
+                _ if self.face_camera_presence() == Some(false) => (Sev::Warn,
+                    "configured UVC camera disconnected; last engine configuration is historical".into(), Fix::None),
+                _ if self.face_camera_presence().is_none() => (Sev::Unknown,
+                    "current camera presence unconfirmed; engine configuration is not an attachment observation".into(), Fix::None),
+                _ if priv_on => (
+                    Sev::Warn,
+                    "camera present, but a privacy switch is ON".to_string(),
+                    Fix::Manual("turn off the camera privacy switch".into()),
+                ),
+                "secure" => (
+                    Sev::Ok,
+                    format!(
+                        "UVC endpoints present ({} + {}); engine configured secure",
+                        h.rgb_dev.as_deref().unwrap_or("?"),
+                        h.ir_dev.as_deref().unwrap_or("?")
+                    ),
+                    Fix::None,
+                ),
+                "convenience" => (
+                    Sev::Warn,
+                    format!(
+                        "RGB-only ({}), convenience tier: face unlocks the screen only, never sudo/login",
+                        h.rgb_dev.as_deref().unwrap_or("?")
+                    ),
+                    Fix::None,
+                ),
+                _ => (
+                    Sev::Warn,
+                    "camera role unclassified; no physical absence is inferred".to_string(),
+                    Fix::None,
+                ),
             };
             v.push(mk("Cameras", csev, cdetail, cfix));
             // Emitter fix only makes sense when an IR node exists.
@@ -1724,47 +2529,7 @@ impl App {
                 // where it is offered without a diagnosis attached.
             }
         } else {
-            let ort = std::env::var("ORT_DYLIB_PATH")
-                .ok()
-                .filter(|p| std::path::Path::new(p).exists())
-                .is_some()
-                || ORT_FALLBACK_PATHS
-                    .iter()
-                    .any(|p| std::path::Path::new(p).exists());
-            v.push(ort_fallback_check(ort));
-            v.push(tflite_fallback_check(
-                std::env::var(irlume_vision::tflite::TFLITE_LIB_ENV)
-                    .ok()
-                    .as_deref(),
-                |p| p.exists(),
-            ));
-
-            // Resolve models the way the daemon does (env → /usr/share/irlume/models
-            // → repo cwd), NOT just cwd-relative; a packaged install keeps them in
-            // /usr/share and the TUI is rarely launched from the repo.
-            let m1 = crate::commands::resolve_model("glintr100.onnx", "IRLUME_MODEL").is_some();
-            let m2 = crate::commands::resolve_model(
-                "face_detection_yunet_2023mar.onnx",
-                "IRLUME_DET_MODEL",
-            )
-            .is_some();
-            v.push(mk(
-                "Models",
-                if m1 && m2 { Sev::Ok } else { Sev::Fail },
-                if m1 && m2 {
-                    "YuNet + AuraFace present".into()
-                } else {
-                    "not found (daemon down; local probe)".into()
-                },
-                if m1 && m2 {
-                    Fix::None
-                } else {
-                    Fix::Manual(
-                        "install the irlume package (models ship in /usr/share/irlume/models)"
-                            .into(),
-                    )
-                },
-            ));
+            v.extend(self.probes.runtime_checks.clone());
 
             let rgb = self
                 .nodes
@@ -1774,7 +2539,9 @@ impl App {
                 .nodes
                 .iter()
                 .any(|(_, r)| matches!(r, irlume_camera::Role::Ir));
-            let priv_on = self.pairs.iter().any(|p| p.privacy);
+            let priv_on = self.current_inventory().is_some()
+                && self.source_usable(Source::CameraPrivacy)
+                && self.pairs.iter().any(|p| p.privacy);
             let (csev, cdetail, cfix) = if self.nodes.is_empty() {
                 // No observation is not proof of missing cameras. In particular,
                 // restarting cannot fix a still-loading or inaccessible daemon.
@@ -1788,7 +2555,7 @@ impl App {
             } else if !rgb && !ir {
                 (
                     Sev::Warn,
-                    "no camera: face auth unavailable (password/fingerprint only)".to_string(),
+                    "camera role unclassified; no physical absence is inferred".to_string(),
                     Fix::None,
                 )
             } else if !ir {
@@ -1917,8 +2684,15 @@ impl App {
         }
         // Fingerprint reader health: a crashed/aborted enrollment leaves the
         // device CLAIMED and pam_fprintd fails silently (no finger prompt).
-        if self.fp.available {
-            if self.probes.reader_stuck {
+        if self.fp.available && self.source_usable(Source::FingerprintReader) {
+            if !self.source_usable(Source::Fingerprint) {
+                v.push(mk(
+                    "Fingerprint enrollment",
+                    Sev::Unknown,
+                    "reader observed; enrollment list unavailable".into(),
+                    Fix::None,
+                ));
+            } else if self.probes.reader_stuck {
                 v.push(mk(
                     "Fingerprint reader",
                     Sev::Fail,
@@ -1945,25 +2719,16 @@ impl App {
         // instead asks "does an auth RULE run this module", the same parsed
         // question the enable gate asks, so a session line or an argument
         // naming the file cannot suppress the not-wired Fail.
-        let pam_has = |needle: &str| {
-            ["/etc/pam.d/common-auth", "/etc/pam.d/system-auth"]
-                .iter()
-                .any(|p| {
-                    std::fs::read_to_string(p)
-                        .map(|s| {
-                            s.lines()
-                                .any(|l| crate::pamwire::directive(l).contains(needle))
-                        })
-                        .unwrap_or(false)
-                })
-        };
-        // The CLI's own gate, not a copy (#583 audit): Omarchy wires
-        // pam_fprintd into sudo/polkit-1 and the lock lane, never into
-        // common-auth/system-auth, so the old two-file probe read a
-        // healthy Omarchy box as unwired.
-        let fprintd_wired =
-            crate::fingerprint::pam_fprintd_wired_pub(&crate::fingerprint::PamSearchPath::live());
+        let fprintd_wired = self.probes.fprintd_wired;
         match self.fp.method.as_str() {
+            "fingerprint" if !self.source_usable(Source::Fingerprint) => {
+                v.push(mk(
+                    "Method wiring",
+                    Sev::Unknown,
+                    "fingerprint enrollment is unobserved".into(),
+                    Fix::None,
+                ));
+            }
             "fingerprint" => {
                 if !fprintd_wired {
                     v.push(mk(
@@ -2067,7 +2832,7 @@ impl App {
         // Foreign face-auth modules left over from another tool hijack the same
         // PAM slots (a leftover module intercepted the greeter in live testing).
         for foreign in ["howdy", "linhello"] {
-            if pam_has(foreign) {
+            if self.probes.foreign_pam.contains(&foreign) {
                 v.push(mk("Other face auth", Sev::Warn,
                     format!("another face-auth module ({foreign}) is wired; it will conflict with irlume"),
                     Fix::Manual(format!("remove the {foreign} lines from /etc/pam.d (or uninstall it)"))));
@@ -2404,7 +3169,7 @@ impl App {
         map: fn(Response) -> (bool, String),
     ) {
         let label = label.into();
-        self.log('→', format!("daemon: {label}"));
+        self.log('→', format!("daemon: {label}\n{}", request_effect(&req)));
         let (tx, rx) = mpsc::channel();
         std::thread::spawn(move || {
             let r = match crate::daemon_request(&req) {
@@ -2558,6 +3323,7 @@ impl App {
         if self.heavy_load.is_some() {
             return;
         }
+        self.freshness.cycle_mut(Worker::Apps).begin();
         let (tx, rx) = mpsc::channel();
         std::thread::spawn(move || {
             let _ = tx.send(gather());
@@ -2566,88 +3332,188 @@ impl App {
     }
 
     fn poll(&mut self) {
-        if let Some(rx) = &self.heavy_load {
-            match rx.try_recv() {
-                Ok(result) => {
-                    self.heavy_load = None;
-                    self.heavy_at = std::time::Instant::now();
-                    if let Ok(state) = result {
+        let now = self.now();
+        if let Some(result) = receive_finished(&self.live_load) {
+            self.live_load = None;
+            if self.freshness.cycle_mut(Worker::Live).finish(now) {
+                match result {
+                    Ok(Ok(snapshot)) => self.apply_live_snapshot(snapshot, now),
+                    _ => {
+                        self.freshness
+                            .observation_mut(Source::Live)
+                            .record(false, now);
+                        self.clear_source(Source::Live);
+                    }
+                }
+            }
+        }
+        if let Some(result) = receive_finished(&self.heavy_load) {
+            self.heavy_load = None;
+            self.heavy_at = now;
+            if self.freshness.cycle_mut(Worker::Apps).finish(now) {
+                let success = matches!(&result, Ok(Ok(_)));
+                self.freshness
+                    .observation_mut(Source::Apps)
+                    .record(success, now);
+                match result {
+                    Ok(Ok(state)) => {
                         self.heavy = state;
                         self.heavy_known = true;
                     }
+                    Err(()) => {
+                        self.clear_source(Source::Apps);
+                        self.log('!', "app status refresh ended without a result; current app state is unavailable. Refresh to retry.");
+                    }
+                    Ok(Err(_)) => self.clear_source(Source::Apps),
                 }
-                Err(mpsc::TryRecvError::Disconnected) => {
-                    self.heavy_load = None;
-                    self.heavy_at = std::time::Instant::now();
-                }
-                Err(mpsc::TryRecvError::Empty) => {}
             }
         }
-        if let Some(rx) = &self.camera_load {
-            match rx.try_recv() {
-                Ok(listing) => {
-                    self.camera_load = None;
-                    if let Some(pairs) = listing.pairs {
-                        self.pairs = pairs;
-                        self.pairs_known = true;
-                        self.cam_sel = self.cam_sel.min(self.pairs.len().saturating_sub(1));
+        if let Some(result) = receive_finished(&self.camera_load) {
+            self.camera_load = None;
+            if self.freshness.cycle_mut(Worker::Cameras).finish(now) {
+                let pairs = result
+                    .as_ref()
+                    .ok()
+                    .and_then(|listing| listing.pairs.as_ref());
+                self.freshness
+                    .observation_mut(Source::Cameras)
+                    .record(pairs.is_some(), now);
+                self.freshness
+                    .observation_mut(Source::CameraPrivacy)
+                    .record(pairs.is_some(), now);
+                if let Some(pairs) = pairs {
+                    let selected = self.selected_camera_choice.take().or_else(|| {
+                        (self.pairs_known || !self.pairs.is_empty()).then(|| {
+                            self.pairs
+                                .get(self.cam_sel)
+                                .and_then(|pair| self.camera_choice(&pair.rgb, &pair.ir))
+                        })
+                    });
+                    self.pairs = pairs
+                        .iter()
+                        .filter(|pair| self.camera_choice(&pair.rgb, &pair.ir).is_some())
+                        .cloned()
+                        .collect();
+                    self.pairs_known = true;
+                    self.cam_sel = match selected {
+                        None => 0,
+                        Some(Some(choice)) if self.camera_choice_current(&choice) => self
+                            .pairs
+                            .iter()
+                            .position(|pair| pair.rgb == choice.rgb && pair.ir == choice.ir)
+                            .unwrap_or(self.pairs.len()),
+                        Some(_) => self.pairs.len(),
+                    };
+                } else {
+                    self.clear_source(Source::Cameras);
+                    if result.is_err() {
+                        self.log('!', "camera refresh ended without a result; current camera classification is unavailable. Refresh to retry.");
                     }
-                    if let Some(mode) = listing.mode {
-                        self.capture_mode = Some(mode);
-                    }
-                    self.run_checks();
-                    self.recompute_visible();
                 }
-                Err(mpsc::TryRecvError::Disconnected) => self.camera_load = None,
-                Err(mpsc::TryRecvError::Empty) => {}
-            }
-        }
-        if self.heavy_at.elapsed() >= Self::HEAVY_TTL {
-            self.refresh_heavy();
-        }
-        if let Some(rx) = &self.light_load {
-            if let Ok(l) = rx.try_recv() {
-                self.light_load = None;
-                self.apply_light(l);
-                // The checklist reads daemon_up/health; rebuild it from the
-                // fresh reads (pure: no probes are taken here).
                 self.run_checks();
                 self.recompute_visible();
             }
         }
-        if let Some(rx) = &self.probes_load {
-            if let Ok(p) = rx.try_recv() {
-                self.probes_load = None;
-                self.probes = p;
-                self.probes_landed = true;
-                self.recompute_checks();
+        if let Some(result) = receive_finished(&self.qualification_load) {
+            self.qualification_load = None;
+            if self.freshness.cycle_mut(Worker::Qualification).finish(now) {
+                let value = result.ok().flatten();
+                self.freshness
+                    .observation_mut(Source::Qualification)
+                    .record(value.is_some(), now);
+                if let Some(value) = value {
+                    self.capture_mode = Some(value);
+                }
             }
         }
-        if let Some(rx) = &self.keyring_load {
-            match rx.try_recv() {
-                Ok((generation, reply)) => {
-                    self.keyring_load = None;
-                    if generation == self.keyring_generation {
-                        self.keyring_drift = match reply {
-                            Ok(Response::KeyringInfo { drifted, .. }) => drifted,
-                            _ => None,
-                        };
-                        self.keyring_checked_at = Some(std::time::Instant::now());
-                        self.run_checks();
-                        self.recompute_visible();
+        if let Some(result) = receive_finished(&self.light_load) {
+            self.light_load = None;
+            if self.freshness.cycle_mut(Worker::Light).finish(now) {
+                match result {
+                    Ok(light) => self.apply_light(light),
+                    Err(()) => {
+                        for source in [
+                            Source::Health,
+                            Source::Preferences,
+                            Source::Wallet,
+                            Source::Recovery,
+                        ] {
+                            self.freshness.observation_mut(source).record(false, now);
+                            self.clear_source(source);
+                        }
+                        self.log('!', "status refresh ended without a result; current status is unavailable. Refresh to retry.");
                     }
                 }
-                Err(mpsc::TryRecvError::Disconnected) => self.keyring_load = None,
-                Err(mpsc::TryRecvError::Empty) => {}
+                self.run_checks();
+                self.recompute_visible();
             }
         }
-        if let Some(rx) = &self.profiles_load {
-            if let Ok(outcome) = rx.try_recv() {
-                self.profiles_load = None;
+        if let Some(result) = receive_finished(&self.probes_load) {
+            self.probes_load = None;
+            if self.freshness.cycle_mut(Worker::Machine).finish(now) {
+                self.freshness
+                    .observation_mut(Source::Machine)
+                    .record(result.is_ok(), now);
+                match result {
+                    Ok(probes) => {
+                        self.freshness
+                            .observation_mut(Source::FingerprintReader)
+                            .record(probes.fp_present.is_some(), now);
+                        self.freshness
+                            .observation_mut(Source::Fingerprint)
+                            .record(probes.fp_enrollment_observed, now);
+                        self.probes = probes;
+                        self.probes_landed = true;
+                        self.recompute_checks();
+                    }
+                    Err(()) => {
+                        for source in [
+                            Source::Machine,
+                            Source::FingerprintReader,
+                            Source::Fingerprint,
+                        ] {
+                            self.freshness.observation_mut(source).record(false, now);
+                            self.clear_source(source);
+                        }
+                        self.log('!', "diagnostics refresh ended without a result; current checks are unavailable. Refresh to retry.");
+                    }
+                }
+            }
+        }
+        if let Some(result) = receive_finished(&self.keyring_load) {
+            self.keyring_load = None;
+            match result {
+                Ok((generation, reply)) if generation == self.keyring_generation => {
+                    self.keyring_drift = match reply {
+                        Ok(Response::KeyringInfo { drifted, .. }) => drifted,
+                        _ => None,
+                    };
+                    self.keyring_checked_at = Some(now);
+                    self.run_checks();
+                    self.recompute_visible();
+                }
+                Err(()) => {
+                    self.keyring_drift = None;
+                    self.log('!', "wallet check ended without a result; current PCR state is unavailable. Check again to retry.");
+                }
+                _ => {}
+            }
+        }
+        if let Some(result) = receive_finished(&self.profiles_load) {
+            self.profiles_load = None;
+            if self.freshness.cycle_mut(Worker::Profiles).finish(now) {
+                let outcome = result.unwrap_or_else(|()| ProfilesOutcome::Transport("profile refresh ended without a result; current profiles are unavailable. Refresh to retry.".into()));
+                self.freshness
+                    .observation_mut(Source::Profiles)
+                    .record(matches!(&outcome, ProfilesOutcome::Loaded { .. }), now);
                 match outcome {
                     ProfilesOutcome::Loaded { profiles } => {
-                        let selected = self.selected_profile_row();
-                        let selection_cleared = !self.profiles.is_empty() && selected.is_none();
+                        let selected = self.selected_profile_identity.take().or_else(|| {
+                            (self.profiles_loaded || !self.profiles.is_empty())
+                                .then(|| self.selected_profile_row())
+                        });
+                        let selection_cleared = matches!(selected, Some(None));
+                        let selected = selected.flatten();
                         self.profiles = profiles;
                         if let Some(selected) = selected {
                             self.sel = self.rows().iter().position(|row| self.profile_row_name(*row) == selected).unwrap_or_else(|| {
@@ -2661,26 +3527,36 @@ impl App {
                         self.enroll_error = None;
                         self.profiles_loaded = true;
                     }
-                    ProfilesOutcome::DaemonError(e) => self.enroll_error = Some(e),
-                    // Transport failures are not state: the previous list
-                    // stays, the next refresh retries, and the Activity log
-                    // says why the list may be stale.
-                    ProfilesOutcome::Transport(e) => {
-                        self.log('·', format!("profile list not refreshed: {e}"));
+                    ProfilesOutcome::DaemonError(error) => {
+                        self.clear_source(Source::Profiles);
+                        self.enroll_error = Some(error);
+                    }
+                    ProfilesOutcome::Transport(error) => {
+                        self.clear_source(Source::Profiles);
+                        self.enroll_error = None;
+                        self.log('·', format!("profile list not refreshed: {error}"));
                     }
                 }
-                // The checks read the profile list (the no-enrollment warn);
-                // recompute now that it is current.
                 self.recompute_checks();
             }
         }
         if let Some(op) = &self.op {
-            if let Ok((ok, msg)) = op.rx.try_recv() {
-                let tag = op.tag;
-                // The IR self-test shows its own result line on the Repair screen;
-                // a normal "no face / uncertain" outcome shouldn't also raise the
-                // alarming error modal (that's for genuine failures like a busy
-                // camera). Identify/Generic keep the modal on failure.
+            let tag = op.tag;
+            let result = match op.rx.try_recv() {
+                Ok(result) => Some(result),
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    let msg = format!("The {} task ended without a result. Its outcome is unknown; refresh status before retrying.", op.label);
+                    self.op = None;
+                    if matches!(tag, OpTag::Identify) {
+                        self.identify_result = Some((false, msg.clone()));
+                        self.identify_checked_at = Some(now);
+                    }
+                    self.set_error(msg);
+                    None
+                }
+                Err(mpsc::TryRecvError::Empty) => None,
+            };
+            if let Some((ok, msg)) = result {
                 if ok {
                     self.log('✓', msg.clone());
                 } else if !matches!(tag, OpTag::Identify) {
@@ -2688,9 +3564,9 @@ impl App {
                 } else {
                     self.log('·', msg.clone());
                 }
-                match tag {
-                    OpTag::Identify => self.identify_result = Some((ok, msg)),
-                    OpTag::Generic => {}
+                if matches!(tag, OpTag::Identify) {
+                    self.identify_result = Some((ok, msg));
+                    self.identify_checked_at = Some(now);
                 }
                 self.op = None;
                 self.refresh();
@@ -2699,9 +3575,13 @@ impl App {
         if let Some(e) = &self.enroll {
             let target = e.target;
             let mut msgs = Vec::new();
-            while let Ok(m) = e.rx.try_recv() {
-                msgs.push(m);
-            }
+            let disconnected = loop {
+                match e.rx.try_recv() {
+                    Ok(m) => msgs.push(m),
+                    Err(mpsc::TryRecvError::Empty) => break false,
+                    Err(mpsc::TryRecvError::Disconnected) => break true,
+                }
+            };
             let mut finished = false;
             let mut merge: Option<MergeConfirm> = None;
             for m in msgs {
@@ -2807,81 +3687,35 @@ impl App {
                     }
                 }
             }
+            if disconnected && !finished {
+                if let Some(enrollment) = &self.enroll {
+                    enrollment.stop.store(true, Ordering::Relaxed);
+                }
+                self.set_error("The enrollment task ended without a result. Its outcome is unknown; refreshing saved profiles before you retry.");
+                finished = true;
+            }
             if finished {
                 self.enroll = None;
                 self.enroll_merge = merge;
                 self.refresh();
             }
         }
+        self.expire_observations(now);
     }
 
     fn main_loop(&mut self, terminal: &mut ratatui::DefaultTerminal) -> std::io::Result<()> {
-        use ratatui::crossterm::event::MouseEventKind;
-        let mut last_light = std::time::Instant::now();
-        let mut last_heavy = std::time::Instant::now();
         while !self.quit {
-            terminal.draw(|f| self.draw(f))?;
+            terminal.draw(|f| self.draw_window(f))?;
             if event::poll(Duration::from_millis(100))? {
-                match event::read()? {
-                    Event::Key(k) if k.kind == KeyEventKind::Press => {
-                        // A Ctrl-modified letter (Ctrl-C…) must not alias to
-                        // that letter's action. Plain keys pass through.
-                        let ctrl = k
-                            .modifiers
-                            .contains(ratatui::crossterm::event::KeyModifiers::CONTROL);
-                        if !(ctrl && matches!(k.code, KeyCode::Char(_))) {
-                            self.on_key(k.code)
-                        }
-                    }
-                    Event::Mouse(m) => match m.kind {
-                        MouseEventKind::ScrollUp | MouseEventKind::ScrollDown => {
-                            let size = terminal.size()?;
-                            self.on_scroll(
-                                m.column,
-                                m.row,
-                                Rect::new(0, 0, size.width, size.height),
-                                if m.kind == MouseEventKind::ScrollUp {
-                                    -1
-                                } else {
-                                    1
-                                },
-                            );
-                        }
-                        MouseEventKind::Down(ratatui::crossterm::event::MouseButton::Left) => {
-                            let size = terminal.size()?;
-                            self.on_click(
-                                m.column,
-                                m.row,
-                                Rect::new(0, 0, size.width, size.height),
-                            );
-                        }
-                        _ => {}
-                    },
-                    _ => {}
-                }
+                let input = event::read()?;
+                // Re-read dimensions at input time: a shrink between drawing
+                // and pressing Enter must not approve a hidden confirmation.
+                let size = terminal.size()?;
+                self.on_window_event(input, Rect::new(0, 0, size.width, size.height));
             }
             self.spin = (self.spin + 1) % SPIN.len();
             self.poll();
-            // Live auto-refresh, tiered so external changes appear on their own
-            // without periodic subprocess hitches. Skip while the user is mid-flow.
-            if self.op.is_none()
-                && self.enroll.is_none()
-                && self.input.is_none()
-                && self.confirm.is_none()
-            {
-                if last_heavy.elapsed() >= Duration::from_millis(HEAVY_REFRESH_MS) {
-                    // Diagnostics only, NOT the slow profile poll: keeping the
-                    // ListProfiles TPM-unseal off every timer tick is what makes
-                    // the UI stay smooth. Profiles refresh on mutation / Profiles
-                    // tab / startup instead.
-                    self.refresh_diagnostics();
-                    last_heavy = std::time::Instant::now();
-                    last_light = std::time::Instant::now();
-                } else if last_light.elapsed() >= Duration::from_millis(LIGHT_REFRESH_MS) {
-                    self.refresh_light(); // daemon state + cameras only
-                    last_light = std::time::Instant::now();
-                }
-            }
+            self.refresh_due(self.now());
             // Interactive flows that need a cooked terminal: tear down, run, re-enter.
             if let Some(s) = self.suspend.take() {
                 let _ = ratatui::crossterm::execute!(
@@ -2949,6 +3783,62 @@ impl App {
             e.stop.store(true, Ordering::Relaxed);
         }
         Ok(())
+    }
+
+    /// Terminal boundary: keep hidden controls inactive until this exact size
+    /// has been drawn. Internal page handlers retain their ordinary behavior.
+    fn on_window_event(&mut self, input: Event, area: Rect) {
+        use ratatui::crossterm::event::{KeyModifiers, MouseButton, MouseEventKind};
+        if !window_fits(area) || self.window_area.get() != Some(area) {
+            self.click_targets.borrow_mut().clear();
+            if let Event::Key(key) = input {
+                if key.kind == KeyEventKind::Press && !key.modifiers.contains(KeyModifiers::CONTROL)
+                {
+                    match key.code {
+                        KeyCode::Char('q') => {
+                            if let Some(enrollment) = &self.enroll {
+                                enrollment.stop.store(true, Ordering::Relaxed);
+                            }
+                            self.quit = true;
+                        }
+                        KeyCode::Esc => {
+                            if let Some(enrollment) = &self.enroll {
+                                enrollment.stop.store(true, Ordering::Relaxed);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            return;
+        }
+        match input {
+            Event::Key(key) if key.kind == KeyEventKind::Press => {
+                // Ctrl-C must not alias to the page's ordinary c action.
+                if !(key.modifiers.contains(KeyModifiers::CONTROL)
+                    && matches!(key.code, KeyCode::Char(_)))
+                {
+                    self.on_key(key.code);
+                }
+            }
+            Event::Mouse(mouse) => match mouse.kind {
+                MouseEventKind::ScrollUp | MouseEventKind::ScrollDown => self.on_scroll(
+                    mouse.column,
+                    mouse.row,
+                    area,
+                    if mouse.kind == MouseEventKind::ScrollUp {
+                        -1
+                    } else {
+                        1
+                    },
+                ),
+                MouseEventKind::Down(MouseButton::Left) => {
+                    self.on_click(mouse.column, mouse.row, area);
+                }
+                _ => {}
+            },
+            _ => {}
+        }
     }
 
     /// Flip mouse capture so the terminal's native selection (highlight +
@@ -3160,10 +4050,21 @@ impl App {
                 "wire the login stack",
                 &["irlume", "login", "enable", "--apply"],
             ),
-            Suspend::SetCameras(rgb, ir) => self.sudo_step(
-                "switch the active camera pair",
-                &["irlume", "set-cameras", &rgb, &ir],
-            ),
+            Suspend::SetCameras(rgb, ir, expected) => {
+                let guard =
+                    serde_json::to_string(&expected).expect("camera selection is serializable");
+                self.sudo_step(
+                    "switch the same connected camera pair",
+                    &[
+                        "irlume",
+                        "set-cameras",
+                        &rgb,
+                        &ir,
+                        "--expected-camera",
+                        &guard,
+                    ],
+                );
+            }
             Suspend::IrSetup => self.sudo_step("enable the IR emitter", &["irlume", "ir-setup"]),
             Suspend::CameraTune => self.sudo_step(
                 "measure simultaneous RGB+IR capture",
@@ -3347,11 +4248,67 @@ impl App {
     }
 
     fn on_key(&mut self, code: KeyCode) {
+        // A long dialog owns its reading keys. They never dismiss/approve the
+        // dialog or scroll the Activity behind it. Text-entry keeps its keys.
+        if self.input.is_none() && self.dialog_open() {
+            let (bounds, max) = self.dialog_view.get();
+            let step = match code {
+                KeyCode::Up => Some(-1),
+                KeyCode::Down => Some(1),
+                KeyCode::PageUp => Some(-i32::from(bounds.height.saturating_sub(4).max(1))),
+                KeyCode::PageDown => Some(i32::from(bounds.height.saturating_sub(4).max(1))),
+                _ => None,
+            };
+            if let Some(step) = step.filter(|_| max > 0 || self.error.is_none()) {
+                self.dialog_scroll.set(
+                    (i32::from(self.dialog_scroll.get()) + step).clamp(0, i32::from(max)) as u16,
+                );
+                return;
+            }
+        }
+        if let Some(selected) = self.sections.filter(|_| self.error.is_none()) {
+            match code {
+                KeyCode::Esc | KeyCode::F(3) => self.sections = None,
+                KeyCode::Up => self.sections = Some(selected.saturating_sub(1)),
+                KeyCode::Down => {
+                    self.sections = Some((selected + 1).min(self.visible.len().saturating_sub(1)))
+                }
+                KeyCode::Enter | KeyCode::Char(' ') => {
+                    self.sections = None;
+                    if let Some(&screen) = self.visible.get(selected) {
+                        self.enter_screen(screen);
+                    }
+                }
+                _ => {}
+            }
+            return;
+        }
         self.dialog_scroll.set(0);
-        // A raised error banner says "press any key to dismiss", so it takes the
-        // next key BEFORE anything else (including the activity scroll below).
+        // Reading keys were handled above. Every other key dismisses an error
+        // before it can reach background controls or Activity.
         if self.error.is_some() {
             self.error = None;
+            return;
+        }
+        if self.live_overlay_visible() {
+            if matches!(code, KeyCode::Esc | KeyCode::F(4)) {
+                self.show_live = false;
+            }
+            return;
+        }
+        if code == KeyCode::F(4)
+            && !self.dialog_open()
+            && self.sections.is_none()
+            && self.more_actions.is_none()
+        {
+            self.show_live = true;
+            return;
+        }
+        if self.activity_history_open && !self.dialog_open() {
+            match code {
+                KeyCode::Esc | KeyCode::Char('L') => self.activity_history_open = false,
+                key => self.activity.scroll(key),
+            }
             return;
         }
         if let Some((query, selected)) = self.more_actions.as_mut() {
@@ -3383,12 +4340,38 @@ impl App {
             }
             return;
         }
+        // Explicit page focus owns page reading. Without it, keep Activity's
+        // established PgUp/PgDn contract, including during a running operation.
+        if self.focused_action().is_some()
+            && !self.dialog_open()
+            && self.op.is_none()
+            && self.enroll.is_none()
+        {
+            let (screen, bounds, scroll, max) = self.page_view.get();
+            if screen == self.screen && bounds.height > 0 {
+                let next = match code {
+                    KeyCode::PageUp => Some(scroll.saturating_sub(bounds.height)),
+                    KeyCode::PageDown => Some(scroll.saturating_add(bounds.height).min(max)),
+                    _ => None,
+                };
+                if let Some(next) = next {
+                    self.page_view.set((screen, bounds, next, max));
+                    self.action_reveal.set(false);
+                    return;
+                }
+            }
+        }
         // Activity history scroll works in every state except text entry:
         // mid-enroll and mid-op, when lines stream fastest, is exactly when
         // the user wants to read back. Handled before the state gates below
         // so those can't swallow it.
         if self.input.is_none() {
             match code {
+                KeyCode::Char('L') if !self.dialog_open() => {
+                    self.activity_history_open = true;
+                    self.activity.follow();
+                    return;
+                }
                 KeyCode::Char('A') => {
                     self.activity_open = !self.activity_open;
                     if !self.activity_open {
@@ -3428,7 +4411,10 @@ impl App {
                         }
                         e.stop.store(true, Ordering::Relaxed);
                     }
-                    self.log('·', "enrollment cancelled; pending scans were not saved");
+                    self.log(
+                        '·',
+                        "enrollment cancellation requested; refreshing saved profiles",
+                    );
                     self.refresh_profiles();
                 }
                 _ => {}
@@ -3440,7 +4426,10 @@ impl App {
             if matches!(code, KeyCode::Esc) {
                 e.stop.store(true, Ordering::Relaxed);
                 self.enroll = None;
-                self.log('·', "enrollment cancelled");
+                self.log(
+                    '·',
+                    "enrollment cancellation requested; refreshing saved profiles",
+                );
                 // The daemon may already hold what the cancelled run created:
                 // scan 1 creates the profile before any of the later scans, so
                 // stopping after it leaves a real profile the cached list has
@@ -3487,6 +4476,17 @@ impl App {
             match code {
                 KeyCode::Char('y') | KeyCode::Char('Y') => {
                     let (_, _, act) = self.confirm.take().unwrap();
+                    if matches!(&act, ConfirmAct::Sus(Suspend::SetCameras(..)))
+                        && !self
+                            .camera_confirmation
+                            .as_ref()
+                            .is_some_and(|choice| self.camera_choice_current(choice))
+                    {
+                        self.camera_confirmation = None;
+                        self.set_error("Current camera connection could not be confirmed. Select the camera again.");
+                        return;
+                    }
+                    self.camera_confirmation = None;
                     match act {
                         // Async so the UI keeps animating; poll() logs the
                         // result (✓/error banner) and refreshes. map_confirm
@@ -3496,10 +4496,12 @@ impl App {
                         }
                         // Root op: leave the alt-screen and run it under sudo.
                         ConfirmAct::Sus(s) => self.suspend = Some(s),
+                        ConfirmAct::CameraQualification => self.refresh_qualification(),
                     }
                 }
                 KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
                     self.confirm = None;
+                    self.camera_confirmation = None;
                 }
                 _ => {} // ignore stray keys
             }
@@ -3540,6 +4542,22 @@ impl App {
             KeyCode::Esc => self.go_home(),
             KeyCode::Char('?') => self.show_help = true,
             KeyCode::F(2) => self.more_actions = Some((String::new(), 0)),
+            KeyCode::F(3) => {
+                self.sections = Some(
+                    self.visible
+                        .iter()
+                        .position(|&s| s == self.screen)
+                        .unwrap_or(0),
+                );
+            }
+            KeyCode::F(6) => {
+                self.action_focus = if self.focused_action().is_some() {
+                    None
+                } else {
+                    Some((self.screen, 0))
+                };
+                self.action_reveal.set(true);
+            }
             // Home: jump back to the Welcome hub from any tab, so the "at a
             // glance" summary is one key away instead of a Tab walk. (Home the
             // KEY is taken by activity scroll; 'h' for home is unused globally.)
@@ -3563,6 +4581,24 @@ impl App {
             }
             KeyCode::Tab | KeyCode::Right => self.step(1),
             KeyCode::BackTab | KeyCode::Left => self.step(-1),
+            KeyCode::Up | KeyCode::Char('k') if self.focused_action().is_some() => {
+                self.move_action_focus(-1)
+            }
+            KeyCode::Down | KeyCode::Char('j') if self.focused_action().is_some() => {
+                self.move_action_focus(1)
+            }
+            KeyCode::Enter | KeyCode::Char(' ') if self.focused_action().is_some() => {
+                if let Some((key, _)) = self
+                    .focused_action()
+                    .and_then(|(k, d)| footer_keycode(k).map(|k| (k, d)))
+                {
+                    // Replay the established handler without interpreting a
+                    // focused Enter (e.g. Use camera) recursively as activation.
+                    let focus = self.action_focus.take();
+                    self.on_key(key);
+                    self.action_focus = focus;
+                }
+            }
             KeyCode::Up | KeyCode::Char('k') => self.move_sel(-1),
             KeyCode::Down | KeyCode::Char('j') => self.move_sel(1),
             // Activity jump-to-oldest/newest (PgUp/PgDn are handled at the top
@@ -3575,6 +4611,37 @@ impl App {
 
     fn act_max(&self) -> usize {
         self.activity.len().saturating_sub(ACT_H)
+    }
+
+    fn focused_action(&self) -> Option<(&'static str, &'static str)> {
+        self.action_focus
+            .filter(|(screen, _)| *screen == self.screen)
+            .and_then(|(_, index)| self.focus_actions().get(index).copied())
+    }
+
+    fn focus_actions(&self) -> &'static [(&'static str, &'static str)] {
+        if self.is_first_run() {
+            &[("e", "Scan my face")]
+        } else {
+            self.screen_actions()
+        }
+    }
+
+    fn move_action_focus(&mut self, direction: i32) {
+        if let Some((screen, index)) = &mut self.action_focus {
+            if *screen == self.screen {
+                *index = if direction < 0 {
+                    index.saturating_sub(1)
+                } else {
+                    index.saturating_add(1)
+                };
+            }
+        }
+        let last = self.focus_actions().len().saturating_sub(1);
+        if let Some((_, index)) = &mut self.action_focus {
+            *index = (*index).min(last);
+        }
+        self.action_reveal.set(true);
     }
 
     /// Step `d` tabs through the VISIBLE (hardware-applicable) screens, wrapping.
@@ -3696,7 +4763,7 @@ impl App {
                 );
             }
             (SC_WELCOME, KeyCode::Char('e' | 'i')) => {
-                self.log('·', "no camera on this device: face enrollment/identify unavailable (see Fingerprint/Settings)");
+                self.log('·', "current camera availability is unconfirmed; inspect Cameras or Diagnostics before face enrollment/identify");
             }
             // Cameras: switch the active pair; persists to /etc, so it's a root
             // op that suspends to `sudo irlume set-cameras`. Confirmed first:
@@ -3708,6 +4775,11 @@ impl App {
                 // free for the log/suspend below).
                 match self.pairs.get(self.cam_sel).cloned() {
                     Some(p) => {
+                        let Some(choice) = self.camera_choice(&p.rgb, &p.ir) else {
+                            self.set_error("Current camera connection is unavailable; wait for the live inventory and inspect the camera again.");
+                            return;
+                        };
+                        self.camera_confirmation = Some(choice.clone());
                         self.confirm = Some((
                             format!(
                                 "Switch the active camera pair to {} + {}? This \
@@ -3716,7 +4788,8 @@ impl App {
                                 p.rgb, p.ir
                             ),
                             "Switch",
-                            ConfirmAct::Sus(Suspend::SetCameras(p.rgb.clone(), p.ir.clone())),
+                            ConfirmAct::Sus(Suspend::SetCameras(p.rgb.clone(), p.ir.clone(),
+                                irlume_common::live_camera::CameraSelection { supervisor_id: choice.supervisor, candidate: choice.candidate })),
                         ));
                     }
                     None => self.log(
@@ -3781,6 +4854,14 @@ impl App {
             }
             // Cameras: IR emitter auto-setup (root; writes the persisted UVC
             // control) suspends to sudo; the [p] probe below is read-only.
+            (SC_CAMERAS, KeyCode::Char('r')) => {
+                self.freshness.cycle_mut(Worker::Cameras).invalidate();
+                self.invalidate_source(Source::Cameras);
+                self.refresh_camera_listing();
+            }
+            (SC_CAMERAS, KeyCode::Char('c')) => {
+                self.confirm = Some(("Inspect capture qualification? This opens camera controls when available; it does not capture frames. The result is a dated observation, not a live readiness guarantee.".into(), "Inspect", ConfirmAct::CameraQualification));
+            }
             (SC_CAMERAS, KeyCode::Char('s')) => {
                 self.log('→', "sudo irlume ir-setup: set up the 850nm emitter; this writes to the camera (you'll be asked for your password)");
                 self.suspend = Some(Suspend::IrSetup);
@@ -3897,7 +4978,9 @@ impl App {
             }
             // Fingerprint.
             (SC_FINGERPRINT, KeyCode::Char('a')) => {
-                if self.fp.available {
+                if !self.fp_known || !self.source_usable(Source::FingerprintReader) {
+                    self.log('·', "current fingerprint reader observation unavailable; refresh before enrollment");
+                } else if self.fp.available {
                     self.suspend = Some(Suspend::FingerprintAdd);
                 } else {
                     self.log('✗', "no fingerprint reader detected");
@@ -3906,7 +4989,9 @@ impl App {
             // 't' not 'v': 'v' is the global basic/advanced view toggle and
             // never reaches per-screen actions (found in container E2E).
             (SC_FINGERPRINT, KeyCode::Char('t')) => {
-                if self.fp.available {
+                if !self.fp_known || !self.source_usable(Source::FingerprintReader) {
+                    self.log('·', "current fingerprint reader observation unavailable; refresh before verification");
+                } else if self.fp.available {
                     self.suspend = Some(Suspend::FingerprintVerify);
                 } else {
                     self.log('✗', "no fingerprint reader detected");
@@ -3990,7 +5075,7 @@ impl App {
             (SC_SETTINGS, KeyCode::Char('r')) => self.prepare_action(actions::Invocation { action: &actions::SENSOR_PREFLIGHT, values: Vec::new() }),
             // Settings.
             (SC_SETTINGS, KeyCode::Char('p')) => {
-                if crate::consent::overridden() || self.preference_state().consent_overridden {
+                if self.preference_state().consent_overridden {
                     self.log('·', "An environment override controls privileged consent; remove it before changing the saved setting.");
                     return;
                 }
@@ -4134,7 +5219,9 @@ impl App {
             Some(Row::Profile(pi)) => {
                 let p = self.profiles[pi].name.clone();
                 self.confirm = Some((
-                    format!("Delete profile '{p}' and all its scans? OS approval is required for non-root users. Removing the last profile also erases its recovery passphrase."),
+                    format!(
+                        "Delete profile '{p}' and all its scans? OS approval is required for non-root users. Removing the last profile also erases its recovery passphrase."
+                    ),
                     "Delete",
                     ConfirmAct::Daemon(Request::DeleteProfile {
                         user: self.user.clone(),
@@ -4283,6 +5370,69 @@ impl App {
         }
     }
 
+    fn sections_rect(area: Rect) -> Rect {
+        let width = area.width.saturating_sub(2).min(48);
+        let height = area.height.saturating_sub(2).min(16);
+        Rect::new(
+            area.x + area.width.saturating_sub(width) / 2,
+            area.y + area.height.saturating_sub(height) / 2,
+            width,
+            height,
+        )
+    }
+
+    fn draw_sections(&self, f: &mut Frame, selected: usize) {
+        self.click_targets.borrow_mut().clear();
+        let rect = Self::sections_rect(f.area());
+        f.render_widget(Clear, rect);
+        let block = Block::bordered()
+            .border_type(BorderType::Rounded)
+            .title(" Choose section ")
+            .border_style(Style::new().fg(th().accent));
+        let inner = block.inner(rect);
+        f.render_widget(block, rect);
+        let [list, controls] =
+            Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).areas(inner);
+        let items = self
+            .visible
+            .iter()
+            .map(|&screen| {
+                ListItem::new(format!(
+                    "{} {}",
+                    if screen == self.screen { "●" } else { " " },
+                    SCREENS[screen]
+                ))
+            })
+            .collect::<Vec<_>>();
+        let mut state = ListState::default().with_selected(Some(selected));
+        f.render_stateful_widget(
+            List::new(items)
+                .highlight_style(selected_style())
+                .highlight_symbol("› "),
+            list,
+            &mut state,
+        );
+        for (row, index) in (state.offset()..self.visible.len())
+            .take(list.height as usize)
+            .enumerate()
+        {
+            self.hit(
+                Rect::new(list.x, list.y + row as u16, list.width, 1),
+                Click::SectionRow(index),
+            );
+        }
+        let [close, open] =
+            Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
+                .areas(controls);
+        for (rect, label, key) in [
+            (close, "[Esc] Close", KeyCode::Esc),
+            (open, "[Enter] Open", KeyCode::Enter),
+        ] {
+            f.render_widget(Paragraph::new(label).style(th().chip), rect);
+            self.hit(rect, Click::DialogKey(key));
+        }
+    }
+
     fn submit_input(&mut self) {
         let Some((_, buf, pending)) = self.input.take() else {
             return;
@@ -4369,7 +5519,7 @@ impl App {
                 // TokenSealed reply (GNOME, #250) must be followed by the
                 // keyring re-key, which needs the password and user.
                 self.start_async_task(
-                    "SealPassword",
+                    "Connect Password Wallet: seal its secret with the TPM and update the wallet if needed",
                     OpTag::Generic,
                     Box::new(move || {
                         let wallet_salt = match irlume_common::client::read_wallet_salt(&user) {
@@ -4481,8 +5631,52 @@ impl App {
         }
     }
 
+    /// Render only the resize notice below the supported terminal size.
+    fn draw_window(&self, f: &mut Frame) {
+        let area = f.area();
+        self.window_area.set(Some(area));
+        self.click_targets.borrow_mut().clear();
+        if window_fits(area) {
+            self.draw(f);
+            return;
+        }
+        f.render_widget(Clear, area);
+        let mut lines = vec![
+            Line::styled("Window too small", Style::new().fg(th().warn).bold()),
+            Line::raw(""),
+            Line::raw(format!("Minimum: {MIN_WINDOW_COLS} × {MIN_WINDOW_ROWS}")),
+            Line::raw(format!("Current: {} × {}", area.width, area.height)),
+            Line::raw(""),
+            Line::raw("Enlarge the terminal to continue."),
+        ];
+        if self.enroll.is_some() {
+            lines.push(Line::raw("Esc: request enrollment cancellation"));
+        }
+        lines.push(Line::raw(if self.op.is_some() {
+            "q: exit (current task keeps running)"
+        } else {
+            "q: exit"
+        }));
+        let notice = Paragraph::new(lines).centered().wrap(Wrap { trim: false });
+        let rows = notice.line_count(area.width).min(usize::from(u16::MAX)) as u16;
+        let offset = area.height.saturating_sub(rows) / 2;
+        f.render_widget(
+            notice,
+            Rect::new(
+                area.x,
+                area.y.saturating_add(offset),
+                area.width,
+                area.height.saturating_sub(offset),
+            ),
+        );
+    }
+
     fn draw(&self, f: &mut Frame) {
         self.click_targets.borrow_mut().clear();
+        if self.activity_history_open && !self.dialog_open() {
+            self.draw_activity_history(f);
+            return;
+        }
         let [header, hint, body, activity, footer] = self.frame_rows(f.area());
         self.draw_header(f, header);
         self.draw_hint(f, hint);
@@ -4558,6 +5752,14 @@ impl App {
                 ],
             );
         }
+        if self.live_overlay_visible() {
+            self.modal(
+                f,
+                "Current observations",
+                &self.live_details(),
+                &[("[Esc / F4] Close", KeyCode::Esc)],
+            );
+        }
         // Tier two of the key-disclosure ladder; drawn last so it sits above
         // everything except nothing (help is always answerable).
         if let Some((query, selected)) = &self.more_actions {
@@ -4571,6 +5773,9 @@ impl App {
                 &[("[Esc] Close", KeyCode::Esc)],
             );
         }
+        if let Some(selected) = self.sections.filter(|_| self.error.is_none()) {
+            self.draw_sections(f, selected);
+        }
     }
 
     /// A red, dismissible error banner centred on screen.
@@ -4578,7 +5783,7 @@ impl App {
         self.modal(
             f,
             "⚠ Problem",
-            &format!("{msg}\n\n[any key] dismiss"),
+            &format!("{msg}\n\n[Esc] dismiss · arrows scroll"),
             &[("[Esc] Dismiss", KeyCode::Esc)],
         );
     }
@@ -4600,70 +5805,50 @@ impl App {
     /// three steps of what happens, and the reassurance that the password never
     /// stops working. Deliberately no sidebar — nothing to parse on run one.
     fn draw_firstrun(&self, f: &mut Frame, area: Rect) {
-        let a = th().accent;
-        let key = |k: &str| Span::styled(format!(" {k} "), th().chip);
-        let lines = vec![
-            Line::raw(""),
-            Line::from(Span::styled(
-                "Set up face unlock",
-                Style::new().fg(a).add_modifier(Modifier::BOLD),
-            )),
-            Line::from(Span::styled(
-                "Private, local enrollment using your infrared camera.",
-                Style::new().dim(),
-            )),
-            Line::raw(""),
-            Line::from(Span::styled(
-                "Your password remains available during and after setup.",
-                Style::new().dim(),
-            )),
-            Line::raw(""),
-            Line::from(vec![
-                Span::styled(
-                    "  ▶  Scan my face  ",
-                    Style::new()
-                        .fg(Color::Black)
-                        .bg(a)
-                        .add_modifier(Modifier::BOLD),
-                ),
-                Span::raw("   "),
-                key("e"),
-            ]),
-            Line::raw(""),
-            Line::from(Span::styled(
-                "1  Look at the camera     2  Follow the cues     3  Finish login setup",
-                Style::new().dim(),
-            )),
-            Line::raw(""),
-            Line::from(vec![
-                Span::styled("Tab", Style::new().fg(a)),
-                Span::styled(" walks every step   ", Style::new().dim()),
-                Span::styled("[v]", Style::new().fg(a)),
-                Span::styled(" shows all sections", Style::new().dim()),
-            ]),
-        ];
-        let blk = Block::bordered()
+        let block = Block::bordered()
+            .title(" Set up face unlock ")
+            .title_bottom(if self.focused_action().is_some() {
+                " PgUp/Dn read · F6 back "
+            } else {
+                " F6 controls · wheel to read "
+            })
             .border_type(BorderType::Rounded)
-            .border_style(Style::new().dim());
-        let inner = blk.inner(area);
-        // Register the "Scan my face" row as a click target (→ enroll).
-        if let Some(i) = lines
-            .iter()
-            .position(|l| l.spans.iter().any(|s| s.content.contains("Scan my face")))
-        {
-            let y = inner.y.saturating_add(i as u16);
-            if y < inner.y.saturating_add(inner.height) {
-                self.hit(
-                    Rect::new(inner.x, y, inner.width, 1),
-                    Click::Key(KeyCode::Char('e')),
-                );
-            }
-        }
-        f.render_widget(
-            Paragraph::new(lines)
-                .block(blk)
-                .alignment(ratatui::layout::Alignment::Center),
-            area,
+            .border_style(Style::new().fg(th().accent));
+        let inner = block.inner(area);
+        f.render_widget(block, area);
+        let [button_area, guidance] =
+            Layout::vertical([Constraint::Length(1), Constraint::Min(0)]).areas(inner);
+        // The only primary action stays visible even with a one-line guidance
+        // viewport. Its hit region is the rendered button, not blank row space.
+        let button = Line::from(Span::styled(" [e] Scan my face ", th().chip));
+        let button_area = Rect::new(
+            button_area.x,
+            button_area.y,
+            button_area.width.min(button.width() as u16),
+            button_area.height,
+        );
+        f.render_widget(Paragraph::new(button), button_area);
+        self.hit(button_area, Click::Key(KeyCode::Char('e')));
+        let camera = if self.caps.ir_pair {
+            "Private, local enrollment with your RGB + infrared cameras."
+        } else {
+            "Private, local enrollment with your RGB camera."
+        };
+        self.draw_action_paragraph(
+            f,
+            guidance,
+            vec![
+                Line::raw(camera),
+                Line::raw("Your password remains available during and after setup."),
+                Line::raw(""),
+                Line::raw("1  Look at the camera"),
+                Line::raw("2  Follow the cues"),
+                Line::raw("3  Finish login setup"),
+                Line::raw(""),
+                Line::raw("F3 chooses a section; Tab goes to the next section."),
+                Line::raw("v shows or hides technical tools."),
+            ],
+            &[],
         );
     }
 
@@ -4752,7 +5937,22 @@ impl App {
         let blk = Block::bordered()
             .border_type(BorderType::Rounded)
             .border_style(Style::new().dim());
-        f.render_widget(Paragraph::new(lines).block(blk), area);
+        let offset = self.sidebar_offset(blk.inner(area).height);
+        f.render_widget(
+            Paragraph::new(lines).scroll((offset as u16, 0)).block(blk),
+            area,
+        );
+    }
+
+    fn sidebar_offset(&self, height: u16) -> usize {
+        let rows = self.sidebar_rows();
+        let selected = rows
+            .iter()
+            .position(|row| matches!(row, SidebarRow::Nav(screen) if *screen == self.screen))
+            .unwrap_or(0);
+        selected
+            .saturating_sub(usize::from(height.saturating_sub(1)))
+            .min(rows.len().saturating_sub(usize::from(height)))
     }
 
     /// Split the body area into (optional sidebar, content). Shared by `draw`
@@ -4772,12 +5972,36 @@ impl App {
         self.click_targets.borrow_mut().push((rect, c));
     }
 
+    fn live_overlay_visible(&self) -> bool {
+        self.show_live
+            && self.error.is_none()
+            && self.input.is_none()
+            && self.confirm.is_none()
+            && self.enroll_merge.is_none()
+            && !self.show_help
+            && self
+                .enroll
+                .as_ref()
+                .is_none_or(|enroll| enroll.session_merge.is_none())
+    }
+
+    fn daemon_ready_observed(&self) -> Option<bool> {
+        self.live
+            .as_ref()
+            .filter(|_| self.source_usable(Source::Live))
+            .filter(|live| {
+                live.tracking_available && live.stage != irlume_common::live::LiveStage::Unknown
+            })
+            .map(|live| live.stage == irlume_common::live::LiveStage::Ready)
+    }
+
     fn dialog_open(&self) -> bool {
         self.error.is_some()
             || self.input.is_some()
             || self.confirm.is_some()
             || self.enroll_merge.is_some()
             || self.show_help
+            || self.show_live
             || self
                 .enroll
                 .as_ref()
@@ -4785,6 +6009,24 @@ impl App {
     }
 
     fn on_scroll(&mut self, col: u16, row: u16, area: Rect, direction: i32) {
+        if self.activity_history_open && !self.dialog_open() {
+            self.activity.scroll(if direction < 0 {
+                KeyCode::Up
+            } else {
+                KeyCode::Down
+            });
+            return;
+        }
+        if self.sections.is_some() && !self.dialog_open() {
+            if Self::sections_rect(area).contains((col, row).into()) {
+                self.on_key(if direction < 0 {
+                    KeyCode::Up
+                } else {
+                    KeyCode::Down
+                });
+            }
+            return;
+        }
         if self.dialog_open() {
             let (bounds, max) = self.dialog_view.get();
             if bounds.contains((col, row).into()) {
@@ -4868,9 +6110,27 @@ impl App {
     /// first-run button replays its key. Clicks while a modal/flow owns the
     /// screen are ignored.
     fn on_click(&mut self, col: u16, row: u16, area: Rect) {
+        if self.activity_history_open && !self.dialog_open() {
+            let key = self
+                .click_targets
+                .borrow()
+                .iter()
+                .find_map(|(rect, click)| {
+                    if rect.contains((col, row).into()) {
+                        if let Click::DialogKey(key) = click {
+                            return Some(*key);
+                        }
+                    }
+                    None
+                });
+            if let Some(key) = key {
+                self.on_key(key);
+            }
+            return;
+        }
         // Only the top overlay registers targets; background clicks never
         // dismiss a warning, approve an action or navigate behind a dialog.
-        if self.dialog_open() || self.more_actions.is_some() {
+        if self.dialog_open() || self.more_actions.is_some() || self.sections.is_some() {
             let target = self
                 .click_targets
                 .borrow()
@@ -4885,6 +6145,12 @@ impl App {
                         }
                     }
                 }
+                Some(Click::SectionRow(index)) if !self.dialog_open() => {
+                    if let Some(&screen) = self.visible.get(index) {
+                        self.sections = None;
+                        self.enter_screen(screen);
+                    }
+                }
                 _ => {}
             }
             return;
@@ -4892,14 +6158,15 @@ impl App {
         // Activity remains usable while a camera/daemon operation owns normal
         // input, matching PgUp and [A]. Resolve that one safe disclosure before
         // the flow gate; it never starts, cancels, or confirms an operation.
-        let activity_hit = self.click_targets.borrow().iter().any(|(r, c)| {
-            col >= r.x
-                && col < r.x + r.width
-                && row >= r.y
-                && row < r.y + r.height
-                && matches!(c, Click::Key(KeyCode::Char('A')))
+        let activity_hit = self.click_targets.borrow().iter().find_map(|(r, c)| {
+            if col >= r.x && col < r.x + r.width && row >= r.y && row < r.y + r.height {
+                if let Click::Key(key @ (KeyCode::Char('A' | 'L') | KeyCode::F(4))) = c {
+                    return Some(*key);
+                }
+            }
+            None
         });
-        if activity_hit
+        if activity_hit.is_some()
             && !self.show_help
             && self.more_actions.is_none()
             && self.error.is_none()
@@ -4907,7 +6174,20 @@ impl App {
             && self.confirm.is_none()
             && self.enroll_merge.is_none()
         {
-            self.on_key(KeyCode::Char('A'));
+            if let Some(key) = activity_hit {
+                self.on_key(key);
+            }
+            return;
+        }
+        if self.enroll.is_some() || self.op.is_some() {
+            // Only the visible flow footer can cancel/exit. In particular,
+            // normal page controls and the header never act behind a flow.
+            let flow_control = self.click_targets.borrow().iter().any(|(rect, click)| {
+                rect.contains((col, row).into()) && matches!(click, Click::Key(KeyCode::Esc))
+            });
+            if flow_control {
+                self.on_key(KeyCode::Esc);
+            }
             return;
         }
         if self.more_actions.is_some()
@@ -4916,8 +6196,6 @@ impl App {
             || self.input.is_some()
             || self.confirm.is_some()
             || self.enroll_merge.is_some()
-            || self.enroll.is_some()
-            || self.op.is_some()
         {
             return;
         }
@@ -4930,9 +6208,15 @@ impl App {
             .find(|(r, _)| col >= r.x && col < r.x + r.width && row >= r.y && row < r.y + r.height)
             .map(|(_, c)| *c);
         if let Some(c) = hit {
+            // A pointer-selected row or action owns the click. In particular,
+            // an existing row's Enter must not activate a different F6 action.
+            if !matches!(c, Click::Key(KeyCode::F(6))) {
+                self.action_focus = None;
+                self.action_reveal.set(false);
+            }
             match c {
                 Click::Key(kc) => self.on_key(kc),
-                Click::DialogKey(_) | Click::ActionRow(_) => {}
+                Click::DialogKey(_) | Click::ActionRow(_) | Click::SectionRow(_) => {}
                 Click::Hub(i) => {
                     if let Some((_, _, target)) = self.hub_rows().get(i).copied() {
                         self.hub_sel = i;
@@ -4975,7 +6259,7 @@ impl App {
         if !in_inner {
             return;
         }
-        let idx = (row - inner.y) as usize;
+        let idx = (row - inner.y) as usize + self.sidebar_offset(inner.height);
         if let Some(SidebarRow::Nav(s)) = self.sidebar_rows().get(idx).copied() {
             self.enter_screen(s);
         }
@@ -4985,17 +6269,8 @@ impl App {
         // Slim one-line title bar. On a wide terminal the sidebar shows position;
         // on a narrow terminal a compact N/M location keeps orientation without
         // presenting the persistent settings app as a wizard.
-        let mut left = vec![
-            Span::styled(
-                " irlume ",
-                Style::new()
-                    .fg(Color::Black)
-                    .bg(th().accent)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::raw("  "),
-        ];
-        if area.width < SIDEBAR_MIN_COLS {
+        let mut left = vec![Span::styled(" irlume ", th().chip), Span::raw("  ")];
+        if (60..SIDEBAR_MIN_COLS).contains(&area.width) {
             left.push(Span::styled(
                 format!(
                     "{}/{} · ",
@@ -5012,36 +6287,43 @@ impl App {
             SCREENS[self.screen],
             Style::new().fg(th().accent).add_modifier(Modifier::BOLD),
         ));
+        // Give the page title and Exit separate rectangles. A long account
+        // name must never overwrite either on a compact terminal.
+        let exit_span = Span::styled(" ✕ Exit (q) ", th().chip);
+        let exit_width = (exit_span.width() as u16).min(area.width);
+        let exit = Rect::new(
+            area.right().saturating_sub(exit_width),
+            area.y,
+            exit_width,
+            area.height,
+        );
+        let title = Line::from(left);
+        let remaining = area.width.saturating_sub(exit_width);
         let account = if self.advanced {
             format!("advanced · {} ", self.user)
         } else {
             format!("{} ", self.user)
         };
-        // Visible, clickable exit: 'q' quits but a key nobody mentions is not
-        // discoverability (user report 2026-08-23: "how would I exit?"). The
-        // chip both teaches the key and is a click target for it.
-        let exit_span = Span::styled(
-            " ✕ Exit (q) ",
-            Style::new()
-                .fg(Color::Black)
-                .bg(th().warn)
-                .add_modifier(Modifier::BOLD),
+        let account_width = (Span::raw(&account).width().min(u16::MAX as usize) as u16).min(
+            remaining
+                .saturating_sub((title.width().min(u16::MAX as usize) as u16).saturating_add(1)),
         );
-        let exit_width = exit_span.content.len() as u16;
-        let right =
-            Line::from(vec![Span::styled(account, Style::new().dim()), exit_span]).right_aligned();
-        f.render_widget(Paragraph::new(Line::from(left)), area);
-        f.render_widget(Paragraph::new(right.clone()), area);
-        // The chip sits at the line's right edge; register its exact rect.
-        self.click_targets.borrow_mut().push((
-            Rect::new(
-                area.right().saturating_sub(exit_width),
-                area.y,
-                exit_width,
-                1,
-            ),
-            Click::Key(KeyCode::Char('q')),
-        ));
+        let title_area = Rect::new(
+            area.x,
+            area.y,
+            remaining.saturating_sub(account_width),
+            area.height,
+        );
+        let account_area = Rect::new(title_area.right(), area.y, account_width, area.height);
+        f.render_widget(Paragraph::new(title), title_area);
+        f.render_widget(
+            Paragraph::new(account)
+                .style(Style::new().dim())
+                .right_aligned(),
+            account_area,
+        );
+        f.render_widget(Paragraph::new(exit_span), exit);
+        self.hit(exit, Click::Key(KeyCode::Char('q')));
     }
 
     /// A single plain-language line under the header: what THIS tab is for and
@@ -5109,7 +6391,25 @@ impl App {
             .border_style(Style::new().fg(th().accent))
             // Breathing room (whitespace over chrome): content never touches
             // the frame.
-            .padding(ratatui::widgets::Padding::new(2, 2, 1, 0));
+            .padding(ratatui::widgets::Padding::new(
+                2,
+                2,
+                u16::from(area.height >= 6),
+                0,
+            ));
+        let blk = if self.focused_action().is_some() {
+            blk.title(format!(
+                " Action: {} ",
+                self.focused_action().map_or("", |(_, label)| label)
+            ))
+        } else {
+            blk
+        };
+        let blk = if self.enroll.is_none() {
+            blk.title(self.page_observation())
+        } else {
+            blk
+        };
         let inner = blk.inner(area);
         f.render_widget(blk.clone(), area);
         if self.enroll.is_some() {
@@ -5129,9 +6429,19 @@ impl App {
             SC_SETTINGS => self.draw_settings(f, inner),
             _ => self.draw_done(f, inner),
         }
-        let (screen, _, _, max) = self.page_view.get();
-        if screen == self.screen && max > 0 {
-            f.render_widget(blk.title_bottom(" Scroll inside panel for more "), area);
+        let (screen, bounds, _, max) = self.page_view.get();
+        if self.focused_action().is_some() {
+            let hint = if screen == self.screen && bounds.height > 0 {
+                " ↑↓ action · Enter/Space · PgUp/Dn read "
+            } else {
+                " ↑↓ action · Enter/Space · F6 back "
+            };
+            f.render_widget(blk.title_bottom(hint), area);
+        } else if screen == self.screen && max > 0 {
+            f.render_widget(
+                blk.title_bottom(" Wheel scroll · F6 keyboard controls "),
+                area,
+            );
         }
     }
 
@@ -5164,7 +6474,32 @@ impl App {
             ])
         };
         let face = r.map(|x| x.face).unwrap_or(false);
+        let cue = if e.stalled.is_some() {
+            Line::from(Span::styled(
+                "Camera guide not answering; this is not about your face or lighting.",
+                Style::new().fg(th().err).bold(),
+            ))
+        } else if let Some(count) = e.count {
+            Line::from(Span::styled(
+                format!("● Hold still; capturing in {count}…"),
+                Style::new().fg(th().ok).bold(),
+            ))
+        } else {
+            let guidance = r.map(|report| report.guidance.clone()).unwrap_or_else(|| {
+                let spinner = if self.reduce_motion {
+                    "·"
+                } else {
+                    SPIN[self.spin]
+                };
+                format!("{spinner} Starting camera…")
+            });
+            Line::from(vec![
+                Span::styled("→ ", Style::new().fg(th().accent)),
+                Span::styled(guidance, Style::new().bold()),
+            ])
+        };
         let mut lines = vec![
+            cue,
             Line::from(Span::styled(
                 format!("Enrolling '{}'", e.profile),
                 Style::new().add_modifier(Modifier::BOLD),
@@ -5186,13 +6521,6 @@ impl App {
             // live reading (quality bar, checklist, guidance) is stale and
             // rendering any of it reads as a current verdict against a hung
             // capture (#309). The stall replaces the whole live panel.
-            lines.push(Line::from(vec![
-                Span::styled("  ✗ ", Style::new().fg(th().err)),
-                Span::styled(
-                    "Camera guide not answering; this is not about your face or lighting.",
-                    Style::new().fg(th().err).add_modifier(Modifier::BOLD),
-                ),
-            ]));
             lines.push(Line::from(Span::styled(
                 format!("    ({err}) Check: journalctl -u irlumed -n 50"),
                 Style::new().dim(),
@@ -5223,25 +6551,6 @@ impl App {
             ),
             Line::raw(""),
         ]);
-        if let Some(c) = e.count {
-            lines.push(Line::from(Span::styled(
-                format!("  ● Hold still; capturing in {c}…",),
-                Style::new().fg(th().ok).add_modifier(Modifier::BOLD),
-            )));
-        } else {
-            let g = r.map(|x| x.guidance.clone()).unwrap_or_else(|| {
-                let spinner = if self.reduce_motion {
-                    "·"
-                } else {
-                    SPIN[self.spin]
-                };
-                format!("{spinner} Starting camera…")
-            });
-            lines.push(Line::from(vec![
-                Span::styled("  → ", Style::new().fg(th().accent)),
-                Span::styled(g, Style::new().add_modifier(Modifier::BOLD)),
-            ]));
-        }
         lines.push(Line::raw(""));
         lines.push(Line::from(Span::styled(
             "  [esc] cancel",
@@ -5262,7 +6571,9 @@ impl App {
                 // The load FAILED (daemon up, enrollment unreadable). The [e]
                 // prompt here invited overwriting an enrollment that exists;
                 // Repair carries the recovery guidance.
-                format!("\nProfile list unreadable: {err}\n\nDo not re-enroll over it; see Diagnostics first.")
+                format!(
+                    "\nProfile list unreadable: {err}\n\nDo not re-enroll over it; see Diagnostics first."
+                )
             } else if !self.profiles_loaded {
                 // Never answered (daemon unreachable): the enrollment may
                 // exist and be fine, so no "none" and no enroll prompt.
@@ -5422,11 +6733,36 @@ impl App {
         let total = heights.iter().fold(0u16, |sum, h| sum.saturating_add(*h));
         let max = total.saturating_sub(area.height);
         let (screen, _, old_scroll, _) = self.page_view.get();
-        let scroll = if screen == self.screen {
+        let mut scroll = if screen == self.screen {
             old_scroll.min(max)
         } else {
             0
         };
+        let focused_key = self
+            .focused_action()
+            .and_then(|(key, _)| footer_keycode(key));
+        let focused_row = actions
+            .iter()
+            .find_map(|(row, key)| (Some(*key) == focused_key).then_some(*row));
+        if self.action_reveal.replace(false) {
+            if let Some(row) = focused_row {
+                let start = heights
+                    .iter()
+                    .take(row)
+                    .fold(0u16, |sum, height| sum.saturating_add(*height));
+                let end = start.saturating_add(heights.get(row).copied().unwrap_or(1));
+                if start < scroll || end > scroll.saturating_add(area.height) {
+                    // Prioritize the beginning of a wrapped action even when
+                    // its explanation is taller than the whole viewport.
+                    scroll = if heights.get(row).copied().unwrap_or(0) > area.height {
+                        start
+                    } else {
+                        end.saturating_sub(area.height).min(start)
+                    }
+                    .min(max);
+                }
+            }
+        }
         self.page_view.set((self.screen, area, scroll, max));
         let mut offset = 0u16;
         for (index, (line, height)) in lines.into_iter().zip(heights).enumerate() {
@@ -5441,9 +6777,13 @@ impl App {
                     height.saturating_sub(skipped).min(area.bottom() - y),
                 );
                 f.render_widget(
-                    Paragraph::new(line)
-                        .wrap(Wrap { trim: false })
-                        .scroll((skipped, 0)),
+                    Paragraph::new(if focused_row == Some(index) {
+                        line.style(selected_style())
+                    } else {
+                        line
+                    })
+                    .wrap(Wrap { trim: false })
+                    .scroll((skipped, 0)),
                     rect,
                 );
                 if let Some((_, key)) = actions.iter().find(|(row, _)| *row == index) {
@@ -5456,7 +6796,14 @@ impl App {
 
     fn preference_state(&self) -> irlume_common::PreferencesState {
         self.preferences
-            .unwrap_or_else(irlume_common::PreferencesState::observe)
+            .filter(|_| self.source_usable(Source::Preferences))
+            .unwrap_or(irlume_common::PreferencesState {
+                face_sensor_policy: irlume_common::config::FaceSensorPolicyObservation::Unreadable,
+                privileged_face_consent: None,
+                enforce_biopolicy: None,
+                consent_overridden: false,
+                biopolicy_overridden: false,
+            })
     }
 
     fn draw_settings(&self, f: &mut Frame, area: Rect) {
@@ -5473,18 +6820,25 @@ impl App {
             v.push(Line::raw(if self.preferences.is_some() {
                 "  State: daemon observed (refreshes automatically)"
             } else {
-                "  State: local observation; daemon preferences unavailable"
+                "  State: daemon preferences unavailable"
             }));
+            v.push(Line::raw(format!(
+                "  {}",
+                self.source_status(Source::Preferences)
+            )));
             v.push(Line::raw(""));
             v.push(section("Face sensor policy"));
             let ir_only = state.face_sensor_policy.resolve().ok().map(|policy| {
                 policy == irlume_common::config::FaceSensorPolicy::IrOnlyExperimental
             });
-            v.push(Line::raw(format!(
-                "  IR-only: {} — {}",
-                crate::preferences::toggle_label(ir_only),
-                crate::sensor_policy::state_label(state.face_sensor_policy)
-            )));
+            v.push(Line::from(vec![
+                Span::raw("  IR-only: "),
+                setting_badge(ir_only),
+                Span::raw(format!(
+                    " — {}",
+                    crate::sensor_policy::state_label(state.face_sensor_policy)
+                )),
+            ]));
             push_page_actions(
                 &mut v,
                 &mut page_actions,
@@ -5506,11 +6860,11 @@ impl App {
             v.push(Line::raw(""));
             v.push(section("Face authentication at privileged prompts"));
             v.push(Line::raw(""));
-            v.push(Line::raw(format!(
-                "  Hands-free: {} — {}",
-                crate::preferences::toggle_label(consent.map(|required| !required)),
-                crate::consent::state_label(consent)
-            )));
+            v.push(Line::from(vec![
+                Span::raw("  Hands-free: "),
+                setting_badge(consent.map(|required| !required)),
+                Span::raw(format!(" — {}", crate::consent::state_label(consent))),
+            ]));
             v.push(Line::raw(
                 "  Machine-wide for configured sudo/polkit and other privileged services.",
             ));
@@ -5544,29 +6898,15 @@ impl App {
             v.extend(vec![
                 section("Biopolicy operation-class gate"),
                 {
-                    // The shared tri-state reader, not the raw config read the
-                    // [b] direction uses: settings.conf is 0600 root-only, so
-                    // the raw read showed "off (default)" here while the Done
-                    // dashboard said "◐ root-only" for the same key. Same
-                    // truthy set and env override as the daemon.
-                    let (icon, icon_style, label) = match self.preference_state().enforce_biopolicy
-                    {
-                        Some(true) => (
-                            "●",
-                            Style::new().fg(th().ok).add_modifier(Modifier::BOLD),
-                            "ON — ENFORCING",
-                        ),
-                        Some(false) => ("○", Style::new().dim(), "OFF — off (default)"),
-                        None => (
-                            "◐",
-                            Style::new().fg(th().warn),
-                            "UNKNOWN — settings unavailable",
-                        ),
+                    let detail = match bio {
+                        Some(true) => " — ENFORCING",
+                        Some(false) => " — off (default)",
+                        None => " — settings unavailable",
                     };
                     Line::from(vec![
                         Span::raw("  state  "),
-                        Span::styled(format!("{icon} "), icon_style),
-                        Span::styled(label, Style::new().dim()),
+                        setting_badge(bio),
+                        Span::raw(detail),
                     ])
                 },
                 Line::from(Span::styled(
@@ -5582,8 +6922,7 @@ impl App {
                     Style::new().dim(),
                 )),
             ]);
-            if state.biopolicy_overridden || std::env::var_os("IRLUME_ENFORCE_BIOPOLICY").is_some()
-            {
+            if state.biopolicy_overridden {
                 v.push(Line::raw(if self.preferences.is_some_and(|state| state.biopolicy_overridden) { "  Daemon environment override controls biopolicy; the saved value has no effect." } else { "  Local environment override; daemon policy may differ. Remove it before changing this setting." }));
             }
             push_page_actions(
@@ -5616,10 +6955,8 @@ impl App {
         // The active pair comes from the daemon's Health, NOT from
         // select_pair(): that helper falls through to discovery when no
         // explicit pair is configured, and discovery opens every node. This
-        // is a DRAW function, so it ran per frame, which is where the last
-        // hundred-odd opens per session came from (#187). Health reports the
-        // devices the daemon actually has open, which is a better answer
-        // anyway.
+        // is a DRAW function, so it ran per frame (#187). Health reports the
+        // selected configuration, not open devices or an active capture.
         let (argb, air) = self
             .health
             .as_ref()
@@ -5630,32 +6967,42 @@ impl App {
                 )
             })
             .unwrap_or_default();
-        let pairs = &self.pairs;
+        let inventory = self.current_inventory();
+        let pairs = if inventory.is_some() && self.source_usable(Source::Cameras) {
+            self.pairs.as_slice()
+        } else {
+            &[]
+        };
         // Size the list to its rows (header + one row per camera/note) so the
         // info block sits right under it instead of a stretched gap; leftover
         // space stays empty at the bottom (content near the top).
-        let list_rows = self.nodes.len().max(pairs.len()).max(1) as u16 + 1;
-        let [list_area, info_area] =
-            Layout::vertical([Constraint::Length(list_rows + 1), Constraint::Min(9)]).areas(area);
+        let list_rows = pairs
+            .len()
+            .max(inventory.map_or(0, |value| value.candidates.len()))
+            .max(1) as u16
+            + 1;
+        let [list_area, info_area] = Layout::vertical([
+            Constraint::Length((list_rows + 1).min(area.height.saturating_sub(1).max(1))),
+            Constraint::Min(0),
+        ])
+        .areas(area);
 
         // ---- selectable list of trusted (physical) Hello camera pairs ----
         // No pair ≠ no camera: an RGB-only device still serves the convenience
         // tier, so show what exists instead of only an error line.
         let items: Vec<ListItem> = if pairs.is_empty() {
             let mut v = Vec::new();
-            for (path, role) in &self.nodes {
-                if matches!(role, irlume_camera::Role::Rgb) {
-                    v.push(ListItem::new(Line::from(vec![
-                        Span::styled(" ● ", Style::new().fg(th().ok)),
-                        Span::styled(
-                            format!("{:<16}", path.trim_start_matches("/dev/")),
-                            Style::new().add_modifier(Modifier::BOLD),
-                        ),
-                        Span::styled(
-                            "RGB-only, convenience tier (face unlocks the screen only)",
-                            Style::new().dim(),
-                        ),
-                    ])));
+            if let Some(inventory) = inventory {
+                for candidate in &inventory.candidates {
+                    v.push(ListItem::new(Line::raw(format!(
+                        " ◐ {} · {}",
+                        if self.camera_load.is_some() {
+                            "Inspecting"
+                        } else {
+                            "Attached; inspect roles"
+                        },
+                        candidate.endpoint_paths.join(" + ")
+                    ))));
                 }
             }
             if v.is_empty() {
@@ -5665,20 +7012,11 @@ impl App {
                 // printing "no camera found" for it contradicted the active
                 // pair shown right below (#187).
                 v.push(ListItem::new(Span::styled(
-                    if self.pairs_known {
-                        "no paired RGB+IR camera found: an RGB webcam alone gives the \
-                         Convenience tier (lock-screen face only); run `irlume camera census` \
-                         or `sudo irlume doctor --probe` to see every camera-like device"
-                    } else if self.daemon_up {
-                        "asking irlumed for the camera list (it answers once the camera is free)"
+                    if inventory.is_some() {
+                        "No UVC candidates in the current passive inventory; other camera backends are not covered."
                     } else {
-                        "irlumed is not running, so the camera list is unknown; start it from Repair"
+                        "Current camera inventory unavailable; no hardware absence is inferred."
                     },
-                    Style::new().dim(),
-                )));
-            } else {
-                v.push(ListItem::new(Span::styled(
-                    "   no IR node: the Secure tier (sudo/login/keyring) needs an IR Hello camera",
                     Style::new().dim(),
                 )));
             }
@@ -5690,11 +7028,11 @@ impl App {
                     let active = p.rgb == argb && p.ir == air;
                     let kind = if p.fixed { "built-in" } else { "external" };
                     let id = p.id.clone().unwrap_or_else(|| "?".into());
-                    let priv_on = p.privacy;
+                    let priv_on = p.privacy && self.source_usable(Source::CameraPrivacy);
                     ListItem::new(Line::from(vec![
                         Span::styled(
                             if active { " ● " } else { " ○ " },
-                            Style::new().fg(if active { th().ok } else { Color::DarkGray }),
+                            Style::new().fg(if active { th().ok } else { Color::Reset }),
                         ),
                         Span::styled(
                             format!(
@@ -5715,6 +7053,8 @@ impl App {
                         Span::styled(format!("[{id}]"), Style::new().dim()),
                         if priv_on {
                             Span::styled("  ⚠ privacy ON", Style::new().fg(th().err))
+                        } else if !self.source_usable(Source::CameraPrivacy) {
+                            Span::styled("  ◐ privacy unobserved", Style::new().fg(th().warn))
                         } else {
                             Span::raw("")
                         },
@@ -5723,14 +7063,17 @@ impl App {
                 .collect()
         };
         let mut st = ListState::default()
-            .with_selected(Some(self.cam_sel.min(pairs.len().saturating_sub(1))));
+            .with_selected((self.cam_sel < pairs.len()).then_some(self.cam_sel));
         // No inner border (whitespace over chrome; the content panel already
         // frames this). A section header carries what the border title did.
-        let [hdr_area, rows_area] =
-            Layout::vertical([Constraint::Length(1), Constraint::Min(1)]).areas(list_area);
+        let [hdr_area, rows_area] = Layout::vertical([
+            Constraint::Length(u16::from(list_area.height > 1)),
+            Constraint::Min(1),
+        ])
+        .areas(list_area);
         f.render_widget(
             Paragraph::new(section(
-                "Cameras  (● = active · ↑↓ select · Enter uses one)",
+                "Cameras  (● = configured · ↑↓ select · Enter uses one)",
             )),
             hdr_area,
         );
@@ -5739,7 +7082,11 @@ impl App {
             rows_area,
             &mut st,
         );
-        for i in 0..pairs.len().min(rows_area.height as usize) {
+        for i in 0..pairs
+            .len()
+            .saturating_sub(st.offset())
+            .min(rows_area.height as usize)
+        {
             self.hit(
                 Rect::new(
                     rows_area.x,
@@ -5747,35 +7094,32 @@ impl App {
                     rows_area.width,
                     1,
                 ),
-                Click::Select(i),
+                Click::Select(i + st.offset()),
             );
         }
 
-        // ---- info: active pair, selected pair nodes, emitter ----
-        // Only claim a node as "active" if it exists; select_pair's fixed
-        // fallback names devices that may be absent on this hardware.
-        let ex = |d: &str| std::path::Path::new(d).exists();
-        // "No camera hardware" is a claim about the MACHINE, so it needs an
-        // answer from the daemon to stand on. With health absent the paths
-        // above default to "", `ex("")` is false, and this line asserted no
-        // hardware on machines with four video nodes, contradicting the
-        // daemon row rendered above it. Unknown is not none.
+        // Health carries the daemon's cached device observation. Client-side
+        // path visibility (permissions or a different mount namespace) cannot
+        // establish camera absence, and rendering must not probe devices.
         let (active, active_style) = if self.health.is_none() {
             (
-                "unknown (daemon not answering; see Diagnostics)".to_string(),
+                "unknown (observation unavailable; see Diagnostics)".to_string(),
                 Style::new().dim(),
             )
         } else {
             let ok = Style::new().fg(th().ok).add_modifier(Modifier::BOLD);
-            match (ex(&argb), ex(&air)) {
+            match (!argb.is_empty(), !air.is_empty()) {
                 (true, true) => (format!("{argb} + {air}"), ok),
                 (true, false) => (format!("{argb} (RGB only)"), ok),
                 (false, true) => (format!("{air} (IR only)"), ok),
-                (false, false) => ("none (no camera hardware)".to_string(), Style::new().dim()),
+                (false, false) => (
+                    "no camera reported by daemon".to_string(),
+                    Style::new().dim(),
+                ),
             }
         };
         let mut lines = vec![Line::from(vec![
-            Span::styled("  active   ", Style::new().dim()),
+            Span::styled("  configured ", Style::new().dim()),
             Span::styled(active, active_style),
         ])];
         if let Some(p) = pairs.get(self.cam_sel) {
@@ -5792,14 +7136,17 @@ impl App {
         // without leaving the screen. Not-fetched draws as unknown, never
         // as the default schedule.
         let capture = match &self.capture_mode {
-            Some(text) => Span::raw(text.clone()),
+            Some(text) => Span::raw(format!(
+                "last observation ({}): {text}",
+                self.source_status(Source::Qualification)
+            )),
             None => Span::styled(
                 "unknown (daemon not answering)".to_string(),
                 Style::new().dim(),
             ),
         };
         lines.push(Line::from(vec![
-            Span::styled("  capture  ", Style::new().dim()),
+            Span::styled("  capture history  ", Style::new().dim()),
             capture,
         ]));
         lines.push(Line::raw(""));
@@ -5809,13 +7156,21 @@ impl App {
             Style::new().dim(),
         )));
         lines.push(Line::from(Span::styled(
-            "  your camera's USB descriptor documents, and never runs on its own.",
+            "  your camera's USB descriptor documents; this setup runs on request.",
             Style::new().dim(),
         )));
+        lines.push(Line::raw(
+            "  Authentication and automatic qualification may use the emitter.",
+        ));
+        lines.push(Line::raw(
+            "  F4 shows known current work; it does not prove physical camera power.",
+        ));
         push_page_actions(
             &mut lines,
             &mut page_actions,
             &[
+                ("r", "inspect attached candidates"),
+                ("c", "inspect capture qualification (asks first)"),
                 ("s", "set up emitter"),
                 ("t", "tune capture (holds the camera ~1 min)"),
                 ("p", "list units (writes nothing)"),
@@ -5845,7 +7200,12 @@ impl App {
             (None, true) => Span::styled("● present (unnamed)", Style::new().fg(th().ok)),
             (None, false) => Span::styled("○ none detected", Style::new().dim()),
         };
-        let enrolled = if self.fp.enrolled.is_empty() {
+        let enrolled = if !self.source_usable(Source::Fingerprint) {
+            Span::styled(
+                "unknown (enrollment observation unavailable)",
+                Style::new().fg(th().warn),
+            )
+        } else if self.fp.enrolled.is_empty() {
             Span::styled("none".to_string(), Style::new().dim())
         } else {
             Span::styled(
@@ -5944,7 +7304,10 @@ impl App {
                 Style::new().fg(th().err).add_modifier(Modifier::BOLD),
             ),
             Some(_) => Span::styled("○ plaintext at rest", Style::new().dim()),
-            None => Span::styled("◐ unknown (daemon unreachable)", Style::new().fg(th().warn)),
+            None => Span::styled(
+                "◐ unknown (observation unavailable)",
+                Style::new().fg(th().warn),
+            ),
         };
         let rec = match self.recovery {
             Some(r) if r.recovery_set => Span::styled(
@@ -5952,10 +7315,14 @@ impl App {
                 Style::new().fg(th().ok).add_modifier(Modifier::BOLD),
             ),
             Some(_) => Span::styled("○ not set", Style::new().dim()),
-            None => Span::styled("◐ unknown (daemon unreachable)", Style::new().fg(th().warn)),
+            None => Span::styled(
+                "◐ unknown (observation unavailable)",
+                Style::new().fg(th().warn),
+            ),
         };
         let mut lines = vec![
             section("Recovery + template encryption"),
+            Line::raw(format!("  {}", self.source_status(Source::Recovery))),
             state_row("templates", 12, enc),
             state_row("passphrase", 12, rec),
             Line::raw(""),
@@ -6015,11 +7382,12 @@ impl App {
                 Style::new().fg(th().ok).add_modifier(Modifier::BOLD),
             ),
             Some(false) => Span::styled("○ not armed", Style::new().dim()),
-            None => Span::styled("unknown (daemon unreachable)", Style::new().dim()),
+            None => Span::styled("unknown (observation unavailable)", Style::new().dim()),
         };
         let tpm = self.probes.tpm_present;
         let mut lines = vec![
             section("TPM keyring unlock"),
+            Line::raw(format!("  wallet {}", self.source_status(Source::Wallet))),
             Line::from(vec![Span::raw("  state    "), status]),
         ];
         // WHAT is sealed, not just whether something is. A GNOME token means
@@ -6070,13 +7438,15 @@ impl App {
         // the literal tier). Unanswered, it read as this machine's binding.
         let binding = match (&self.keyring_policy, self.keyring_armed) {
             (Some(p), _) => p.clone(),
-            (None, None) => "unknown (daemon unreachable)".to_string(),
-            (None, Some(_)) => "PCR-7 (Secure Boot state)".to_string(),
+            (None, None) => "unknown (observation unavailable)".to_string(),
+            (None, Some(_)) => "policy unreported by daemon".to_string(),
         };
         lines.extend([
             Line::from(vec![
                 Span::raw("  TPM      "),
-                if tpm {
+                if !self.source_usable(Source::Machine) {
+                    Span::styled("◐ unknown", Style::new().fg(th().warn))
+                } else if tpm {
                     Span::styled("● present", Style::new().fg(th().ok))
                 } else {
                     Span::styled("✗ none", Style::new().fg(th().err))
@@ -6242,7 +7612,9 @@ impl App {
             ),
             (
                 "Fingerprint",
-                self.fp_present.then_some(!self.fp.enrolled.is_empty()),
+                (self.source_usable(Source::FingerprintReader)
+                    && self.source_usable(Source::Fingerprint))
+                .then_some(self.fp_present && !self.fp.enrolled.is_empty()),
                 SC_FINGERPRINT,
             ),
             ("Diagnostics", diagnostics, SC_REPAIR),
@@ -6275,12 +7647,30 @@ impl App {
         let scans: usize = self.profiles.iter().map(|p| p.scans.len()).sum();
         let fails = self.repair.iter().filter(|c| c.sev == Sev::Fail).count();
         let warns = self.repair.iter().filter(|c| c.sev == Sev::Warn).count();
-        let (headline, detail, color) = if !self.daemon_up {
+        let live_transition = self
+            .live
+            .as_ref()
+            .filter(|_| self.source_usable(Source::Live))
+            .is_some_and(|live| {
+                live.stage != irlume_common::live::LiveStage::Ready || !live.tracking_available
+            });
+        let (headline, detail, color) = if live_transition {
+            ("Checking daemon readiness", "The daemon responded; its work state is changing or unavailable. F4 shows the current observation.", th().warn)
+        } else if !self.daemon_up {
             (
                 "Irlume needs attention",
                 "The background service is not responding.",
                 th().err,
             )
+        } else if !self
+            .live
+            .as_ref()
+            .filter(|_| self.source_usable(Source::Live))
+            .is_some_and(|live| {
+                live.stage == irlume_common::live::LiveStage::Ready && live.tracking_available
+            })
+        {
+            ("Checking daemon readiness", "Current daemon work state is unavailable or changing; F4 shows the latest observation.", th().warn)
         } else if fails > 0 {
             (
                 "Irlume needs attention",
@@ -6299,9 +7689,23 @@ impl App {
                 "Your face is enrolled; connect it to login and the lock screen.",
                 th().warn,
             )
+        } else if self.enrolled_known() == Some(true) && self.login_wired_known().is_none() {
+            (
+                "Checking login integration",
+                "Your face is enrolled; login wiring has not been observed yet.",
+                th().accent,
+            )
+        } else if self.enrolled_known() == Some(true) && self.face_camera_presence() != Some(true) {
+            ("Camera availability unconfirmed", "The saved enrollment remains; current face-camera availability is not established.", th().warn)
+        } else if !self.source_usable(Source::Machine) {
+            (
+                "Checking setup observations",
+                "Current diagnostics are unavailable; previous checks are not a readiness result.",
+                th().warn,
+            )
         } else if warns > 0 {
             (
-                "Face unlock is available",
+                "Setup has advisories",
                 "Diagnostics has an advisory worth reviewing.",
                 th().warn,
             )
@@ -6434,7 +7838,7 @@ impl App {
                         Style::new().fg(color).add_modifier(Modifier::BOLD),
                     ),
                     Span::styled(
-                        format!("{:<19}", c.label),
+                        format!("{:<19} · ", c.label),
                         Style::new().add_modifier(Modifier::BOLD),
                     ),
                     Span::styled(c.detail.clone(), Style::new().dim()),
@@ -6552,7 +7956,7 @@ impl App {
                 if let Some(p) = &self.keyring_policy {
                     p.clone()
                 } else if !self.daemon_up {
-                    "unknown (daemon unreachable)".to_string()
+                    "unknown (observation unavailable)".to_string()
                 } else if self.keyring_armed == Some(true) {
                     "unreported by this daemon".to_string()
                 } else if irlume_core::pcrsig::signed_policy_available() {
@@ -6611,6 +8015,12 @@ impl App {
             )),
             Line::raw(""),
         ];
+        if let Some(at) = self.identify_checked_at {
+            lines.push(Line::raw(format!(
+                "  Last recognition test: {}s ago",
+                self.now().saturating_duration_since(at).as_secs()
+            )));
+        }
         match &self.identify_result {
             Some((true, who)) => {
                 lines.push(Line::from(vec![
@@ -6621,11 +8031,11 @@ impl App {
                     Span::styled(who.clone(), Style::new().fg(th().ok)),
                 ]));
                 lines.push(Line::from(Span::styled(
-                    "    confidence is 0.00-1.00 (higher = surer); this cleared your match",
+                    "    The match score cleared the configured threshold.",
                     Style::new().dim(),
                 )));
                 lines.push(Line::from(Span::styled(
-                    "    threshold. Identify is a diagnostic check, not a login.",
+                    "    This is a diagnostic check, not a login or a probability estimate.",
                     Style::new().dim(),
                 )));
             }
@@ -6645,7 +8055,10 @@ impl App {
 
     fn draw_pam(&self, f: &mut Frame, area: Rect) {
         let mut page_actions = Vec::new();
-        let mut lines = vec![section("PAM services (face auth wiring)")];
+        let mut lines = vec![
+            section("PAM services (face auth wiring)"),
+            Line::raw(format!("  {}", self.source_status(Source::Machine))),
+        ];
         // Everything below renders `self.pam_cache`, computed with the
         // diagnostics: draw used to re-read every PAM service file and probe
         // the LSM on EVERY FRAME, which is I/O in a render loop.
@@ -6759,7 +8172,7 @@ impl App {
             }
             // Daemon unreachable/older, or no camera; don't promise credential release.
             _ => lines.push(Line::from(Span::styled(
-                "  tier unknown (daemon unreachable); password remains the fallback",
+                "  tier unknown (observation unavailable); password remains the fallback",
                 Style::new().dim(),
             ))),
         }
@@ -6870,7 +8283,7 @@ impl App {
             Line::raw(""),
             Line::from(vec![
                 Span::raw("  daemon            "),
-                onoff(self.daemon_up),
+                onoff_opt(self.daemon_ready_observed()),
             ]),
             Line::from(vec![
                 Span::raw("  auth method       "),
@@ -6922,21 +8335,34 @@ impl App {
             ]),
             Line::from(vec![
                 Span::raw("  fingerprint       "),
-                onoff(self.fp.available),
+                onoff_opt(
+                    self.source_usable(Source::FingerprintReader)
+                        .then_some(self.fp.available),
+                ),
             ]),
             Line::from(vec![Span::raw("  login connection  "), onoff_opt(wired)]),
             Line::raw(""),
             Line::from(Span::styled(
-                if !self.daemon_up {
+                if self.daemon_ready_observed().is_none() {
+                    "  Current daemon readiness unavailable; F4 shows observation status."
+                } else if self.daemon_ready_observed() == Some(false) {
+                    "  Daemon is changing state; wait for Ready before checking setup."
+                } else if !self.daemon_up {
                     "  Daemon not running; see Diagnostics before quitting."
+                } else if !self.source_usable(Source::Profiles) || self.enrolled_known().is_none() {
+                    "  Current enrollment observation unavailable; wait for Faces to refresh."
                 } else if self.profiles.is_empty() && self.caps.rgb {
                     "  Not set up yet; enroll a face (Overview [e]) to begin."
                 } else if self.profiles.is_empty() {
-                    "  No face hardware; fingerprint/password remain your methods."
+                    "  Face hardware availability is unconfirmed; password remains available."
                 } else if wired == Some(false) {
                     "  One step left: your login screen isn't wired yet; press [w] (sudo; password stays the fallback)."
                 } else if wired.is_none() {
                     "  Checking login connection; the row above fills in when the probe lands."
+                } else if self.face_camera_presence() != Some(true)
+                    || !self.source_usable(Source::Profiles)
+                {
+                    "  Current face setup is unconfirmed; inspect Cameras and Faces observations."
                 } else {
                     "  All set. irlume keeps running as a daemon; this panel is safe to quit."
                 },
@@ -6962,17 +8388,55 @@ impl App {
         } else {
             SPIN[self.spin]
         };
-        let title = match (&self.op, expanded, scrolled) {
+        let history_title = match (&self.op, expanded, scrolled) {
             (Some(op), _, _) => format!(" Activity · {spinner} {}… ", op.label),
             (None, true, true) => format!(
                 " Activity · ↑ history ({} up · PgDn/End to follow) ",
                 self.act_scroll
             ),
             (None, true, false) => {
-                " Activity · newest last · [A] collapse · PgUp history ".to_string()
+                " Activity · newest last · [A] collapse · [L] full history ".to_string()
             }
-            (None, false, _) => " Recent activity · [A] expand ".to_string(),
+            (None, false, _) => " Session activity · [A] expand · [L] full history ".to_string(),
         };
+        let live_label = if !self.source_usable(Source::Live) || self.live.is_none() {
+            "unavailable"
+        } else if self
+            .live
+            .as_ref()
+            .is_some_and(|live| !live.tracking_available)
+        {
+            "activity unknown"
+        } else if self
+            .live
+            .as_ref()
+            .is_some_and(|live| live.worker.is_some() || !live.background.is_empty())
+        {
+            "working"
+        } else if self
+            .live
+            .as_ref()
+            .is_some_and(|live| live.stage == irlume_common::live::LiveStage::Ready)
+        {
+            "worker ready"
+        } else {
+            "changing state"
+        };
+        let title = format!(" [F4] Daemon {live_label} ·{history_title}");
+        self.hit(
+            Rect::new(
+                area.x.saturating_add(1),
+                area.y,
+                5.min(area.width.saturating_sub(1)),
+                u16::from(area.height > 0),
+            ),
+            Click::Key(KeyCode::F(4)),
+        );
+        let history_button = title.find("[L]").map(|index| {
+            let left = u16::try_from(Line::raw(&title[..index]).width()).unwrap_or(u16::MAX);
+            Rect::new(area.x.saturating_add(1).saturating_add(left), area.y, 16, 1)
+                .intersection(area)
+        });
         let blk = Block::bordered()
             .title(title)
             .border_type(BorderType::Rounded)
@@ -6986,14 +8450,21 @@ impl App {
         } else {
             area
         };
+        if let Some(button) = history_button {
+            self.hit(button, Click::Key(KeyCode::Char('L')));
+        }
         self.hit(activity_target, Click::Key(KeyCode::Char('A')));
+        // Detail text always opens a fully readable view; the title keeps the
+        // compact disclosure behavior. No normal screen action is dispatched.
+        self.hit(inner, Click::Key(KeyCode::Char('L')));
         let h = inner.height as usize;
         // Window ends `act_scroll` lines up from the newest entry.
         // Designed empty state (HIG placeholders): say what will appear, not
         // nothing.
         if self.activity.is_empty() {
             f.render_widget(
-                Paragraph::new("No activity yet.").style(Style::new().dim()),
+                Paragraph::new("No actions recorded in this TUI session.")
+                    .style(Style::new().dim()),
                 inner,
             );
             return;
@@ -7002,20 +8473,115 @@ impl App {
         let start = end.saturating_sub(h);
         let lines: Vec<Line> = self.activity[start..end]
             .iter()
-            .map(|(g, m)| {
+            .enumerate()
+            .map(|(offset, (g, _))| {
                 let gs = match g {
                     '→' => Style::new().fg(th().accent),
                     '✓' => Style::new().fg(th().ok),
                     '✗' => Style::new().fg(th().err),
                     _ => Style::new().dim(),
                 };
-                Line::from(vec![
-                    Span::styled(format!("{g} "), gs),
-                    Span::raw(m.clone()),
-                ])
+                Line::styled(self.activity.summary(start + offset, inner.width), gs)
             })
             .collect();
-        f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
+        f.render_widget(Paragraph::new(lines), inner);
+    }
+
+    fn draw_activity_history(&self, f: &mut Frame) {
+        let area = f.area();
+        f.render_widget(Clear, area);
+        let block = Block::bordered()
+            .title(" Session history · [F4] Current status ")
+            .border_type(BorderType::Rounded)
+            .border_style(Style::new().fg(th().accent));
+        let inner = block.inner(area);
+        f.render_widget(block, area);
+        self.hit(
+            Rect::new(
+                area.x.saturating_add(1),
+                area.y,
+                area.width.saturating_sub(2),
+                u16::from(area.height > 0),
+            ),
+            Click::DialogKey(KeyCode::F(4)),
+        );
+        let descriptions = [
+            "This TUI session: selected actions only; other apps and past sessions are not recorded. Status refreshes automatically query daemon, device and setup observations; camera enumeration may open devices. Setup/test actions can use the camera or TPM, or change configuration. Completion does not prove rollback or camera shutoff. F2 on the main screen opens history and diagnostic tools.",
+            "This TUI session only. Refreshes query devices; actions may use hardware or change settings. F2: history/diagnostics.",
+            "This TUI session. F2: tools.",
+        ];
+        // Shorten the explanation on small terminals, never the retained
+        // detail viewport. All entry text remains available through scrolling.
+        let scope = descriptions
+            .iter()
+            .copied()
+            .find(|text| {
+                Paragraph::new(*text)
+                    .wrap(Wrap { trim: false })
+                    .line_count(inner.width)
+                    <= usize::from((inner.height / 2).max(1))
+            })
+            .unwrap_or(descriptions[2]);
+        let scope_rows = Paragraph::new(scope)
+            .wrap(Wrap { trim: false })
+            .line_count(inner.width) as u16;
+        let [context, state, _separator, body, controls] = Layout::vertical([
+            Constraint::Length(scope_rows),
+            Constraint::Length(2),
+            Constraint::Length(1),
+            Constraint::Min(0),
+            Constraint::Length(1),
+        ])
+        .areas(inner);
+        f.render_widget(
+            Paragraph::new(scope)
+                .wrap(Wrap { trim: false })
+                .style(Style::new().dim()),
+            context,
+        );
+        let status = if let Some(op) = &self.op {
+            format!("In progress: {} (history does not cancel it)", op.label)
+        } else if self.enroll.is_some() {
+            "Enrollment in progress (history does not cancel it)".to_string()
+        } else if self.activity.following() {
+            "Following newest · ↑/PgUp to read earlier".to_string()
+        } else {
+            "Reading history · End to follow newest".to_string()
+        };
+        f.render_widget(
+            Paragraph::new(vec![
+                Line::raw(format!("{} · {status}", self.activity.retention())),
+                Line::raw(format!("{} · F4 details", self.live_summary())),
+            ]),
+            state,
+        );
+        if self.activity.is_empty() {
+            f.render_widget(
+                Paragraph::new("No actions recorded in this TUI session."),
+                body,
+            );
+        } else {
+            f.render_widget(self.activity.paragraph(body.width, body.height), body);
+        }
+        let labels = if controls.width >= 39 {
+            ["[Esc/L] Close", "[Home] First", "[End] Last"]
+        } else {
+            ["[Esc] Close", "[Home]", "[End]"]
+        };
+        let mut x = controls.x;
+        for (label, key) in labels
+            .into_iter()
+            .zip([KeyCode::Esc, KeyCode::Home, KeyCode::End])
+        {
+            let width = (label.len() as u16).min(controls.right().saturating_sub(x));
+            let button = Rect::new(x, controls.y, width, controls.height);
+            f.render_widget(Paragraph::new(label).style(selected_style()), button);
+            self.hit(button, Click::DialogKey(key));
+            x = x
+                .saturating_add(width)
+                .saturating_add(2)
+                .min(controls.right());
+        }
     }
 
     /// Per-screen action keys, ordered primary-first: the footer shows
@@ -7077,6 +8643,8 @@ impl App {
                 ("t", "Toggle Debug Logs"),
             ],
             SC_CAMERAS => &[
+                ("r", "Inspect Candidates"),
+                ("c", "Inspect Qualification"),
                 ("enter", "Use Selected Pair…"),
                 ("s", "Set Up Emitter…"),
                 ("p", "List Units"),
@@ -7162,114 +8730,128 @@ impl App {
 
     fn draw_footer(&self, f: &mut Frame, area: Rect) {
         let key = |k: &str| Span::styled(format!(" {k} "), th().chip);
-        // Guided enrollment swallows every key but Esc; show only that, so the
-        // footer doesn't advertise dead nav/action keys during a capture.
-        if self.enroll.is_some() {
-            let spans = vec![
-                key("esc"),
-                Span::styled(" cancel enrollment", Style::new().dim()),
-            ];
-            let blk = Block::bordered()
-                .border_type(BorderType::Rounded)
-                .border_style(Style::new().dim());
-            f.render_widget(Paragraph::new(Line::from(spans)).block(blk), area);
-            return;
-        }
-        // A running op (Identify / IR self-test) also swallows every key but
-        // q/Esc, so don't advertise the live nav/action keys during it.
-        if self.op.is_some() {
-            let spans = vec![
-                key("q / esc"),
-                // "quit", not "cancel": these keys leave the TUI. The op keeps
-                // running in the daemon and its result is dropped; nothing here
-                // can call it back. Esc means "back out and stay" on every other
-                // screen, so promising a cancel here read as the safe choice.
-                Span::styled(
-                    " quit (the op keeps running) · working…",
-                    Style::new().dim(),
-                ),
-            ];
-            let blk = Block::bordered()
-                .border_type(BorderType::Rounded)
-                .border_style(Style::new().dim());
-            f.render_widget(Paragraph::new(Line::from(spans)).block(blk), area);
-            return;
-        }
-        let actions = self.screen_actions();
-        // Three-tier disclosure: the footer shows the primary action plus one
-        // secondary action; [?] opens the full keymap overlay;
-        // docs hold the rest. The first action is THE action for the screen,
-        // so it alone gets the emphasized label.
-        // Build the chip row while tracking x so each key chip becomes a click
-        // target (border eats one column, so content starts at area.x + 1).
-        let inner_y = area.y + 1;
-        let mut x = area.x + 1;
-        let mut spans: Vec<Span> = Vec::new();
-        let nav_x = x;
-        let s = key("Tab");
-        let w = s.content.chars().count() as u16;
-        x = x.saturating_add(w);
-        spans.push(s);
-        let s = Span::styled(" sections  ", Style::new().dim());
-        x = x.saturating_add(s.content.chars().count() as u16);
-        spans.push(s);
-        self.hit(
-            Rect::new(nav_x, inner_y, x.saturating_sub(nav_x), 1),
-            Click::Key(KeyCode::Tab),
-        );
-        let visible_actions = if area.width >= 100 { 2 } else { 1 };
-        for (i, (k, d)) in actions.iter().take(visible_actions).enumerate() {
-            let action_x = x;
-            let s = key(k);
-            let w = s.content.chars().count() as u16;
-            x = x.saturating_add(w);
-            spans.push(s);
-            let ds = if i == 0 {
-                Span::styled(format!(" {d}  "), Style::new().add_modifier(Modifier::BOLD))
+        // These controls replay the same state-specific keys as the keyboard.
+        // Leaving a generic operation does not retract its daemon request.
+        if self.enroll.is_some() || self.op.is_some() {
+            let label = if self.enroll.is_some() {
+                " cancel enrollment"
             } else {
-                Span::styled(format!(" {d}  "), Style::new().dim())
+                " quit · task keeps running"
             };
-            x = x.saturating_add(ds.content.chars().count() as u16);
-            spans.push(ds);
-            if let Some(kc) = footer_keycode(k) {
+            let line = Line::from(vec![
+                key("esc"),
+                Span::raw(label),
+                Span::raw(if self.op.is_some() && area.width >= 60 {
+                    " · working…"
+                } else {
+                    ""
+                }),
+            ]);
+            let block = Block::bordered()
+                .border_type(BorderType::Rounded)
+                .border_style(Style::new().dim());
+            let inner = block.inner(area);
+            let width = (line.width().min(u16::MAX as usize) as u16).min(inner.width);
+            f.render_widget(block, area);
+            f.render_widget(Paragraph::new(line), inner);
+            if width > 0 && inner.height > 0 {
                 self.hit(
-                    Rect::new(action_x, inner_y, x.saturating_sub(action_x), 1),
-                    Click::Key(kc),
+                    Rect::new(inner.x, inner.y, width, 1),
+                    Click::Key(KeyCode::Esc),
                 );
             }
+            return;
         }
-        let more_x = x;
-        let chip = key("F2");
-        x = x.saturating_add(chip.content.chars().count() as u16 + 10);
-        spans.push(chip);
-        spans.push(Span::styled(" actions  ", Style::new().dim()));
-        self.hit(
-            Rect::new(more_x, inner_y, x.saturating_sub(more_x), 1),
-            Click::Key(KeyCode::F(2)),
-        );
-        let help_x = x;
-        let s = key("?");
-        let w = s.content.chars().count() as u16;
-        x = x.saturating_add(w);
-        spans.push(s);
-        let s = Span::styled(" shortcuts", Style::new().dim());
-        x = x.saturating_add(s.content.chars().count() as u16);
-        spans.push(s);
-        self.hit(
-            Rect::new(help_x, inner_y, x.saturating_sub(help_x), 1),
-            Click::Key(KeyCode::Char('?')),
-        );
-        let blk = Block::bordered()
+        let block = Block::bordered()
             .border_type(BorderType::Rounded)
             .border_style(Style::new().dim());
-        f.render_widget(Paragraph::new(Line::from(spans)).block(blk), area);
+        let inner = block.inner(area);
+        let compact = inner.width < 78;
+        let control = |key: &str, label: &str, primary: bool| {
+            Line::from(vec![
+                Span::styled(format!(" {key} "), th().chip),
+                Span::styled(
+                    if compact {
+                        format!("{label} ")
+                    } else {
+                        format!(" {label}  ")
+                    },
+                    if primary {
+                        Style::new().bold()
+                    } else {
+                        Style::new()
+                    },
+                ),
+            ])
+        };
+        let labels = if compact {
+            if inner.width >= 36 {
+                ["Menu", "Focus", "More", "Help"]
+            } else {
+                ["", "", "", ""]
+            }
+        } else {
+            ["sections", "controls", "actions", "shortcuts"]
+        };
+        let fixed = [
+            (control("F3", labels[0], false), KeyCode::F(3)),
+            (
+                control("F6", labels[1], self.focused_action().is_some()),
+                KeyCode::F(6),
+            ),
+            (control("F2", labels[2], false), KeyCode::F(2)),
+            (control("?", labels[3], false), KeyCode::Char('?')),
+        ];
+        let reserved = fixed.iter().map(|(line, _)| line.width()).sum::<usize>();
+        let mut controls = Vec::new();
+        let mut used = 0;
+        // Retain the familiar wide-screen Tab/action placement. On compact
+        // terminals F3 provides direct access to every section in one menu.
+        if !compact {
+            let tab = Line::from(vec![key("Tab"), Span::raw(" sections  ")]);
+            used += tab.width();
+            controls.push((tab, KeyCode::Tab));
+        }
+        let actions = self.focused_action().map_or_else(
+            || {
+                self.screen_actions()
+                    .iter()
+                    .take(2)
+                    .copied()
+                    .collect::<Vec<_>>()
+            },
+            |action| vec![action],
+        );
+        for (index, (key, description)) in actions.into_iter().enumerate() {
+            let line = control(key, description, index == 0);
+            if used + line.width() + reserved <= usize::from(inner.width) {
+                if let Some(key) = footer_keycode(key) {
+                    used += line.width();
+                    controls.push((line, key));
+                }
+            }
+        }
+        controls.extend(fixed);
+        f.render_widget(block, area);
+        let mut x = inner.x;
+        for (line, key) in controls {
+            let width =
+                (line.width().min(u16::MAX as usize) as u16).min(inner.right().saturating_sub(x));
+            if width == 0 || inner.height == 0 {
+                break;
+            }
+            let rect = Rect::new(x, inner.y, width, 1);
+            f.render_widget(Paragraph::new(line), rect);
+            self.hit(rect, Click::Key(key));
+            x = x.saturating_add(width);
+        }
     }
 
     /// The full keymap for the [?] overlay: the global keys plus every action
     /// of the CURRENT screen (tier two of the disclosure ladder).
     fn help_body(&self) -> String {
         let mut b = String::from(
-            "Global\n              F2  search more actions\n  Tab / \u{2190}\u{2192}  switch section       \u{2191}\u{2193}  select\n               v  show/hide technical tools\n               A  expand/collapse activity history\n         PgUp/Dn  scroll activity history\n               h  Overview              q  quit\n           click  rows and action chips\n               M  release mouse (highlight/copy)\n\nThis screen\n",
+            "Global\n              F4  current daemon, camera inventory and observation age\n              F3  choose a section (click or arrows + Enter)\n              F6  focus page actions / return to page selection\n          ↑↓ + Enter/Space  choose and activate a focused action\n              F2  search more actions\n  Tab / \u{2190}\u{2192}  switch section       \u{2191}\u{2193}  select\n               v  show/hide technical tools\n               A  expand/collapse activity history\n               L  full session history and wrapped details\n         PgUp/Dn  read page with F6 focus; otherwise Activity\n               h  Overview              q  quit\n           click  rows and action chips\n        Dialogs  ↑↓ / PgUp/Dn scroll long messages\n               M  release mouse (highlight/copy)\n\nThis screen\n",
         );
         for (k, d) in self.screen_actions() {
             b.push_str(&format!("  {k:<7} {d}\n"));
@@ -7333,7 +8915,7 @@ impl App {
             let hint = Rect::new(inner.x, button_area.y.saturating_sub(1), inner.width, 1)
                 .intersection(inner);
             f.render_widget(
-                Paragraph::new("Scroll to read more").style(Style::new().dim()),
+                Paragraph::new("↑↓ / PgUp/Dn / wheel: read more").style(Style::new().dim()),
                 hint,
             );
         }
@@ -7356,32 +8938,14 @@ impl App {
     }
 }
 
-/// Approximate ratatui's word-wrap line count for `text` at `width` columns, so
-/// `modal()` can size its height to fit. Off-by-one on a word longer than the
-/// width is harmless (the height is clamped to the frame).
+/// Use the same grapheme-aware wrapper for layout and the scroll limit.
 fn wrapped_line_count(text: &str, width: usize) -> usize {
     if width == 0 {
         return 1;
     }
-    // Count each explicit line (split on '\n'), word-wrapped to `width`.
-    text.split('\n')
-        .map(|line| {
-            let mut lines = 1usize;
-            let mut col = 0usize;
-            for word in line.split_whitespace() {
-                let wlen = word.chars().count();
-                if col == 0 {
-                    col = wlen;
-                } else if col + 1 + wlen <= width {
-                    col += 1 + wlen;
-                } else {
-                    lines += 1;
-                    col = wlen;
-                }
-            }
-            lines
-        })
-        .sum()
+    Paragraph::new(text)
+        .wrap(Wrap { trim: true })
+        .line_count(width.clamp(1, u16::MAX as usize) as u16)
 }
 
 // ---- rich-render helpers --------------------------------------------------
@@ -7395,10 +8959,15 @@ fn tui_rows(area: Rect) -> [Rect; 5] {
 }
 
 fn tui_rows_with_activity(area: Rect, activity_rows: u16) -> [Rect; 5] {
+    // Keep three rows for the footer and recent Activity, plus a usable page
+    // before expanding history. Overconstraining Min(6) at small heights can
+    // squeeze the bordered footer/history down to two rows with no content.
+    let activity_rows = activity_rows.min(area.height.saturating_sub(9));
+    let body_min = 6.min(area.height.saturating_sub(5 + activity_rows));
     Layout::vertical([
         Constraint::Length(1),
         Constraint::Length(1),
-        Constraint::Min(6),
+        Constraint::Min(body_min),
         Constraint::Length(activity_rows),
         Constraint::Length(3),
     ])
@@ -7621,11 +9190,51 @@ fn tflite_fallback_check(
 
 // ---- async response mappers (Response -> (ok, message)) -------------------
 
+/// Describe the requested effect without formatting request fields. Activity
+/// records intent here; only the later response can establish an outcome.
+fn request_effect(request: &Request) -> &'static str {
+    match request {
+        Request::Identify => {
+            "Requests a camera capture and compares it with enrolled faces. This recognition test does not change login wiring."
+        }
+        Request::SetupIrEmitter { dry_run: true } => {
+            "Inspects the IR emitter controls without applying their configuration."
+        }
+        Request::SetupIrEmitter { dry_run: false } => {
+            "Requests configuration of the camera's IR emitter controls."
+        }
+        Request::DeleteProfile { .. } => {
+            "Requests deletion of the selected face profile and its saved scans."
+        }
+        Request::DeleteScan { .. } => "Requests deletion of the selected saved face scan.",
+        Request::RenameProfile { .. } | Request::RenameScan { .. } => {
+            "Requests a new name for the selected saved profile or scan; no new capture."
+        }
+        Request::ForgetPassword { .. } => {
+            "Requests removal of the sealed wallet secret; wallet unlock will need its password."
+        }
+        Request::RecoverySetup { .. } => {
+            "Creates a passphrase-protected recovery backup for this account's template key."
+        }
+        Request::RecoveryRestore { .. } => {
+            "Restores the template key from its recovery backup and seals it to the current TPM state."
+        }
+        Request::RecoveryForget { .. } => {
+            "Requests removal of the recovery backup while keeping the current template key."
+        }
+        _ => "Requests an operation from the daemon. Waiting for its result.",
+    }
+}
+
+fn unexpected_response() -> String {
+    "unexpected daemon response; the operation's result was not confirmed. Refresh status before retrying.".into()
+}
+
 fn map_ok(resp: Response) -> (bool, String) {
     match resp {
         Response::Ok(m) => (true, m),
         Response::Error(e) => (false, e),
-        o => (false, format!("unexpected: {o:?}")),
+        _ => (false, unexpected_response()),
     }
 }
 
@@ -7655,7 +9264,7 @@ fn map_identify(resp: Response) -> (bool, String) {
         } => (
             true,
             format!(
-                "{u} · {} · confidence {score:.3}",
+                "{u} · {} · match score {score:.3}",
                 profile.unwrap_or_default()
             ),
         ),
@@ -7684,7 +9293,7 @@ fn map_identify(resp: Response) -> (bool, String) {
             )
         }
         Response::Error(e) => (false, e),
-        o => (false, format!("unexpected: {o:?}")),
+        _ => (false, unexpected_response()),
     }
 }
 
@@ -7698,7 +9307,7 @@ fn map_confirm(resp: Response) -> (bool, String) {
             "sealed keyring secret erased; keyring unlock disarmed".into(),
         ),
         Response::Error(e) => (false, e),
-        o => (false, format!("unexpected: {o:?}")),
+        _ => (false, unexpected_response()),
     }
 }
 
@@ -7710,7 +9319,7 @@ fn map_sealed(resp: Response) -> (bool, String) {
             "keyring armed; unlocking your session will open your wallet".into(),
         ),
         Response::Error(e) => (false, format!("arm failed: {e}")),
-        o => (false, format!("arm failed: {o:?}")),
+        _ => (false, unexpected_response()),
     }
 }
 
@@ -7786,10 +9395,8 @@ fn guide_until_capture(
             // A response of the wrong type is a protocol break, not a cue to
             // retry: swallowing it here would spin a tight request loop
             // against a confused daemon.
-            Ok(o) => {
-                let _ = send(WMsg::Err(format!(
-                    "camera guide answered with the wrong response type: {o:?}"
-                )));
+            Ok(_) => {
+                let _ = send(WMsg::Err(unexpected_response()));
                 return GuideOutcome::Halt;
             }
             Err(e) => {
@@ -7828,10 +9435,8 @@ fn guide_until_capture(
                 let _ = send(WMsg::Err(e));
                 return GuideOutcome::Halt;
             }
-            Ok(o) => {
-                let _ = send(WMsg::Err(format!(
-                    "camera guide answered with the wrong response type: {o:?}"
-                )));
+            Ok(_) => {
+                let _ = send(WMsg::Err(unexpected_response()));
                 return GuideOutcome::Halt;
             }
             // A mid-countdown miss counts like any other: the counter
@@ -7928,7 +9533,7 @@ fn enroll_worker(
                     match reply.recv_timeout(Duration::from_millis(100)) {
                         Ok(accept) => return Ok(Some(accept)),
                         Err(mpsc::RecvTimeoutError::Disconnected) => {
-                            return Err(std::io::Error::other("enrollment UI closed"))
+                            return Err(std::io::Error::other("enrollment UI closed"));
                         }
                         Err(mpsc::RecvTimeoutError::Timeout) => {}
                     }
@@ -7955,8 +9560,8 @@ fn enroll_worker(
         Ok(Response::Error(error)) => {
             let _ = send(WMsg::Err(error));
         }
-        Ok(other) => {
-            let _ = send(WMsg::Err(format!("unexpected enrollment reply: {other:?}")));
+        Ok(_) => {
+            let _ = send(WMsg::Err(unexpected_response()));
         }
         Err(error) => {
             let _ = send(WMsg::Err(format!(
@@ -8066,8 +9671,8 @@ fn legacy_enroll_worker(
                     let _ = send(WMsg::Err(e));
                     return;
                 }
-                Ok(o) => {
-                    let _ = send(WMsg::Err(format!("unexpected: {o:?}")));
+                Ok(_) => {
+                    let _ = send(WMsg::Err(unexpected_response()));
                     return;
                 }
                 Err(e) => {
@@ -8085,6 +9690,8 @@ fn legacy_enroll_worker(
 #[cfg(test)]
 mod tests {
     use super::*;
+    include!("tui/visual_tests.rs");
+    include!("tui/live_tests.rs");
     /// Serializes tests that mutate process-global environment (IRLUME_SOCKET,
     /// PATH) so they can't race each other under the parallel test runner.
     /// One binary-wide lock: main.rs and commands.rs tests use the same one,
@@ -8960,7 +10567,7 @@ mod tests {
     #[test]
     fn audit_removed_selection_cannot_silently_target_another_person() {
         let _guard = dead_socket();
-        let mut app = test_app();
+        let mut app = live_test_app();
         app.caps.rgb = true;
         app.screen = SC_PROFILES;
         app.profiles = vec![profile("Alice", &["a1"]), profile("Bob", &["b1"])];
@@ -8986,6 +10593,7 @@ mod tests {
             app.confirm.is_none(),
             "another refresh must keep selection cleared"
         );
+        assert_eq!(app.screen, SC_PROFILES, "selection test stays on Faces");
         app.move_sel(1);
         assert!(
             app.sel_profile().is_some(),
@@ -9025,14 +10633,27 @@ mod tests {
             std::process::id()
         ));
         let listener = std::os::unix::net::UnixListener::bind(&sock).unwrap();
+        listener.set_nonblocking(true).unwrap();
         std::env::set_var("IRLUME_SOCKET", &sock);
         let server = std::thread::spawn(move || {
             let mut requests = Vec::new();
-            for response in [
-                Response::Cameras(vec![]),
-                Response::Error("old daemon".into()),
-            ] {
-                let (mut stream, _) = listener.accept().unwrap();
+            for response in [Response::Cameras(vec![])] {
+                let deadline = Instant::now() + Duration::from_secs(2);
+                let mut stream = loop {
+                    match listener.accept() {
+                        Ok((stream, _)) => break stream,
+                        Err(error)
+                            if error.kind() == std::io::ErrorKind::WouldBlock
+                                && Instant::now() < deadline =>
+                        {
+                            std::thread::sleep(Duration::from_millis(5))
+                        }
+                        Err(error) => panic!("camera fixture accept did not finish: {error}"),
+                    }
+                };
+                stream
+                    .set_read_timeout(Some(Duration::from_secs(2)))
+                    .unwrap();
                 let mut line = String::new();
                 std::io::BufReader::new(&stream)
                     .read_line(&mut line)
@@ -9043,11 +10664,16 @@ mod tests {
             }
             requests
         });
-        let mut app = test_app();
+        let mut app = live_test_app();
         let started = std::time::Instant::now();
         app.refresh_camera_listing();
         let blocked = started.elapsed();
         let requests = server.join().unwrap();
+        assert!(matches!(requests.as_slice(), [Request::ListCameras]));
+        assert!(
+            app.qualification_load.is_none(),
+            "role inspection never qualifies capture"
+        );
         let deadline = std::time::Instant::now() + Duration::from_secs(2);
         while !app.pairs_known && std::time::Instant::now() < deadline {
             app.poll();
@@ -9150,7 +10776,21 @@ mod tests {
             ir_pair: false,
             rgb: false,
         };
-        App {
+        let mut app = App {
+            freshness: Freshness::default(),
+            clock_override: None,
+            usable_sources: [false; 13],
+            show_live: false,
+            live: None,
+            live_load: None,
+            live_epoch: None,
+            camera_epoch: None,
+            classified_epoch: None,
+            camera_confirmation: None,
+            selected_camera_choice: None,
+            selected_profile_identity: None,
+            qualification_load: None,
+            identify_checked_at: None,
             user: "testuser".into(),
             screen: SC_WELCOME,
             sel: 0,
@@ -9167,16 +10807,20 @@ mod tests {
             pairs_known: false,
             capture_mode: None,
             camera_load: None,
-            activity: Vec::new(),
+            activity: activity::Activity::default(),
             input: None,
             confirm: None,
             mouse_select: false,
             click_targets: std::cell::RefCell::new(Vec::new()),
+            window_area: std::cell::Cell::new(None),
             dialog_view: std::cell::Cell::new((Rect::default(), 0)),
             dialog_scroll: std::cell::Cell::new(0),
             page_view: std::cell::Cell::new((usize::MAX, Rect::default(), 0, 0)),
             show_help: false,
             more_actions: None,
+            sections: None,
+            action_focus: None,
+            action_reveal: std::cell::Cell::new(false),
             hub_sel: 0,
             op: None,
             enroll: None,
@@ -9201,9 +10845,12 @@ mod tests {
             preferences: None,
             act_scroll: 0,
             activity_open: false,
+            activity_history_open: false,
             reduce_motion: false,
             visible: App::compute_visible(&caps, VisibilityInputs::default(), &[]),
             advanced: false,
+            reported_caps: caps,
+            known_uvc_paths: Vec::new(),
             caps,
             fp_present: false,
             fp_known: true,
@@ -9217,7 +10864,9 @@ mod tests {
             fp_coverage: Vec::new(),
             spin: 0,
             quit: false,
-        }
+        };
+        app.mark_fixture_observations_fresh(Instant::now());
+        app
     }
 
     /// A running-op placeholder whose worker never answers (the receiver stays
@@ -9946,6 +11595,7 @@ mod tests {
         // Biopolicy [b]: enabling (from off) is confirm-gated; the confirm's
         // affirmative names the specific verb and carries the enable suspend.
         app.screen = SC_SETTINGS;
+        app.preferences = Some(irlume_common::PreferencesState::observe());
         app.on_key(KeyCode::Char('b'));
         assert!(
             app.suspend.is_none(),
@@ -10531,7 +12181,7 @@ mod tests {
             reason: String::new(),
         });
         assert!(ok);
-        assert_eq!(msg, "alice · Face Profile 1 · confidence 0.812");
+        assert_eq!(msg, "alice · Face Profile 1 · match score 0.812");
         let (ok, msg) = map_identify(Response::Identified {
             user: None,
             profile: None,
@@ -10580,7 +12230,7 @@ mod tests {
             (false, true, true, "Fingerprint (secure), or Face (RGB)"),
             (false, true, false, "Face (RGB) · convenience"),
             (false, false, true, "Fingerprint"),
-            (false, false, false, "Password only"),
+            (false, false, false, "Password remains available"),
         ];
         for (ir_pair, rgb, fp, want) in cases {
             app.caps = irlume_camera::Caps { ir_pair, rgb };
@@ -10857,7 +12507,10 @@ mod tests {
         app.on_key(KeyCode::Char('e'));
         assert!(app.input.is_none(), "no name prompt without a camera");
         let (_, msg) = app.activity.last().expect("a guidance line is logged");
-        assert!(msg.contains("no camera"), "got: {msg}");
+        assert!(
+            msg.contains("current camera availability is unconfirmed"),
+            "got: {msg}"
+        );
         let before = app.activity.len();
         app.on_key(KeyCode::Char('i'));
         assert!(app.op.is_none(), "identify must not start without a camera");
@@ -11130,7 +12783,11 @@ mod tests {
 
     #[test]
     fn cameras_enter_switches_only_when_a_pair_exists() {
-        let mut app = test_app();
+        let mut app = live_test_app();
+        let mut snapshot = live_test_snapshot();
+        snapshot.cameras.candidates[0].endpoint_paths =
+            vec!["/dev/video0".into(), "/dev/video2".into()];
+        app.apply_live_snapshot(snapshot, app.now());
         app.screen = SC_CAMERAS;
         app.on_key(KeyCode::Enter);
         assert!(app.suspend.is_none());
@@ -11154,7 +12811,7 @@ mod tests {
         );
         let (_, _verb, act) = app.confirm.take().expect("confirm dialog armed");
         match act {
-            ConfirmAct::Sus(Suspend::SetCameras(ref r, ref i)) => {
+            ConfirmAct::Sus(Suspend::SetCameras(ref r, ref i, _)) => {
                 assert_eq!((r.as_str(), i.as_str()), ("/dev/video0", "/dev/video2"));
             }
             _ => panic!("confirm action must be SetCameras"),
@@ -11484,7 +13141,9 @@ mod tests {
         app.on_key(KeyCode::Enter);
         assert_eq!(
             app.op.as_ref().map(|o| o.label.as_str()),
-            Some("SealPassword")
+            Some(
+                "Connect Password Wallet: seal its secret with the TPM and update the wallet if needed"
+            )
         );
         wait_op_done(&mut app);
         assert!(app.error.is_some(), "a failed seal must surface");
@@ -11955,6 +13614,36 @@ mod tests {
         assert_eq!(stalls, 2, "misses below the limit render as stalls");
     }
 
+    #[test]
+    fn guide_unexpected_responses_do_not_copy_payloads_in_framing_or_countdown() {
+        for ready_samples in [0, GOOD_STREAK] {
+            let stop = AtomicBool::new(false);
+            let (tx, rx) = mpsc::channel();
+            let send = |m| tx.send(m).is_ok();
+            let mut remaining = ready_samples;
+            let mut sample = |_req: &Request| {
+                if remaining > 0 {
+                    remaining -= 1;
+                    Ok(Response::Position(good_report("hold still")))
+                } else {
+                    Ok(Response::Ok("synthetic-sensitive-payload".into()))
+                }
+            };
+            let outcome = guide_until_capture("synthetic-user", &stop, &send, &mut sample, &mut 0);
+            assert!(matches!(outcome, GuideOutcome::Halt));
+            drop(tx);
+            let error = rx
+                .into_iter()
+                .find_map(|m| match m {
+                    WMsg::Err(e) => Some(e),
+                    _ => None,
+                })
+                .expect("wrong reply must end the guide with an error");
+            assert!(!error.contains("synthetic-sensitive-payload"), "{error}");
+            assert!(error.contains("not confirmed"), "{error}");
+        }
+    }
+
     /// A guide that recovers goes back to live cues with no stall residue.
     #[test]
     fn cue_after_stall_clears_the_stall() {
@@ -11991,7 +13680,7 @@ mod tests {
         assert!(
             app.activity
                 .iter()
-                .any(|(_, m)| m.contains("enrollment cancelled")),
+                .any(|(_, m)| m.contains("enrollment cancellation requested")),
             "the cancel must be logged"
         );
         drain_loads(&mut app);
@@ -12001,7 +13690,8 @@ mod tests {
 
     #[test]
     fn overview_prioritizes_status_and_next_action() {
-        let mut app = test_app();
+        let mut app = live_test_app();
+        app.repair.clear();
         app.caps = irlume_camera::Caps {
             ir_pair: true,
             rgb: true,
@@ -12010,6 +13700,8 @@ mod tests {
         app.daemon_up = true;
         app.profiles = vec![profile("a", &["s1", "s2"])];
         app.profiles_loaded = true;
+        app.probes_landed = true;
+        app.probes.login_wired = true;
         let text = draw_text(&app);
         assert!(text.contains("Face unlock is ready"));
         assert!(text.contains("Status"));
@@ -12029,11 +13721,14 @@ mod tests {
             text.contains("Setup"),
             "the sidebar nav is missing:\n{text}"
         );
-        // No-camera tier: the recommendation flips to password-only.
+        // Unobserved hardware: keep the password fallback without asserting absence.
         let app2 = test_app();
         let text = draw_text(&app2);
         assert!(text.contains("Irlume needs attention"));
-        assert!(text.contains("Password only"), "got no fallback tier");
+        assert!(
+            text.contains("Password remains available"),
+            "got no fallback tier"
+        );
     }
 
     #[test]
@@ -12154,6 +13849,7 @@ mod tests {
         assert!(app.profiles_load.is_none(), "the landed load must clear");
         assert_eq!(app.profiles.len(), 1);
 
+        let last_success = app.freshness.observation(Source::Profiles).last_success;
         // A daemon-side error is STATE (corrupt enrollment): it lands on
         // enroll_error so Repair can flag it, exactly as the sync path did.
         let (tx, rx) = mpsc::channel();
@@ -12163,18 +13859,32 @@ mod tests {
         app.poll();
         assert_eq!(app.enroll_error.as_deref(), Some("corrupt"));
 
-        // A transport failure is NOT state: the loaded list stays, and the
-        // next refresh retries.
+        assert_eq!(
+            app.freshness.observation(Source::Profiles).last_success,
+            last_success
+        );
+        live_test_land_profiles(&mut app, vec![profile("Alice", &["s1"])]);
+        assert_eq!(app.profiles.len(), 1);
+        let last_success = app.freshness.observation(Source::Profiles).last_success;
+        // A transport failure is unavailable, never a successful empty list.
+        // Retain observation age and require a successful replacement.
         let (tx, rx) = mpsc::channel();
         app.profiles_load = Some(rx);
         tx.send(ProfilesOutcome::Transport("timeout".into()))
             .unwrap();
         app.poll();
         assert_eq!(
-            app.profiles.len(),
-            1,
-            "a failed refresh must not clear the list"
+            app.freshness.observation(Source::Profiles).last_success,
+            last_success
         );
+        assert!(app.profiles.is_empty());
+        assert!(!app.profiles_loaded && !app.source_usable(Source::Profiles));
+        assert!(app
+            .source_status(Source::Profiles)
+            .contains("last successful check"));
+        live_test_land_profiles(&mut app, vec![profile("Alice", &["s1"])]);
+        assert_eq!(app.profiles.len(), 1);
+        assert!(app.source_usable(Source::Profiles));
     }
 
     #[test]
@@ -12195,6 +13905,7 @@ mod tests {
         assert!(app.profiles_loaded);
         assert!(app.profiles_load.is_none());
         app.apply_light(LightState {
+            observed_at: [Some(Instant::now()); 4],
             daemon_up: true,
             reach: crate::commands::DaemonReach::Running,
             health: None,
@@ -12303,16 +14014,31 @@ mod tests {
         assert!(app.heavy_load.is_none());
         assert!(app.heavy_known);
         assert!(matches!(app.heavy, Some(crate::bitwarden::TuiState::Ready)));
+        let last_success = app.freshness.observation(Source::Apps).last_success;
         app.refresh_heavy_with(|| Err(std::io::ErrorKind::TimedOut.into()));
         while app.heavy_load.is_some() && std::time::Instant::now() < deadline {
             app.poll();
             std::thread::sleep(Duration::from_millis(5));
         }
         assert!(app.heavy_load.is_none());
-        assert!(
-            matches!(app.heavy, Some(crate::bitwarden::TuiState::Ready)),
-            "failed refresh must preserve the last observation"
+        assert!(app.heavy.is_none() && !app.heavy_known);
+        assert!(!app.source_usable(Source::Apps));
+        assert_eq!(
+            app.freshness.observation(Source::Apps).last_success,
+            last_success
         );
+        assert!(app
+            .source_status(Source::Apps)
+            .contains("last successful check"));
+        app.refresh_heavy_with(|| Ok(Some(crate::bitwarden::TuiState::Ready)));
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while app.heavy_load.is_some() && Instant::now() < deadline {
+            app.poll();
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        assert!(app.heavy_load.is_none());
+        assert!(app.source_usable(Source::Apps));
+        assert!(matches!(app.heavy, Some(crate::bitwarden::TuiState::Ready)));
     }
 
     #[test]
@@ -12324,6 +14050,7 @@ mod tests {
         app.keyring_drift = Some(true);
         app.keyring_checked_at = Some(std::time::Instant::now());
         app.apply_light(LightState {
+            observed_at: [Some(Instant::now()); 4],
             daemon_up: true,
             reach: crate::commands::DaemonReach::Running,
             health: None,
@@ -12487,7 +14214,7 @@ mod tests {
         app.screen = SC_KEYRING;
         // Daemon unreachable: unknown, never a fake "not armed".
         let text = draw_text(&app);
-        assert!(text.contains("unknown (daemon unreachable)"));
+        assert!(text.contains("unknown (observation unavailable)"));
         // Not armed on a fingerprint box: names the fingerprint trigger.
         app.keyring_armed = Some(false);
         app.fp_present = true;
@@ -12514,8 +14241,11 @@ mod tests {
             "Tier 2 offers the [p] pcrlock-refresh action, not the re-arm warning"
         );
         assert!(text.contains("At a face login"));
-        // Armed on the plain PCR-7 tier: the dbx re-arm warning instead.
+        // Missing policy is unavailable, never an invented PCR-7 binding.
         app.keyring_policy = None;
+        assert!(draw_text(&app).contains("policy unreported by daemon"));
+        // Explicit observed PCR-7 binding retains its warning.
+        app.keyring_policy = Some("PCR-7 (Secure Boot state)".into());
         app.keyring_drift = None;
         let text = draw_text(&app);
         assert!(text.contains("PCR-7 (Secure Boot state)"));
@@ -12594,12 +14324,12 @@ mod tests {
         app.screen = SC_IDENTIFY;
         let text = draw_text(&app);
         assert!(text.contains("press [i] and look at the camera"));
-        app.identify_result = Some((true, "alice · Face Profile 1 · confidence 0.912".into()));
+        app.identify_result = Some((true, "alice · Face Profile 1 · match score 0.912".into()));
         let text = draw_text(&app);
-        assert!(text.contains("alice · Face Profile 1 · confidence 0.912"));
+        assert!(text.contains("alice · Face Profile 1 · match score 0.912"));
         assert!(
-            text.contains("✓ Recognized") && text.contains("confidence is 0.00-1.00"),
-            "the hit shows a plain verdict + the confidence scale"
+            text.contains("✓ Recognized") && text.contains("not a login or a probability estimate"),
+            "the hit shows a verdict without presenting similarity as a probability"
         );
         app.identify_result = Some((false, "no live face (flat depth)".into()));
         let text = draw_text(&app);
@@ -12654,13 +14384,16 @@ mod tests {
         // because an unanswered listing is not an observation (#187).
         let text = draw_text(&app);
         assert!(!text.contains("no camera found"), "{text}");
-        assert!(text.contains("camera list is unknown"), "{text}");
+        assert!(
+            text.contains("Current camera inventory unavailable"),
+            "{text}"
+        );
         // The ACTIVE line has the same rule: with health unanswered it used
         // to default the paths to "" and assert "no camera hardware" from
         // Path::new("").exists(), contradicting the list line above it.
         assert!(!text.contains("no camera hardware"), "{text}");
-        assert!(text.contains("unknown (daemon not answering"), "{text}");
-        // The daemon answered but named no devices: now none IS the fact.
+        assert!(text.contains("unknown (observation unavailable"), "{text}");
+        // The daemon answered but named no devices; scope absence to its report.
         app.health = Some(HealthInfo {
             tier: "none".into(),
             rgb_dev: None,
@@ -12673,18 +14406,35 @@ mod tests {
             apparmor: None,
         });
         let text = draw_text(&app);
-        assert!(text.contains("no camera hardware"), "{text}");
+        assert!(text.contains("no camera reported by daemon"), "{text}");
         app.health = None;
-        // The daemon ANSWERED with an empty list: now "none" is a fact.
-        app.pairs_known = true;
+        // An observed empty UVC snapshot scopes absence to this backend.
+        let mut snapshot = live_test_snapshot();
+        snapshot.cameras.candidates.clear();
+        app.apply_live_snapshot(snapshot, app.now());
+        assert_eq!(app.screen, SC_CAMERAS, "inventory changes stay on Cameras");
         let text = draw_text(&app);
-        assert!(text.contains("no paired RGB+IR camera found"), "{text}");
-        // RGB node only: convenience tier, and why Secure needs IR.
-        app.nodes = vec![("/dev/video9".into(), irlume_camera::Role::Rgb)];
+        assert!(text.contains("No UVC candidates"), "{text}");
+        // Newly attached endpoints are visible before roles are inspected.
+        let mut snapshot = live_test_snapshot();
+        snapshot.cameras.revision = 2;
+        snapshot.cameras.candidates[0].endpoint_paths = vec!["/dev/video9".into()];
+        app.apply_live_snapshot(snapshot, app.now());
+        assert_eq!(app.screen, SC_CAMERAS, "inventory changes stay on Cameras");
         let text = draw_text(&app);
         assert!(text.contains("video9"));
-        assert!(text.contains("RGB-only, convenience tier"));
-        assert!(text.contains("no IR node"));
+        assert!(text.contains("Attached; inspect roles"));
+        assert!(!text.contains("no IR node"));
+        let mut snapshot = live_test_snapshot();
+        snapshot.cameras.revision = 3;
+        snapshot.cameras.candidates[0].endpoint_paths =
+            vec!["/dev/video0".into(), "/dev/video2".into()];
+        app.apply_live_snapshot(snapshot, app.now());
+        assert_eq!(app.screen, SC_CAMERAS, "inventory changes stay on Cameras");
+        let now = app.now();
+        app.freshness
+            .observation_mut(Source::Cameras)
+            .record(true, now);
         // A real Hello pair renders its nodes, kind, and USB id.
         app.pairs = vec![irlume_common::CameraPairInfo {
             rgb: "/dev/video0".into(),
@@ -12708,7 +14458,7 @@ mod tests {
         let text = draw_text(&app);
         assert!(text.contains("PAM services"));
         assert!(
-            text.contains("tier unknown (daemon unreachable)"),
+            text.contains("tier unknown (observation unavailable)"),
             "no tier claim without the daemon"
         );
         // The aligned action list retains its current head-gated actions.
@@ -12771,14 +14521,22 @@ mod tests {
         let text = draw_text(&app);
         assert!(text.contains("Setup dashboard"));
         assert!(
-            text.contains("Daemon not running; see Diagnostics"),
-            "a down daemon is the first thing Done must flag"
+            text.contains("Current daemon readiness unavailable"),
+            "unobserved readiness must be explicit"
         );
+        app.apply_live_snapshot(live_test_snapshot(), app.now());
+        app.screen = SC_DONE;
         app.daemon_up = true;
         app.caps = irlume_camera::Caps {
             ir_pair: false,
             rgb: true,
         };
+        assert!(draw_text(&app).contains("enrollment observation unavailable"));
+        app.profiles_loaded = true; // explicitly observed empty enrollment
+        let now = app.now();
+        app.freshness
+            .observation_mut(Source::Profiles)
+            .record(true, now);
         let text = draw_text(&app);
         assert!(
             text.contains("enroll a face (Overview [e])"),
@@ -12789,7 +14547,7 @@ mod tests {
             rgb: false,
         };
         let text = draw_text(&app);
-        assert!(text.contains("No face hardware"));
+        assert!(text.contains("Face hardware availability is unconfirmed"));
     }
 
     #[test]
@@ -12866,7 +14624,7 @@ mod tests {
         let text = draw_text(&app);
         assert!(text.contains("⚠ Problem"));
         assert!(text.contains("camera busy"));
-        assert!(text.contains("[any key] dismiss"));
+        assert!(text.contains("[Esc] dismiss · arrows scroll"));
         assert!(
             !text.contains("New profile name"),
             "the error modal must take precedence over the input prompt"
@@ -12935,7 +14693,7 @@ mod tests {
         let cases: [(usize, &str, &str); 11] = [
             (SC_WELCOME, "Enroll Face", "Uninstall"),
             (SC_REPAIR, "Fix Selected Issue", "Toggle Debug Logs"),
-            (SC_CAMERAS, "Use Selected Pair", "List Units"),
+            (SC_CAMERAS, "Inspect Candidates", "Use Selected Pair"),
             (SC_PROFILES, "Enroll Face", "Delete"),
             (SC_IDENTIFY, "Test Recognition", "Test Recognition"),
             (SC_KEYRING, "Connect Wallet", "Forget"),
@@ -12952,6 +14710,12 @@ mod tests {
                 "[?] overlay for screen {screen} misses '{in_overlay}':\n{}",
                 app.help_body()
             );
+            if screen == SC_CAMERAS {
+                assert!(
+                    app.help_body().contains("List Units"),
+                    "camera help retains unit inspection"
+                );
+            }
             let needle = primary;
             let text = footer(&app);
             assert!(
@@ -13002,6 +14766,361 @@ mod tests {
         app.op = Some(op);
         let text = panel(&app);
         assert!(text.contains("Identify"));
+    }
+
+    #[test]
+    fn activity_latest_result_survives_wrapped_predecessors() {
+        let mut app = test_app();
+        for _ in 0..4 {
+            app.log('·', "a detailed message ".repeat(30));
+        }
+        app.log('✓', "FINAL_RESULT_SENTINEL");
+        let mut term = Terminal::new(TestBackend::new(60, 7)).unwrap();
+        term.draw(|f| app.draw_activity(f, f.area())).unwrap();
+        assert!(rendered(&term).contains("FINAL_RESULT_SENTINEL"));
+    }
+
+    #[test]
+    fn activity_eviction_keeps_a_retained_reading_anchor() {
+        let mut app = test_app();
+        for i in 0..200 {
+            app.log('·', format!("entry-{i}"));
+        }
+        app.act_scroll = 5;
+        app.log('·', "new entry");
+        let mut term = Terminal::new(TestBackend::new(80, 7)).unwrap();
+        term.draw(|f| app.draw_activity(f, f.area())).unwrap();
+        let text = rendered(&term);
+        assert!(
+            text.contains("entry-190"),
+            "retained first row shifted: {text}"
+        );
+        assert!(
+            !text.contains("entry-195"),
+            "newer row displaced the anchor: {text}"
+        );
+    }
+
+    #[test]
+    fn activity_full_history_reaches_a_long_entry_tail_without_running_an_action() {
+        let mut app = test_app();
+        app.log(
+            '·',
+            format!("{}HISTORY_TAIL_SENTINEL", "detail line\n".repeat(60)),
+        );
+        app.on_key(KeyCode::Char('L'));
+        let mut term = Terminal::new(TestBackend::new(80, 24)).unwrap();
+        term.draw(|f| app.draw(f)).unwrap();
+        app.on_key(KeyCode::End);
+        term.draw(|f| app.draw(f)).unwrap();
+        let text = rendered(&term);
+        assert!(
+            text.contains("HISTORY_TAIL_SENTINEL"),
+            "tail inaccessible: {text}"
+        );
+        assert!(
+            text.contains("This TUI session"),
+            "history scope missing: {text}"
+        );
+        assert!(app.op.is_none() && app.enroll.is_none() && app.suspend.is_none());
+        app.on_key(KeyCode::Esc);
+        assert!(!app.quit, "closing history must not exit the TUI");
+    }
+
+    #[test]
+    fn activity_summary_has_elapsed_time_and_textual_status() {
+        let mut app = test_app();
+        app.log('✗', "request was refused");
+        let mut term = Terminal::new(TestBackend::new(100, 3)).unwrap();
+        term.draw(|f| app.draw_activity(f, f.area())).unwrap();
+        let text = rendered(&term);
+        assert!(text.contains("00:00"), "elapsed timestamp missing: {text}");
+        assert!(text.contains("Failed"), "textual status missing: {text}");
+    }
+
+    #[test]
+    fn activity_history_keeps_detail_space_in_a_small_terminal() {
+        let mut app = test_app();
+        app.log('·', "SMALL_TAIL");
+        app.on_key(KeyCode::Char('L'));
+        let mut term = Terminal::new(TestBackend::new(30, 16)).unwrap();
+        term.draw(|f| app.draw(f)).unwrap();
+        assert!(rendered(&term).contains("SMALL_TAIL"));
+    }
+
+    #[test]
+    fn minimum_window_notice_hides_pages_and_overlays_and_restores_them() {
+        for (width, height) in [(40, 12), (79, 24), (80, 23)] {
+            for screen in 0..SCREENS.len() {
+                for overlay in 0..7 {
+                    let mut app = test_app();
+                    app.screen = screen;
+                    match overlay {
+                        1 => app.error = Some("HIDDEN_ERROR_SENTINEL".into()),
+                        2 => {
+                            app.input = Some((
+                                "HIDDEN_INPUT_SENTINEL".into(),
+                                "private input".into(),
+                                Pending::RecoveryPw(None),
+                            ))
+                        }
+                        3 => {
+                            app.confirm = Some((
+                                "HIDDEN_CONFIRM_SENTINEL".into(),
+                                "View",
+                                ConfirmAct::Sus(Suspend::Logs),
+                            ))
+                        }
+                        4 => app.activity_history_open = true,
+                        5 => app.show_help = true,
+                        6 => app.show_live = true,
+                        _ => {}
+                    }
+                    let mut small = Terminal::new(TestBackend::new(width, height)).unwrap();
+                    small.draw(|f| app.draw_window(f)).unwrap();
+                    let text = rendered(&small);
+                    assert!(text.contains("Window too small"));
+                    assert!(text.contains("Minimum: 80 × 24"));
+                    assert!(text.contains(&format!("Current: {width} × {height}")));
+                    assert!(!text.contains("HIDDEN_") && !text.contains("private input"));
+                    assert!(
+                        !text.contains("Session history") && !text.contains("Current observations")
+                    );
+                    assert!(app.click_targets.borrow().is_empty());
+                    assert_eq!(app.screen, screen);
+                    let mut normal = Terminal::new(TestBackend::new(80, 24)).unwrap();
+                    normal.draw(|f| app.draw_window(f)).unwrap();
+                    assert!(!rendered(&normal).contains("Window too small"));
+                    assert_eq!(app.screen, screen);
+                    assert_eq!(app.error.is_some(), overlay == 1);
+                    assert_eq!(app.input.is_some(), overlay == 2);
+                    assert_eq!(app.confirm.is_some(), overlay == 3);
+                    assert_eq!(app.activity_history_open, overlay == 4);
+                }
+            }
+        }
+        for (width, height) in [(0, 0), (1, 1), (5, 2)] {
+            let app = test_app();
+            let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+            terminal.draw(|f| app.draw_window(f)).unwrap();
+            assert!(app.click_targets.borrow().is_empty());
+        }
+    }
+
+    #[test]
+    fn minimum_window_resize_race_blocks_hidden_keyboard_and_mouse_controls() {
+        use ratatui::crossterm::event::{
+            KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
+        };
+        let mut app = test_app();
+        app.confirm = Some((
+            "Visible approval".into(),
+            "View",
+            ConfirmAct::Sus(Suspend::Logs),
+        ));
+        let normal = Rect::new(0, 0, 80, 24);
+        let small = Rect::new(0, 0, 79, 24);
+        let mut terminal = Terminal::new(TestBackend::new(80, 24)).unwrap();
+        terminal.draw(|f| app.draw_window(f)).unwrap();
+        let affirmative = app
+            .click_targets
+            .borrow()
+            .iter()
+            .find_map(|(rect, click)| {
+                matches!(click, Click::DialogKey(KeyCode::Char('y'))).then_some(*rect)
+            })
+            .expect("visible affirmative control");
+        let key = || Event::Key(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE));
+        app.on_window_event(key(), small);
+        app.on_window_event(
+            Event::Mouse(MouseEvent {
+                kind: MouseEventKind::Down(MouseButton::Left),
+                column: affirmative.x,
+                row: affirmative.y,
+                modifiers: KeyModifiers::NONE,
+            }),
+            small,
+        );
+        assert!(app.confirm.is_some() && app.suspend.is_none());
+        let mut undersized = Terminal::new(TestBackend::new(79, 24)).unwrap();
+        undersized.draw(|f| app.draw_window(f)).unwrap();
+        // Growing back cannot activate a dialog before it has been redrawn.
+        app.on_window_event(key(), normal);
+        assert!(app.confirm.is_some() && app.suspend.is_none());
+        terminal.draw(|f| app.draw_window(f)).unwrap();
+        app.on_window_event(
+            Event::Key(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::CONTROL)),
+            normal,
+        );
+        let mut released = KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE);
+        released.kind = KeyEventKind::Release;
+        app.on_window_event(Event::Key(released), normal);
+        assert!(app.confirm.is_some() && app.suspend.is_none());
+        app.on_window_event(key(), normal);
+        assert!(app.confirm.is_none() && matches!(app.suspend, Some(Suspend::Logs)));
+
+        let mut input = test_app();
+        input.input = Some((
+            "Input".into(),
+            "unchanged".into(),
+            Pending::RecoveryPw(None),
+        ));
+        input.page_view.set((SC_SETTINGS, normal, 3, 20));
+        input.act_scroll = 2;
+        undersized.draw(|f| input.draw_window(f)).unwrap();
+        input.on_window_event(
+            Event::Key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE)),
+            small,
+        );
+        input.on_window_event(
+            Event::Mouse(MouseEvent {
+                kind: MouseEventKind::ScrollDown,
+                column: 4,
+                row: 8,
+                modifiers: KeyModifiers::NONE,
+            }),
+            small,
+        );
+        assert_eq!(input.input.as_ref().unwrap().1, "unchanged");
+        assert_eq!(input.page_view.get().2, 3);
+        assert_eq!(input.act_scroll, 2);
+        assert!(input.op.is_none() && input.suspend.is_none());
+    }
+
+    #[test]
+    fn minimum_window_allows_safe_exit_and_enrollment_cancellation_only() {
+        use ratatui::crossterm::event::{KeyEvent, KeyModifiers};
+        let small = Rect::new(0, 0, 40, 12);
+        let mut app = test_app();
+        let (_sender, enrollment) = fake_enroll(0, 4);
+        let stop = enrollment.stop.clone();
+        app.enroll = Some(enrollment);
+        let mut terminal = Terminal::new(TestBackend::new(40, 12)).unwrap();
+        terminal.draw(|f| app.draw_window(f)).unwrap();
+        assert!(
+            !stop.load(Ordering::Relaxed),
+            "resizing must not cancel enrollment"
+        );
+        for code in [
+            KeyCode::Enter,
+            KeyCode::Char('y'),
+            KeyCode::Char('e'),
+            KeyCode::F(4),
+            KeyCode::Tab,
+        ] {
+            app.on_window_event(Event::Key(KeyEvent::new(code, KeyModifiers::NONE)), small);
+        }
+        assert!(app.enroll.is_some() && !app.quit && app.suspend.is_none());
+        assert!(!stop.load(Ordering::Relaxed));
+        app.on_window_event(
+            Event::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)),
+            small,
+        );
+        assert!(stop.load(Ordering::Relaxed) && app.enroll.is_some() && !app.quit);
+        // Keep the worker handle for the actual completion/unknown-outcome path.
+        app.on_window_event(
+            Event::Key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE)),
+            small,
+        );
+        assert!(app.quit && stop.load(Ordering::Relaxed));
+
+        let mut direct_quit = test_app();
+        let (_sender, enrollment) = fake_enroll(0, 4);
+        let direct_stop = enrollment.stop.clone();
+        direct_quit.enroll = Some(enrollment);
+        assert!(!direct_stop.load(Ordering::Relaxed));
+        direct_quit.on_window_event(
+            Event::Key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE)),
+            small,
+        );
+        assert!(direct_quit.quit && direct_stop.load(Ordering::Relaxed));
+
+        let mut general = test_app();
+        let (_sender, op) = fake_op();
+        general.op = Some(op);
+        terminal.draw(|f| general.draw_window(f)).unwrap();
+        general.on_window_event(
+            Event::Key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE)),
+            small,
+        );
+        assert!(general.quit && general.op.is_some());
+    }
+
+    #[test]
+    fn activity_history_buttons_have_visible_noninteractive_gaps() {
+        for width in [30, 40, 80] {
+            let mut app = test_app();
+            app.log('·', "history detail");
+            app.on_key(KeyCode::Char('L'));
+            let mut term = Terminal::new(TestBackend::new(width, 12)).unwrap();
+            term.draw(|f| app.draw(f)).unwrap();
+            let controls: Vec<_> = app
+                .click_targets
+                .borrow()
+                .iter()
+                .filter_map(|(rect, click)| match click {
+                    Click::DialogKey(key @ (KeyCode::Esc | KeyCode::Home | KeyCode::End)) => {
+                        Some((*rect, *key))
+                    }
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(controls.len(), 3);
+            for pair in controls.windows(2) {
+                let gap = pair[0].0.right();
+                assert!(gap < pair[1].0.x, "buttons touch at width {width}");
+                assert_eq!(term.backend().buffer()[(gap, pair[0].0.y)].symbol(), " ");
+                app.on_click(gap, pair[0].0.y, Rect::new(0, 0, width, 12));
+                assert!(app.activity_history_open && !app.quit);
+            }
+            let row: String = (0..width)
+                .map(|x| term.backend().buffer()[(x, controls[0].0.y)].symbol())
+                .collect();
+            assert!(row.contains("[Esc"), "close shortcut missing: {row}");
+            assert!(row.contains("[Home]"), "first shortcut missing: {row}");
+            assert!(row.contains("[End]"), "last shortcut missing: {row}");
+            let (close, _) = controls[0];
+            app.on_click(close.x, close.y, Rect::new(0, 0, width, 12));
+            assert!(!app.activity_history_open && !app.quit);
+        }
+    }
+
+    #[test]
+    fn activity_full_history_title_button_opens_its_advertised_view() {
+        let mut app = test_app();
+        let mut term = Terminal::new(TestBackend::new(100, 7)).unwrap();
+        term.draw(|f| app.draw_activity(f, f.area())).unwrap();
+        let row = &term.backend().buffer().content[..100];
+        let x = row
+            .windows(3)
+            .position(|cells| {
+                cells[0].symbol() == "[" && cells[1].symbol() == "L" && cells[2].symbol() == "]"
+            })
+            .expect("full history button is visible") as u16;
+        app.on_click(x + 1, 0, Rect::new(0, 0, 100, 7));
+        assert!(
+            app.activity_history_open,
+            "button must not merely toggle the compact strip"
+        );
+    }
+
+    #[test]
+    fn activity_history_does_not_dismiss_an_arriving_error_or_cancel_an_operation() {
+        let mut app = test_app();
+        let (_tx, op) = fake_op();
+        app.op = Some(op);
+        app.on_key(KeyCode::Char('L'));
+        app.error = Some("ATTENTION_SENTINEL".into());
+        let mut term = Terminal::new(TestBackend::new(80, 24)).unwrap();
+        term.draw(|f| app.draw(f)).unwrap();
+        assert!(rendered(&term).contains("ATTENTION_SENTINEL"));
+        app.on_key(KeyCode::Esc);
+        assert!(app.error.is_none());
+        assert!(app.activity_history_open);
+        app.on_key(KeyCode::Esc);
+        assert!(!app.activity_history_open);
+        assert!(app.op.is_some());
+        assert!(!app.quit);
     }
 
     // ---- log ring, scroll bounds, status poll ------------------------------
@@ -13055,12 +15174,13 @@ mod tests {
     }
 
     #[test]
-    fn refresh_light_clamps_selections_to_the_shrunken_lists() {
+    fn refresh_light_cannot_retarget_selections_in_shrunken_lists() {
         let mut app = test_app();
         app.profiles = vec![profile("a", &["s1"])]; // 2 rows
         app.sel = 9;
         app.cam_sel = 9;
         app.apply_light(LightState {
+            observed_at: [Some(Instant::now()); 4],
             daemon_up: false,
             reach: crate::commands::DaemonReach::Down,
             health: None,
@@ -13070,11 +15190,16 @@ mod tests {
             keyring_kind: None,
             recovery: None,
         });
-        assert_eq!(app.sel, 1, "sel must clamp to the last real row");
-        assert!(
-            app.cam_sel < app.pairs.len().max(1),
-            "cam_sel must clamp to the discovered pairs"
+        assert_eq!(
+            app.sel, 9,
+            "a status reply cannot choose another profile row"
         );
+        assert!(app.selected_profile_row().is_none());
+        assert_eq!(
+            app.cam_sel, 9,
+            "a status reply cannot choose another camera"
+        );
+        assert!(app.pairs.get(app.cam_sel).is_none());
         assert!(!app.daemon_up);
         assert!(app.health.is_none());
     }
@@ -13120,8 +15245,8 @@ mod tests {
         assert!(pad.sev == Sev::Ok);
         assert!(pad.detail.contains("RGB loaded + IR loaded"));
         let cams = find("Cameras");
-        assert!(cams.sev == Sev::Ok);
-        assert!(cams.detail.contains("secure tier"));
+        assert!(cams.sev == Sev::Unknown);
+        assert!(cams.detail.contains("current camera presence unconfirmed"));
         // Repair no longer carries an emitter row. It never measured the
         // emitter: it was unconditionally a warning whenever an IR node
         // existed, so it cried wolf on every working machine and pointed its
@@ -13139,6 +15264,17 @@ mod tests {
         let enroll = find("Enrollment");
         assert!(enroll.sev == Sev::Warn, "no profiles yet is a warning");
         assert!(enroll.detail.contains("no face enrolled yet"));
+        let mut snapshot = live_test_snapshot();
+        snapshot.cameras.candidates[0].endpoint_paths =
+            vec!["/dev/video0".into(), "/dev/video2".into()];
+        app.apply_live_snapshot(snapshot, app.now());
+        let cameras = app
+            .repair
+            .iter()
+            .find(|check| check.label == "Cameras")
+            .unwrap();
+        assert!(cameras.sev == Sev::Ok);
+        assert!(cameras.detail.contains("engine configured secure"));
     }
 
     #[test]
@@ -13156,6 +15292,10 @@ mod tests {
             version: "0.0.1-old".into(),
             apparmor: None,
         });
+        let mut snapshot = live_test_snapshot();
+        snapshot.cameras.candidates[0].endpoint_paths =
+            vec!["/dev/video0".into(), "/dev/video2".into()];
+        app.apply_live_snapshot(snapshot, app.now());
         app.enroll_error = Some("bad ciphertext".into());
         app.run_checks();
         let find = |label: &str| {
@@ -13563,7 +15703,10 @@ mod tests {
         assert!(!text.contains("plaintext at rest"), "{text}");
         assert!(!text.contains("No TPM on this host"), "{text}");
         assert!(!text.contains("○ not set"), "{text}");
-        assert!(text.contains("◐ unknown (daemon unreachable)"), "{text}");
+        assert!(
+            text.contains("◐ unknown (observation unavailable)"),
+            "{text}"
+        );
     }
 
     #[test]
@@ -13649,7 +15792,7 @@ mod tests {
         let text = draw_text(&app);
         assert!(!text.contains("literal PCR-7"), "{text}");
         assert!(
-            row_with(&text, "PCR policy").contains("unknown (daemon unreachable)"),
+            row_with(&text, "PCR policy").contains("unknown (observation unavailable)"),
             "{text}"
         );
         // The daemon's KeyringInfo names the rung: show it verbatim, exactly
@@ -13691,7 +15834,7 @@ mod tests {
         // The pre-KeyringInfo default described a binding nobody read.
         assert!(!text.contains("PCR-7 (Secure Boot state)"), "{text}");
         assert!(
-            row_with(&text, "binding").contains("unknown (daemon unreachable)"),
+            row_with(&text, "binding").contains("unknown (observation unavailable)"),
             "{text}"
         );
         // And no armed-state consequence line off an unanswered question.
@@ -13743,6 +15886,7 @@ mod tests {
         let old = std::env::var_os("IRLUME_ENFORCE_BIOPOLICY");
         std::env::set_var("IRLUME_ENFORCE_BIOPOLICY", "yes");
         let mut app = test_app();
+        app.preferences = Some(irlume_common::PreferencesState::observe());
         app.screen = SC_DONE;
         let text = draw_text(&app);
         match old {
@@ -13753,7 +15897,7 @@ mod tests {
     }
 
     #[test]
-    fn settings_sensor_policy_is_explicitly_local_experimental_and_read_only() {
+    fn settings_sensor_policy_displays_observed_experimental_policy_without_writing() {
         let _guard = dead_socket();
         let old_cfg = std::env::var_os("IRLUME_CONFIG_DIR");
         let dir = std::env::temp_dir().join(format!("irlume-tui-sensor-{}", std::process::id()));
@@ -13762,11 +15906,11 @@ mod tests {
         let original = "face_sensor_policy=ir-only-experimental\n";
         std::fs::write(dir.join("settings.conf"), original).unwrap();
         let mut app = test_app();
+        app.preferences = Some(irlume_common::PreferencesState::observe());
         app.screen = SC_SETTINGS;
         let text = draw_text(&app);
         assert!(
-            text.contains("local observation; daemon preferences unavailable")
-                && text.contains("EXPERIMENTAL IR-only"),
+            text.contains("daemon observed") && text.contains("EXPERIMENTAL IR-only"),
             "{text}"
         );
         assert!(text.contains("not qualified"), "{text}");
@@ -13794,6 +15938,7 @@ mod tests {
         std::fs::write(dir.join("settings.conf"), "privileged_face_consent=1\n").unwrap();
         let mut app = test_app();
         app.screen = SC_SETTINGS;
+        app.preferences = Some(irlume_common::PreferencesState::observe());
         app.on_key(KeyCode::Char('p'));
         assert!(
             app.confirm.is_some() && app.suspend.is_none(),
@@ -13805,6 +15950,7 @@ mod tests {
             std::fs::read_to_string(dir.join("settings.conf")).unwrap(),
             "privileged_face_consent=1\n"
         );
+        app.preferences = Some(irlume_common::PreferencesState::observe());
         app.on_key(KeyCode::Char('p'));
         app.on_key(KeyCode::Char('y'));
         assert!(
@@ -13813,6 +15959,7 @@ mod tests {
         );
         app.suspend = None;
         std::fs::write(dir.join("settings.conf"), "privileged_face_consent=0\n").unwrap();
+        app.preferences = Some(irlume_common::PreferencesState::observe());
         app.on_key(KeyCode::Char('p'));
         assert!(
             app.confirm.is_none() && matches!(app.suspend, Some(Suspend::PrivilegedConsent(true))),
@@ -13821,6 +15968,7 @@ mod tests {
         app.suspend = None;
         std::fs::remove_file(dir.join("settings.conf")).unwrap();
         std::fs::create_dir(dir.join("settings.conf")).unwrap();
+        app.preferences = Some(irlume_common::PreferencesState::observe());
         app.on_key(KeyCode::Char('p'));
         assert!(
             app.confirm.is_none() && app.suspend.is_none(),
@@ -13845,6 +15993,7 @@ mod tests {
         for (v, expected) in [("0", "hands-free"), ("1", "required"), ("typo", "required")] {
             std::env::set_var("IRLUME_PRIVILEGED_FACE_CONSENT", v);
             let mut app = test_app();
+            app.preferences = Some(irlume_common::PreferencesState::observe());
             app.screen = SC_SETTINGS;
             let text = draw_text(&app);
             assert!(
@@ -13853,8 +16002,8 @@ mod tests {
             );
             assert!(text.contains("environment override"), "{text}");
             assert!(
-                !text.contains("Daemon environment override"),
-                "local fallback must not claim a daemon observation: {text}"
+                text.contains("Daemon environment override"),
+                "an explicitly landed observer result identifies the daemon override: {text}"
             );
             app.on_key(KeyCode::Char('p'));
             assert!(app.suspend.is_none() && app.confirm.is_none());
@@ -13863,6 +16012,416 @@ mod tests {
             Some(v) => std::env::set_var("IRLUME_PRIVILEGED_FACE_CONSENT", v),
             None => std::env::remove_var("IRLUME_PRIVILEGED_FACE_CONSENT"),
         }
+    }
+
+    #[test]
+    fn interface_preferences_state_text_uses_semantic_colors() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let monochrome = std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty());
+        for (observed, label, color) in [
+            (Some(true), "ON", Color::Green),
+            (Some(false), "OFF", Color::Reset),
+            (None, "UNKNOWN", Color::Yellow),
+        ] {
+            let mut app = test_app();
+            let mut state = preference_fixture(observed.unwrap_or(false));
+            state.privileged_face_consent = observed.map(|on| !on);
+            state.enforce_biopolicy = observed;
+            if observed.is_none() {
+                state.face_sensor_policy =
+                    irlume_common::config::FaceSensorPolicyObservation::Unreadable;
+            }
+            app.preferences = Some(state);
+            let mut term = Terminal::new(TestBackend::new(120, 60)).unwrap();
+            term.draw(|f| app.draw_settings(f, f.area())).unwrap();
+            let text = rendered(&term);
+            for row_label in ["IR-only:", "Hands-free:", "  state  "] {
+                let (y, line) = text
+                    .lines()
+                    .enumerate()
+                    .find(|(_, l)| l.contains(row_label))
+                    .unwrap();
+                let byte = line.find(label).unwrap();
+                let x = line[..byte].chars().count() as u16;
+                let cell = &term.backend().buffer()[(x, y as u16)];
+                let expected = if monochrome { Color::Reset } else { color };
+                assert_eq!(
+                    cell.fg, expected,
+                    "{row_label} {label} must color the state text"
+                );
+                assert!(
+                    cell.modifier.contains(Modifier::BOLD),
+                    "state text must stay legible without color"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn interface_chrome_keeps_terminal_default_background_and_no_black_text() {
+        let mut app = test_app();
+        app.caps.rgb = true;
+        app.profiles_loaded = true;
+        let mut term = Terminal::new(TestBackend::new(120, 40)).unwrap();
+        term.draw(|f| app.draw(f)).unwrap();
+        for cell in &term.backend().buffer().content {
+            assert_ne!(
+                cell.fg,
+                Color::Black,
+                "chrome must not assume a dark or light background"
+            );
+            assert_eq!(cell.bg, Color::Reset, "the terminal owns the background");
+        }
+    }
+
+    #[test]
+    fn interface_keyboard_focus_reaches_last_wrapped_page_action() {
+        let mut app = test_app();
+        app.screen = SC_PAM;
+        let mut term = Terminal::new(TestBackend::new(40, 16)).unwrap();
+        term.draw(|f| app.draw(f)).unwrap();
+        app.on_key(KeyCode::F(6));
+        for _ in 1..app.screen_actions().len() {
+            app.on_key(KeyCode::Down);
+        }
+        term.draw(|f| app.draw(f)).unwrap();
+        let text = rendered(&term);
+        assert!(
+            text.contains("Show full status"),
+            "focused action must scroll into view: {text}"
+        );
+        assert!(!app.activity_open);
+        app.on_key(KeyCode::Enter);
+        assert!(matches!(app.suspend, Some(Suspend::LoginStatus)));
+    }
+
+    #[test]
+    fn interface_focused_toggle_keeps_its_confirmation() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let mut app = test_app();
+        app.screen = SC_SETTINGS;
+        app.preferences = Some(preference_fixture(false));
+        let _ = draw_text(&app);
+        app.on_key(KeyCode::F(6));
+        app.on_key(KeyCode::Char(' '));
+        assert!(app.suspend.is_none());
+        assert!(app
+            .confirm
+            .as_ref()
+            .is_some_and(|c| c.0.contains("not qualified")));
+        app.on_key(KeyCode::Esc);
+        assert!(app.confirm.is_none() && app.suspend.is_none());
+    }
+
+    #[test]
+    fn interface_section_picker_navigates_without_activating_background() {
+        let _g = dead_socket();
+        let mut app = test_app();
+        app.screen = SC_WELCOME;
+        let target = app.visible[1];
+        app.on_key(KeyCode::F(3));
+        assert!(draw_text(&app).contains("Choose section"));
+        app.on_key(KeyCode::Char('e'));
+        assert!(app.input.is_none() && app.enroll.is_none());
+        app.on_key(KeyCode::Down);
+        app.on_key(KeyCode::Enter);
+        assert_eq!(app.screen, target);
+        assert!(!draw_text(&app).contains("Choose section"));
+        drain_loads(&mut app);
+    }
+
+    #[test]
+    fn interface_short_sidebar_keeps_current_section_visible_and_clickable() {
+        let _g = dead_socket();
+        let mut app = test_app();
+        app.caps.rgb = true;
+        app.caps.ir_pair = true;
+        app.fp.available = true;
+        app.advanced = true;
+        app.recompute_visible();
+        app.screen = SC_SETTINGS;
+        let area = Rect::new(0, 0, 100, 20);
+        let mut term = Terminal::new(TestBackend::new(area.width, area.height)).unwrap();
+        term.draw(|f| app.draw(f)).unwrap();
+        let [_, _, body, _, _] = app.frame_rows(area);
+        let inner = Block::bordered().inner(app.body_split(body).0.unwrap());
+        let buffer = term.backend().buffer();
+        let row = (inner.y..inner.bottom())
+            .find(|y| {
+                (inner.x..inner.right())
+                    .map(|x| buffer[(x, *y)].symbol())
+                    .collect::<String>()
+                    .contains("Preferences")
+            })
+            .expect("current section must remain visible in a short sidebar");
+        app.on_click(inner.x + 3, row, area);
+        assert_eq!(
+            app.screen, SC_SETTINGS,
+            "click uses the rendered sidebar offset"
+        );
+    }
+
+    #[test]
+    fn interface_compact_footer_retains_navigation_focus_actions_and_help() {
+        let app = test_app();
+        let mut term = Terminal::new(TestBackend::new(40, 16)).unwrap();
+        term.draw(|f| app.draw(f)).unwrap();
+        let [_, _, _, _, footer] = app.frame_rows(Rect::new(0, 0, 40, 16));
+        let inner = Block::bordered().inner(footer);
+        for key in [
+            KeyCode::F(3),
+            KeyCode::F(6),
+            KeyCode::F(2),
+            KeyCode::Char('?'),
+        ] {
+            assert!(
+                app.click_targets.borrow().iter().any(|(r, c)| {
+                    matches!(c, Click::Key(k) if *k == key)
+                        && r.width > 0
+                        && r.height > 0
+                        && r.intersection(inner) == *r
+                }),
+                "{key:?} must be visibly clickable in compact footer"
+            );
+        }
+    }
+
+    #[test]
+    fn interface_first_run_compact_button_is_visible_and_clickable() {
+        let _g = dead_socket();
+        for (width, height) in [(40, 12), (80, 24)] {
+            let mut app = test_app();
+            app.caps.rgb = true;
+            app.daemon_up = true;
+            app.profiles_loaded = true;
+            let area = Rect::new(0, 0, width, height);
+            let mut term = Terminal::new(TestBackend::new(width, height)).unwrap();
+            term.draw(|f| app.draw(f)).unwrap();
+            assert!(
+                rendered(&term).contains("Scan my face"),
+                "primary action must fit at {width}x{height}"
+            );
+            let [_, _, body, _, _] = app.frame_rows(area);
+            let button = app
+                .click_targets
+                .borrow()
+                .iter()
+                .find_map(|(rect, click)| {
+                    (matches!(click, Click::Key(KeyCode::Char('e')))
+                        && rect.height > 0
+                        && rect.width > 0
+                        && rect.intersection(body) == *rect)
+                        .then_some(*rect)
+                })
+                .expect("visible primary button needs a matching body hit region");
+            app.on_click(button.x, button.y, area);
+            assert!(matches!(app.input, Some((_, _, Pending::EnrollName))));
+            assert!(app.op.is_none() && app.suspend.is_none());
+            drain_loads(&mut app);
+        }
+    }
+
+    #[test]
+    fn interface_first_run_sensor_wording_and_guidance_are_readable_by_keyboard() {
+        for infrared in [false, true] {
+            let mut app = test_app();
+            app.caps.rgb = true;
+            app.caps.ir_pair = infrared;
+            app.profiles_loaded = true;
+            let mut term = Terminal::new(TestBackend::new(40, 12)).unwrap();
+            term.draw(|f| app.draw(f)).unwrap();
+            app.on_key(KeyCode::F(6));
+            let mut seen = String::new();
+            for _ in 0..30 {
+                term.draw(|f| app.draw(f)).unwrap();
+                seen.push_str(&rendered(&term));
+                seen.push('\n');
+                app.on_key(KeyCode::PageDown);
+            }
+            assert!(!app.activity_open, "focused guidance owns reading keys");
+            assert!(seen.contains("RGB"), "identify the observed sensor type");
+            assert_eq!(
+                seen.contains("infrared camera"),
+                infrared,
+                "RGB-only enrollment must not claim an infrared camera"
+            );
+            assert!(
+                seen.contains("Follow the cues") && seen.contains("Finish login setup"),
+                "all setup guidance must be reachable"
+            );
+        }
+    }
+
+    #[test]
+    fn interface_section_picker_preserves_surviving_selection_when_hardware_changes() {
+        let _g = dead_socket();
+        for (selected, expected) in [
+            (SC_PAM, SC_PAM),
+            (SC_SETTINGS, SC_SETTINGS),
+            (SC_CAMERAS, SC_SETTINGS),
+        ] {
+            let mut app = test_app();
+            app.caps.rgb = true;
+            app.caps.ir_pair = true;
+            app.fp.available = true;
+            app.advanced = true;
+            app.recompute_visible();
+            app.on_key(KeyCode::F(3));
+            let index = app.visible.iter().position(|&s| s == selected).unwrap();
+            for _ in 0..index {
+                app.on_key(KeyCode::Down);
+            }
+            app.caps.rgb = false;
+            app.caps.ir_pair = false;
+            app.fp.available = false;
+            app.recompute_visible();
+            assert_eq!(
+                app.sections.and_then(|i| app.visible.get(i)).copied(),
+                Some(expected),
+                "a surviving selected screen keeps its identity after earlier rows disappear"
+            );
+            app.on_key(KeyCode::Enter);
+            assert_eq!(app.screen, expected);
+            drain_loads(&mut app);
+        }
+    }
+
+    #[test]
+    fn interface_first_run_focus_stays_on_the_visible_enrollment_action() {
+        let _g = dead_socket();
+        let mut app = test_app();
+        app.caps.rgb = true;
+        app.caps.ir_pair = true;
+        app.daemon_up = true;
+        app.profiles_loaded = true;
+        assert!(app.is_first_run());
+        let mut term = Terminal::new(TestBackend::new(40, 20)).unwrap();
+        term.draw(|f| app.draw(f)).unwrap();
+        app.on_key(KeyCode::F(6));
+        // The unrestricted Overview list ends in a typed uninstall prompt;
+        // exercising that entry stays entirely in UI state even on RED.
+        for _ in 0..5 {
+            app.on_key(KeyCode::Down);
+        }
+        term.draw(|f| app.draw(f)).unwrap();
+        assert!(rendered(&term).contains("Scan my face"));
+        app.on_key(KeyCode::Char(' '));
+        assert!(
+            matches!(app.input, Some((_, _, Pending::EnrollName))),
+            "first-run focus must activate its visible enrollment button"
+        );
+        assert!(app.op.is_none() && app.suspend.is_none());
+        drain_loads(&mut app);
+    }
+
+    #[test]
+    fn interface_compact_header_keeps_page_title_separate_from_account_and_exit() {
+        let mut app = test_app();
+        app.screen = SC_PAM;
+        app.user = "an-account-name-longer-than-the-page-title".into();
+        let mut term = Terminal::new(TestBackend::new(40, 16)).unwrap();
+        term.draw(|f| app.draw(f)).unwrap();
+        let text = rendered(&term);
+        let header = text.lines().next().unwrap();
+        assert!(
+            header.contains("Login & Apps"),
+            "page title must not be overwritten: {header}"
+        );
+        assert!(
+            header.contains("Exit (q)"),
+            "exit remains visible: {header}"
+        );
+    }
+
+    #[test]
+    fn interface_mouse_selection_does_not_activate_an_unrelated_focused_action() {
+        let mut app = live_test_app();
+        let mut snapshot = live_test_snapshot();
+        snapshot.cameras.candidates[0].endpoint_paths =
+            vec!["/dev/example-rgb".into(), "/dev/example-ir".into()];
+        app.apply_live_snapshot(snapshot, app.now());
+        let now = app.now();
+        app.freshness
+            .observation_mut(Source::Cameras)
+            .record(true, now);
+        app.screen = SC_CAMERAS;
+        app.pairs = vec![irlume_common::CameraPairInfo {
+            rgb: "/dev/example-rgb".into(),
+            ir: "/dev/example-ir".into(),
+            id: Some("example".into()),
+            fixed: true,
+            privacy: false,
+        }];
+        app.on_key(KeyCode::F(6));
+        app.on_key(KeyCode::Down); // keyboard focus is on another control, not the selected camera row
+        let area = Rect::new(0, 0, 120, 40);
+        let mut term = Terminal::new(TestBackend::new(area.width, area.height)).unwrap();
+        term.draw(|f| app.draw(f)).unwrap();
+        let row = app
+            .click_targets
+            .borrow()
+            .iter()
+            .find_map(|(rect, click)| matches!(click, Click::Select(0)).then_some(*rect))
+            .unwrap();
+        app.on_click(row.x, row.y, area);
+        assert!(
+            matches!(&app.confirm, Some((_, _, ConfirmAct::Sus(Suspend::SetCameras(rgb, ir, _))))
+            if rgb == "/dev/example-rgb" && ir == "/dev/example-ir")
+        );
+        assert!(
+            app.suspend.is_none(),
+            "click retains the camera-switch confirmation"
+        );
+    }
+
+    #[test]
+    fn interface_focused_page_scroll_reaches_text_after_last_action() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let mut app = test_app();
+        app.screen = SC_SETTINGS;
+        app.preferences = Some(preference_fixture(false));
+        let mut term = Terminal::new(TestBackend::new(40, 16)).unwrap();
+        term.draw(|f| app.draw(f)).unwrap();
+        app.on_key(KeyCode::F(6));
+        term.draw(|f| app.draw(f)).unwrap();
+        for _ in 0..100 {
+            app.on_key(KeyCode::PageDown);
+            term.draw(|f| app.draw(f)).unwrap();
+        }
+        assert!(
+            rendered(&term).contains("scan count."),
+            "all page text must be readable after the final action"
+        );
+        assert!(!app.activity_open && app.act_scroll == 0);
+        app.on_key(KeyCode::F(6));
+        app.on_key(KeyCode::PageUp);
+        assert!(
+            app.activity_open,
+            "without page focus PgUp retains Activity ownership"
+        );
+    }
+
+    #[test]
+    fn interface_long_token_dialog_scrolls_by_keyboard_without_confirming() {
+        let mut app = test_app();
+        app.confirm = Some((
+            format!("{}TAIL", "界".repeat(200)),
+            "Confirm",
+            ConfirmAct::Daemon(Request::Ping),
+        ));
+        let mut term = Terminal::new(TestBackend::new(40, 12)).unwrap();
+        term.draw(|f| app.draw(f)).unwrap();
+        for _ in 0..100 {
+            app.on_key(KeyCode::PageDown);
+            term.draw(|f| app.draw(f)).unwrap();
+        }
+        assert!(
+            rendered(&term).contains("TAIL"),
+            "all wrapped text must be reachable"
+        );
+        assert!(app.confirm.is_some() && app.op.is_none() && app.suspend.is_none());
+        assert_eq!(app.act_scroll, 0);
+        assert!(!app.activity_open);
     }
 
     fn preference_fixture(ir_only: bool) -> irlume_common::PreferencesState {
@@ -13982,6 +16541,7 @@ mod tests {
         let old = std::env::var_os("IRLUME_ENFORCE_BIOPOLICY");
         std::env::set_var("IRLUME_ENFORCE_BIOPOLICY", "yes");
         let mut app = test_app();
+        app.preferences = Some(irlume_common::PreferencesState::observe());
         app.screen = SC_SETTINGS;
         let text = draw_text(&app);
         match old {
@@ -13999,7 +16559,8 @@ mod tests {
         // Each setup hint has three honest states: not done (instruct), done
         // (describe), never observed (assert neither). The fixed per-screen
         // instruction told a fully configured box to redo every step.
-        let mut app = test_app();
+        let mut app = live_test_app();
+        app.repair.clear();
         app.daemon_up = true;
 
         // Overview: unknown until ListProfiles has answered.
@@ -14008,7 +16569,10 @@ mod tests {
         assert!(draw_text(&app).contains("Set up face unlock while keeping password access"));
         app.profiles = vec![profile("a", &["s1"])];
         let text = draw_text(&app);
-        assert!(text.contains("Face unlock is ready"));
+        assert!(text.contains("Checking login integration"));
+        app.probes_landed = true;
+        app.probes.login_wired = true;
+        assert!(draw_text(&app).contains("Face unlock is ready"));
         assert!(
             !text.contains("Keep nodding to approve"),
             "Overview must not carry the head-gesture line (default-off, \
@@ -14046,7 +16610,8 @@ mod tests {
         });
         assert!(draw_text(&app).contains("A recovery passphrase protects access"));
 
-        // Login wiring: unknown until the first probe sweep lands.
+        // Reset the earlier Overview observation: unknown until a sweep lands.
+        app.probes_landed = false;
         app.screen = SC_PAM;
         let text = draw_text(&app);
         assert!(text.contains("Checking login, lock-screen"), "{text}");
@@ -14078,7 +16643,8 @@ mod tests {
 
     #[test]
     fn done_offers_wire_login_only_when_wiring_is_observed_missing() {
-        let mut app = test_app();
+        let mut app = live_test_app();
+        app.repair.clear();
         app.screen = SC_DONE;
         app.daemon_up = true;
         app.profiles = vec![profile("a", &["s1"])];
@@ -14561,6 +17127,13 @@ mod tests {
                 format!("enforce_biopolicy={on}\n"),
             )
             .unwrap();
+            app.preferences = Some(irlume_common::PreferencesState::observe());
+            // Rendering consumes the observation, not subsequent local edits.
+            std::fs::write(
+                dir.join("settings.conf"),
+                "enforce_biopolicy=unobserved-change\n",
+            )
+            .unwrap();
             let text = draw_text(&app);
             assert!(
                 text.contains("turn it off"),
@@ -14571,6 +17144,13 @@ mod tests {
             std::fs::write(
                 dir.join("settings.conf"),
                 format!("enforce_biopolicy={off}\n"),
+            )
+            .unwrap();
+            app.preferences = Some(irlume_common::PreferencesState::observe());
+            // Rendering consumes the observation, not subsequent local edits.
+            std::fs::write(
+                dir.join("settings.conf"),
+                "enforce_biopolicy=unobserved-change\n",
             )
             .unwrap();
             let text = draw_text(&app);
@@ -14632,5 +17212,291 @@ mod tests {
             "nothing to reseal on an unarmed keyring: {}",
             app.help_body()
         );
+    }
+    #[test]
+    fn disconnected_status_workers_release_loading_state_and_explain_staleness() {
+        fn disconnected<T>() -> mpsc::Receiver<T> {
+            let (sender, receiver) = mpsc::channel();
+            drop(sender);
+            receiver
+        }
+        let mut app = test_app();
+        app.light_load = Some(disconnected());
+        app.probes_load = Some(disconnected());
+        app.profiles_load = Some(disconnected());
+        app.camera_load = Some(disconnected());
+        app.heavy_load = Some(disconnected());
+        app.keyring_load = Some(disconnected());
+        app.poll();
+        assert!(app.light_load.is_none(), "status refresh must be retryable");
+        assert!(app.probes_load.is_none(), "diagnostics must be retryable");
+        assert!(
+            app.profiles_load.is_none(),
+            "profile refresh must be retryable"
+        );
+        let messages = app
+            .activity
+            .iter()
+            .map(|(_, m)| m.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(messages.contains("status refresh ended"), "{messages}");
+        assert!(messages.contains("diagnostics refresh ended"), "{messages}");
+        assert!(messages.contains("profile refresh ended"), "{messages}");
+        assert!(messages.contains("camera refresh ended"), "{messages}");
+        assert!(messages.contains("app status refresh ended"), "{messages}");
+        assert!(messages.contains("wallet check ended"), "{messages}");
+        assert!(
+            app.camera_load.is_none() && app.heavy_load.is_none() && app.keyring_load.is_none()
+        );
+        assert!(
+            !app.profiles_loaded,
+            "worker loss is not an observed empty list"
+        );
+        assert!(
+            app.error.is_none(),
+            "background refresh failure should not steal focus"
+        );
+    }
+
+    #[test]
+    fn visual_review_short_layout_keeps_footer_and_recent_activity_readable() {
+        let mut app = visual_fixture(SC_SETTINGS);
+        let (_sender, op) = fake_op();
+        for busy in [false, true] {
+            if busy {
+                app.op = Some(Op {
+                    label: "synthetic busy".into(),
+                    tag: op.tag,
+                    rx: mpsc::channel().1,
+                });
+            }
+            let [_, _, body, activity, footer] = app.frame_rows(Rect::new(0, 0, 40, 12));
+            assert!(
+                body.height >= 4,
+                "the page needs space for content within its border"
+            );
+            assert_eq!(activity.height, 3, "recent Activity needs a readable row");
+            assert_eq!(footer.height, 3, "navigation/cancel needs a readable row");
+            let mut terminal = Terminal::new(TestBackend::new(40, 12)).unwrap();
+            terminal.draw(|frame| app.draw(frame)).unwrap();
+            let text = rendered(&terminal);
+            assert!(text.contains(if busy { "quit" } else { "F3" }), "{text}");
+        }
+    }
+
+    #[test]
+    fn visual_review_camera_paths_are_reported_without_local_presence_inference() {
+        let mut app = visual_fixture(SC_CAMERAS);
+        // Deliberately outside passive UVC coverage: local path visibility
+        // cannot turn a reported configuration into proof of physical absence.
+        let health = app.health.as_mut().unwrap();
+        health.rgb_dev = Some("/synthetic/rgb".into());
+        health.ir_dev = Some("/synthetic/ir".into());
+        let text = draw_text(&app);
+        assert!(text.contains("/synthetic/rgb + /synthetic/ir"), "{text}");
+        assert!(text.contains("configured"), "{text}");
+        assert!(
+            !text.contains("no camera hardware"),
+            "local path visibility is not hardware absence"
+        );
+    }
+
+    #[test]
+    fn visual_review_long_diagnostic_label_has_an_explicit_separator() {
+        let mut app = test_app();
+        app.screen = SC_REPAIR;
+        app.repair = vec![Check {
+            label: "A long diagnostic label".into(),
+            sev: Sev::Ok,
+            detail: "fixture detail".into(),
+            fix: Fix::None,
+        }];
+        let text = draw_text(&app);
+        assert!(
+            text.contains("A long diagnostic label · fixture detail"),
+            "{text}"
+        );
+    }
+
+    #[test]
+    fn compact_enrollment_prioritizes_current_guidance_countdown_and_stall() {
+        for (count, stalled, expected) in [
+            (None, None, "Move closer"),
+            (Some(2), None, "Hold still; capturing in 2"),
+            (
+                None,
+                Some("synthetic timeout"),
+                "Camera guide not answering",
+            ),
+        ] {
+            let mut app = test_app();
+            app.screen = SC_PROFILES;
+            let (_sender, mut enrollment) = fake_enroll(0, 4);
+            enrollment.last = Some(good_report("Move closer"));
+            enrollment.count = count;
+            enrollment.stalled = stalled.map(str::to_owned);
+            app.enroll = Some(enrollment);
+            let mut terminal = Terminal::new(TestBackend::new(40, 12)).unwrap();
+            terminal.draw(|frame| app.draw(frame)).unwrap();
+            let text = rendered(&terminal);
+            assert!(
+                text.contains(expected),
+                "current cue must be visible: {text}"
+            );
+            assert!(text.contains("cancel enrollment"), "{text}");
+            if stalled.is_some() {
+                assert!(!text.contains("Move closer") && !text.contains("Face detected"));
+            }
+        }
+    }
+
+    #[test]
+    fn operation_footer_click_quits_without_claiming_cancellation() {
+        let mut app = test_app();
+        let (_sender, op) = fake_op();
+        app.op = Some(op);
+        click_text(&mut app, "quit");
+        assert!(app.quit, "the visible quit control must accept clicks");
+        assert!(
+            app.op.is_some(),
+            "quitting cannot retract the daemon request"
+        );
+        assert!(!app.activity.iter().any(|(_, m)| m.contains("cancelled")));
+    }
+
+    #[test]
+    fn enrollment_footer_click_requests_cancel_and_keeps_the_interface_open() {
+        let _guard = dead_socket();
+        let mut app = test_app();
+        let (_sender, enroll) = fake_enroll(0, 4);
+        let stop = enroll.stop.clone();
+        app.enroll = Some(enroll);
+        click_text(&mut app, "cancel enrollment");
+        // If the click succeeds it starts a status refresh: finish that worker
+        // before assertions so failure cannot outlive the dead-socket guard.
+        drain_loads(&mut app);
+        assert!(
+            stop.load(Ordering::Relaxed),
+            "the visible cancel control must accept clicks"
+        );
+        assert!(app.enroll.is_none());
+        assert!(!app.quit);
+        assert!(app
+            .activity
+            .iter()
+            .any(|(_, m)| m.contains("cancellation requested")));
+    }
+
+    #[test]
+    fn disconnected_operation_exits_busy_state_without_claiming_success() {
+        let mut app = test_app();
+        let (sender, op) = fake_op();
+        app.op = Some(op);
+        drop(sender);
+        app.poll();
+        assert!(
+            app.op.is_none(),
+            "a lost worker must not leave an endless spinner"
+        );
+        assert!(app
+            .error
+            .as_deref()
+            .is_some_and(|m| m.contains("outcome is unknown")));
+        assert!(!app.activity.iter().any(|(icon, _)| *icon == '✓'));
+        assert!(!app.quit, "the interface remains usable");
+    }
+
+    #[test]
+    fn disconnected_enrollment_reports_unknown_outcome_and_refreshes_saved_profiles() {
+        let _guard = dead_socket();
+        let mut app = test_app();
+        let (sender, enrollment) = fake_enroll(0, 4);
+        let stop = enrollment.stop.clone();
+        app.enroll = Some(enrollment);
+        sender.send(WMsg::Captured(1, 4)).unwrap();
+        drop(sender);
+        app.poll();
+        assert!(
+            app.enroll.is_none(),
+            "worker loss must not leave a stale framing guide"
+        );
+        assert!(stop.load(Ordering::Relaxed));
+        assert!(app
+            .error
+            .as_deref()
+            .is_some_and(|m| m.contains("outcome is unknown")));
+        assert!(!app.activity.iter().any(|(_, m)| m == "enrollment complete"));
+        drain_loads(&mut app);
+    }
+
+    #[test]
+    fn enrollment_done_before_channel_close_stays_successful() {
+        let _guard = dead_socket();
+        let mut app = test_app();
+        let (sender, enrollment) = fake_enroll(0, 4);
+        app.enroll = Some(enrollment);
+        sender.send(WMsg::Done { ambient_lit: 0 }).unwrap();
+        drop(sender);
+        app.poll();
+        assert!(app.enroll.is_none());
+        assert!(app.error.is_none());
+        assert!(app.activity.iter().any(|(_, m)| m == "enrollment complete"));
+        drain_loads(&mut app);
+    }
+
+    #[test]
+    fn unexpected_responses_do_not_copy_payloads_into_activity_messages() {
+        for mapper in [map_ok, map_confirm, map_sealed] {
+            let response = Response::Identified {
+                user: Some("private-account-sentinel".into()),
+                profile: Some("private-profile-sentinel".into()),
+                score: 0.8123,
+                live: true,
+                reason: "private-reason-sentinel".into(),
+            };
+            let (ok, message) = mapper(response);
+            assert!(!ok);
+            assert!(message.contains("unexpected"), "{message}");
+            assert!(
+                !message.contains("sentinel"),
+                "wrong response payload must not enter Activity"
+            );
+        }
+    }
+
+    #[test]
+    fn confirmed_action_activity_explains_effect_without_copying_request_fields() {
+        let _guard = dead_socket();
+        let mut app = test_app();
+        app.start_async(
+            "(confirmed)",
+            OpTag::Generic,
+            Request::RecoveryForget {
+                user: "private-user-sentinel".into(),
+            },
+            map_confirm,
+        );
+        let message = app.activity.last().unwrap().1.clone();
+        // Drain workers even when the assertion is deliberately RED. Otherwise
+        // it can outlive DeadSocket and race the next test's fake endpoint.
+        wait_op_done(&mut app);
+        assert!(message.contains("recovery backup"), "{message}");
+        assert!(message.contains("template key"), "{message}");
+        assert!(!message.contains("private-user-sentinel"));
+    }
+
+    #[test]
+    fn overview_does_not_claim_ready_before_login_wiring_is_observed() {
+        let mut app = live_test_app();
+        app.repair.clear();
+        app.daemon_up = true;
+        app.caps.rgb = true;
+        app.profiles_loaded = true;
+        app.profiles = vec![profile("Sample", &["scan"])];
+        assert_eq!(app.login_wired_known(), None);
+        let text = draw_text(&app);
+        assert!(!text.contains("Face unlock is ready"), "{text}");
+        assert!(text.contains("Checking login integration"), "{text}");
     }
 }

--- a/crates/irlume-cli/src/tui/actions.rs
+++ b/crates/irlume-cli/src/tui/actions.rs
@@ -125,7 +125,7 @@ pub(super) static ACTIONS: &[Action] = &[
     Action { label: "List profiles and recognizer tags", description: "Shows profiles and scans for the selected account, including recognizer ownership.", args: &["profiles", "list"], root: false, per_user: true, fields: &[] },
     Action { label: "List all camera devices", description: "Read-only camera census, including unsupported devices and classification evidence.", args: &["camera", "census"], root: false, per_user: false, fields: &[] },
     Action { label: "Show full capture qualification", description: "Shows the daemon's active schedule, qualification reason and exact camera context.", args: &["camera-mode"], root: false, per_user: false, fields: &[] },
-    Action { label: "Export camera diagnostics to terminal", description: "Shows the machine-readable delivered-rate and stream evidence; does not start a capture.", args: &["camera", "diagnostics", "--json"], root: false, per_user: false, fields: &[] },
+    Action { label: "Capture camera diagnostics to terminal", description: "Opens the camera and captures gated samples to measure delivered-rate and stream evidence, then displays the report as JSON.", args: &["camera", "diagnostics", "--json"], root: false, per_user: false, fields: &[] },
     Action { label: "Tune capture with a chosen round count", description: "Engages RGB and IR cameras and stores qualification for the exact device context. Requires administrator access.", args: &["camera-tune"], root: true, per_user: false, fields: &[Field { label: "Measurement rounds (blank uses the CLI default)", flag: Some("--rounds"), optional: true }] },
     Action { label: "Record a diagnostic trace", description: "Requires administrator access. Records sensitive diagnostic measurements for a bounded duration, with no frames, embeddings or credentials. Review before sharing.", args: &["trace", "record"], root: true, per_user: false, fields: &[Field { label: "Duration, e.g. 60s (blank uses 60s; maximum 5m)", flag: Some("--duration"), optional: true }, OUTPUT] },
     Action { label: "Explain a recorded trace", description: "Validates a trace file and displays its timeline. Sensitive diagnostic measurements may appear. No camera capture.", args: &["trace", "explain"], root: false, per_user: false, fields: &[Field { label: "Trace file (.jsonl)", flag: None, optional: false }, OUTPUT] },
@@ -216,6 +216,17 @@ pub(super) fn auth_test_feedback(
 mod auth_feedback_tests {
     use super::auth_test_feedback;
     use std::os::unix::process::ExitStatusExt;
+    #[test]
+    fn camera_diagnostics_action_discloses_capture_before_confirmation() {
+        let action = super::matching("camera diagnostics")
+            .into_iter()
+            .find(|action| action.args == ["camera", "diagnostics", "--json"])
+            .unwrap();
+        assert!(!action.description.contains("does not start a capture"));
+        assert!(action.description.contains("captures"));
+        assert!(action.description.contains("camera"));
+    }
+
     fn output(code: i32, value: serde_json::Value) -> std::io::Result<std::process::Output> {
         Ok(std::process::Output {
             status: std::process::ExitStatus::from_raw(code << 8),

--- a/crates/irlume-cli/src/tui/activity.rs
+++ b/crates/irlume-cli/src/tui/activity.rs
@@ -1,0 +1,563 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! Bounded, process-local TUI messages. This is not a system audit collector.
+
+use ratatui::buffer::{Buffer, Cell};
+use ratatui::crossterm::event::KeyCode;
+use ratatui::layout::Rect;
+use ratatui::style::Style;
+use ratatui::text::Line;
+use ratatui::widgets::{Paragraph, Widget, Wrap};
+use std::cell::RefCell;
+use std::ops::Deref;
+use std::time::{Duration, Instant};
+
+const MAX_ENTRIES: usize = 200;
+const MAX_ENTRY_BYTES: usize = 4096;
+// Also bounds the wrapped paragraph below u16::MAX rows, even at width 1.
+const MAX_TEXT_BYTES: usize = 32 * 1024;
+const TRUNCATED: &str = " [detail truncated]";
+
+#[derive(Clone, Copy)]
+struct Anchor {
+    id: u64,
+    byte: usize,
+    row: usize,
+    width: u16,
+}
+
+#[derive(Default)]
+struct View {
+    // Stable entry id and source byte; None follows the newest message.
+    anchor: Option<Anchor>,
+    rows: Vec<(u64, usize)>,
+    scroll: usize,
+    max_scroll: usize,
+    height: usize,
+    width: u16,
+}
+
+pub(super) struct Activity {
+    entries: Vec<(char, String)>,
+    elapsed: Vec<Duration>,
+    started: Instant,
+    bytes: usize,
+    discarded: u64,
+    view: RefCell<View>,
+}
+
+impl Default for Activity {
+    fn default() -> Self {
+        Self {
+            entries: Vec::new(),
+            elapsed: Vec::new(),
+            started: Instant::now(),
+            bytes: 0,
+            discarded: 0,
+            view: RefCell::new(View::default()),
+        }
+    }
+}
+
+// Existing consumers can inspect tuples, but cannot mutate entries separately
+// from timestamps, retention accounting or the stable history anchor.
+impl Deref for Activity {
+    type Target = [(char, String)];
+
+    fn deref(&self) -> &Self::Target {
+        &self.entries
+    }
+}
+
+impl Activity {
+    pub(super) fn push(&mut self, icon: char, message: String) {
+        self.push_at(icon, message, self.started.elapsed());
+    }
+
+    fn push_at(&mut self, icon: char, message: String, elapsed: Duration) {
+        let message = bounded_text(&message);
+        self.bytes += message.len();
+        self.entries.push((icon, message));
+        self.elapsed.push(elapsed);
+        while self.entries.len() > MAX_ENTRIES || self.bytes > MAX_TEXT_BYTES {
+            self.bytes -= self.entries.remove(0).1.len();
+            self.elapsed.remove(0);
+            self.discarded = self.discarded.saturating_add(1);
+        }
+    }
+
+    fn prefix(&self, index: usize) -> String {
+        let seconds = self.elapsed[index].as_secs();
+        format!(
+            "[{:02}:{:02}] {} ",
+            seconds / 60,
+            seconds % 60,
+            status(self.entries[index].0)
+        )
+    }
+
+    pub(super) fn summary(&self, index: usize, width: u16) -> String {
+        let message = &self.entries[index].1;
+        let first = message.split('\n').next().unwrap_or_default();
+        let mut text = format!("{}{first}", self.prefix(index));
+        if message.contains('\n') {
+            text.push('…');
+        }
+        clip(&text, width)
+    }
+
+    fn entry_lines(&self, index: usize) -> Vec<Line<'static>> {
+        self.entries[index]
+            .1
+            .split('\n')
+            .enumerate()
+            .map(|(line, text)| {
+                Line::raw(if line == 0 {
+                    format!("{}{text}", self.prefix(index))
+                } else {
+                    text.to_string()
+                })
+            })
+            .collect()
+    }
+
+    /// Use the renderer's emitted graphemes to locate each row in its source.
+    /// This runs only for navigation/resizing, not on each ordinary draw. Each
+    /// temporary buffer holds one bounded logical line, never the whole history.
+    fn row_offsets(&self, index: usize, width: u16) -> Vec<usize> {
+        let mut offsets = Vec::new();
+        let mut base = 0;
+        for line in self.entry_lines(index) {
+            let text = line.to_string();
+            offsets.extend(
+                wrapped_source_offsets(&text, width)
+                    .into_iter()
+                    .map(|n| base + n),
+            );
+            base += text.len() + 1;
+        }
+        offsets
+    }
+
+    pub(super) fn retention(&self) -> String {
+        format!(
+            "{} retained · {} older discarded · session memory only",
+            self.entries.len(),
+            self.discarded
+        )
+    }
+
+    pub(super) fn follow(&self) {
+        self.view.borrow_mut().anchor = None;
+    }
+
+    pub(super) fn following(&self) -> bool {
+        self.view.borrow().anchor.is_none()
+    }
+
+    /// All detail uses the same ratatui wrapping for counting and rendering.
+    /// A stable entry anchor survives append/eviction and viewport resizing.
+    pub(super) fn paragraph(&self, width: u16, height: u16) -> Paragraph<'static> {
+        let mut rows = Vec::with_capacity(self.entries.len());
+        let mut lines = Vec::new();
+        for index in 0..self.entries.len() {
+            let entry = self.entry_lines(index);
+            let count = Paragraph::new(entry.clone())
+                .wrap(Wrap { trim: false })
+                .line_count(width);
+            rows.push((self.discarded + index as u64, count));
+            lines.extend(entry);
+        }
+        let mut view = self.view.borrow_mut();
+        let max_scroll = rows
+            .iter()
+            .map(|(_, count)| count)
+            .sum::<usize>()
+            .saturating_sub(usize::from(height));
+        let scroll = match view.anchor {
+            None => max_scroll,
+            Some(mut anchor) => {
+                if anchor.width != width {
+                    if let Some(index) = anchor
+                        .id
+                        .checked_sub(self.discarded)
+                        .and_then(|n| usize::try_from(n).ok())
+                        .filter(|index| *index < self.entries.len())
+                    {
+                        anchor.row = self
+                            .row_offsets(index, width)
+                            .partition_point(|byte| *byte <= anchor.byte)
+                            .saturating_sub(1);
+                    }
+                    anchor.width = width;
+                    view.anchor = Some(anchor);
+                }
+                let before = rows
+                    .iter()
+                    .take_while(|(row_id, _)| *row_id < anchor.id)
+                    .map(|(_, count)| count)
+                    .sum::<usize>();
+                let offset = rows
+                    .iter()
+                    .find(|(row_id, _)| *row_id == anchor.id)
+                    .map_or(0, |(_, count)| anchor.row.min(count.saturating_sub(1)));
+                (before + offset).min(max_scroll)
+            }
+        };
+        view.rows = rows;
+        view.scroll = scroll;
+        view.max_scroll = max_scroll;
+        view.height = usize::from(height);
+        view.width = width;
+        // The total byte/entry bounds above make this conversion lossless.
+        let scroll = u16::try_from(scroll).unwrap_or(u16::MAX);
+        Paragraph::new(lines)
+            .wrap(Wrap { trim: false })
+            .scroll((scroll, 0))
+    }
+
+    pub(super) fn scroll(&self, key: KeyCode) {
+        let mut view = self.view.borrow_mut();
+        let next = match key {
+            KeyCode::Home => 0,
+            KeyCode::End => {
+                view.anchor = None;
+                return;
+            }
+            KeyCode::Up => view.scroll.saturating_sub(1),
+            KeyCode::PageUp => view.scroll.saturating_sub(view.height.max(1)),
+            KeyCode::Down => view.scroll.saturating_add(1).min(view.max_scroll),
+            KeyCode::PageDown => view
+                .scroll
+                .saturating_add(view.height.max(1))
+                .min(view.max_scroll),
+            _ => return,
+        };
+        if next == view.max_scroll && !matches!(key, KeyCode::Home | KeyCode::Up | KeyCode::PageUp)
+        {
+            view.anchor = None;
+        } else {
+            let mut remaining = next;
+            view.anchor = view.rows.iter().find_map(|(id, count)| {
+                if remaining < *count {
+                    let byte = id
+                        .checked_sub(self.discarded)
+                        .and_then(|n| usize::try_from(n).ok())
+                        .filter(|index| *index < self.entries.len())
+                        .and_then(|index| {
+                            self.row_offsets(index, view.width).get(remaining).copied()
+                        })
+                        .unwrap_or(0);
+                    Some(Anchor {
+                        id: *id,
+                        byte,
+                        row: remaining,
+                        width: view.width,
+                    })
+                } else {
+                    remaining = remaining.saturating_sub(*count);
+                    None
+                }
+            });
+        }
+        view.scroll = next;
+    }
+}
+
+/// Ratatui's word wrapper can consume boundary spaces and omit graphemes
+/// wider than the viewport. Match emitted symbols to whole source graphemes
+/// monotonically, so repeated words, combining characters and those omissions
+/// retain their source positions. NUL marks untouched padding/continuation
+/// cells only in this offscreen buffer; bounded_text excludes it from input.
+fn wrapped_source_offsets(text: &str, width: u16) -> Vec<usize> {
+    if width == 0 {
+        return Vec::new();
+    }
+    let width = width.min(
+        u16::try_from(Line::raw(text).width())
+            .unwrap_or(u16::MAX)
+            .max(1),
+    );
+    let paragraph = Paragraph::new(text).wrap(Wrap { trim: false });
+    let height = u16::try_from(paragraph.line_count(width)).unwrap_or(u16::MAX);
+    let area = Rect::new(0, 0, width, height);
+    let mut buffer = Buffer::filled(area, Cell::new("\0"));
+    paragraph.render(area, &mut buffer);
+    let source_line = Line::raw(text);
+    let mut source = source_line
+        .styled_graphemes(Style::default())
+        .scan(0, |byte, grapheme| {
+            let position = *byte;
+            *byte += grapheme.symbol.len();
+            Some((position, grapheme.symbol))
+        });
+    let mut next = 0;
+    buffer
+        .content
+        .chunks(usize::from(width))
+        .map(|row| {
+            let mut start = None;
+            let mut first_text = None;
+            for cell in row {
+                let symbol = cell.symbol();
+                if symbol == "\0" {
+                    continue;
+                }
+                if let Some((byte, _)) = source.find(|(_, original)| *original == symbol) {
+                    start.get_or_insert(byte);
+                    if !symbol.chars().all(char::is_whitespace) {
+                        first_text.get_or_insert(byte);
+                    }
+                    next = byte + symbol.len();
+                }
+            }
+            // Prefer actual text over leading spaces consumed differently by reflow.
+            first_text.or(start).unwrap_or(next)
+        })
+        .collect()
+}
+
+fn status(icon: char) -> &'static str {
+    match icon {
+        '→' => "Requested",
+        '✓' => "Completed",
+        '✗' => "Failed",
+        '!' => "Warning",
+        _ => "Info",
+    }
+}
+
+fn bounded_text(message: &str) -> String {
+    let mut text = String::new();
+    for ch in message.chars() {
+        let ch = if ch.is_control() && ch != '\n' {
+            ' '
+        } else {
+            ch
+        };
+        if text.len() + ch.len_utf8() > MAX_ENTRY_BYTES - TRUNCATED.len() {
+            text.push_str(TRUNCATED);
+            return text;
+        }
+        text.push(ch);
+    }
+    text
+}
+
+fn clip(text: &str, width: u16) -> String {
+    if Line::raw(text).width() <= usize::from(width) {
+        return text.to_string();
+    }
+    let mut result = String::new();
+    let mut columns = 0;
+    for ch in text.chars() {
+        let next = columns + Line::raw(ch.to_string()).width();
+        if next + 1 > usize::from(width) {
+            break;
+        }
+        result.push(ch);
+        columns = next;
+    }
+    if width > 0 {
+        result.push('…');
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    fn render(activity: &Activity, width: u16, height: u16) -> String {
+        let mut term = Terminal::new(TestBackend::new(width, height)).unwrap();
+        term.draw(|frame| {
+            frame.render_widget(activity.paragraph(width, height), frame.area());
+        })
+        .unwrap();
+        term.backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect()
+    }
+
+    #[test]
+    fn history_has_exact_elapsed_times_and_non_color_statuses() {
+        let mut activity = Activity::default();
+        for (icon, seconds, message) in [
+            ('→', 0, "request"),
+            ('✓', 65, "reply"),
+            ('✗', 125, "error"),
+            ('!', 126, "warning"),
+            ('·', 127, "observation"),
+        ] {
+            activity.push_at(icon, message.into(), Duration::from_secs(seconds));
+        }
+        let text = render(&activity, 80, 8);
+        for expected in [
+            "[00:00] Requested request",
+            "[01:05] Completed reply",
+            "[02:05] Failed error",
+            "Warning warning",
+            "Info observation",
+        ] {
+            assert!(text.contains(expected), "missing {expected}: {text}");
+        }
+    }
+
+    #[test]
+    fn long_unicode_detail_is_bounded_and_truncation_is_visible() {
+        let mut activity = Activity::default();
+        activity.push('·', "界".repeat(5000));
+        assert!(activity[0].1.len() <= 4096);
+        assert!(activity[0].1.ends_with("[detail truncated]"));
+        let text = render(&activity, 60, 5);
+        assert!(
+            text.contains("[detail truncated]"),
+            "omission must be reachable: {text}"
+        );
+    }
+
+    #[test]
+    fn aggregate_detail_retention_reports_discarded_entries() {
+        let mut activity = Activity::default();
+        for _ in 0..200 {
+            activity.push('·', "x".repeat(3000));
+        }
+        assert!(activity.iter().map(|(_, text)| text.len()).sum::<usize>() <= 32 * 1024);
+        assert!(activity.len() < 200);
+        assert!(activity.discarded > 0);
+        assert!(activity
+            .retention()
+            .contains(&format!("{} older discarded", activity.discarded)));
+    }
+
+    #[test]
+    fn display_normalizes_terminal_controls_but_keeps_detail_lines() {
+        let mut activity = Activity::default();
+        activity.push('·', "before\u{1b}[31m\r\t\u{7}\nafter".into());
+        assert!(activity[0].1.contains("\nafter"));
+        assert!(!activity[0]
+            .1
+            .chars()
+            .any(|ch| ch.is_control() && ch != '\n'));
+    }
+
+    #[test]
+    fn reading_anchor_survives_new_entries_and_oldest_eviction() {
+        let mut activity = Activity::default();
+        for i in 0..200 {
+            activity.push('·', format!("entry-{i:03}"));
+        }
+        render(&activity, 60, 5);
+        activity.scroll(KeyCode::PageUp);
+        let before = render(&activity, 60, 5);
+        activity.push('✓', "latest".into());
+        assert_eq!(before, render(&activity, 60, 5));
+        activity.scroll(KeyCode::Home);
+        let before = render(&activity, 60, 5);
+        assert!(before.contains("entry-001"));
+        activity.push('✓', "another latest".into());
+        let after = render(&activity, 60, 5);
+        assert!(after.contains("entry-002"));
+        assert!(!after.contains("entry-001"));
+        assert!(activity.retention().contains("2 older discarded"));
+    }
+
+    #[test]
+    fn resizing_and_single_row_scrolling_reach_all_wrapped_detail() {
+        let mut activity = Activity::default();
+        activity.push('·', "START\n界 detail ".repeat(10) + "FINAL_SENTINEL");
+        render(&activity, 20, 3);
+        activity.scroll(KeyCode::Home);
+        let mut seen = String::new();
+        for _ in 0..120 {
+            seen.push_str(&render(&activity, 20, 3));
+            activity.scroll(KeyCode::Down);
+        }
+        assert!(seen.contains("START"));
+        assert!(seen.contains("FINAL_SENTINEL"));
+        assert!(activity.following());
+        assert!(render(&activity, 40, 4).contains("FINAL_SENTINEL"));
+    }
+
+    #[test]
+    fn reading_mid_entry_keeps_the_same_text_across_width_changes() {
+        let mut activity = Activity::default();
+        let message = (0..150).map(|n| format!("word{n:03} ")).collect::<String>();
+        activity.push('·', message);
+        render(&activity, 60, 4);
+        activity.scroll(KeyCode::Home);
+        render(&activity, 60, 4);
+        for _ in 0..7 {
+            activity.scroll(KeyCode::Down);
+            render(&activity, 60, 4);
+        }
+        let before = render(&activity, 60, 4);
+        let first_word = before.split_whitespace().next().unwrap();
+        let narrow = render(&activity, 24, 4);
+        assert!(
+            narrow[..24].contains(first_word),
+            "resizing must retain the first reading word {first_word}: {narrow}"
+        );
+        assert_eq!(
+            render(&activity, 60, 4),
+            before,
+            "resizing back must retain the original source position"
+        );
+        assert!(!activity.following());
+    }
+
+    #[test]
+    fn source_offsets_distinguish_repeats_combining_text_and_consumed_spaces() {
+        for (text, width, expected) in [
+            ("echo echo echo echo", 9, vec![0, 10]),
+            ("e\u{301}界 e\u{301}界 e\u{301}界", 7, vec![0, 14]),
+            ("word0     word1 word2", 10, vec![0, 10, 16]),
+            ("界a界b", 1, vec![3, 7]),
+        ] {
+            assert_eq!(wrapped_source_offsets(text, width), expected, "{text:?}");
+        }
+    }
+
+    #[test]
+    fn skipped_wide_grapheme_cannot_supply_a_later_ascii_anchor() {
+        assert_eq!(
+            wrapped_source_offsets("1\u{fe0f}\u{20e3}1x", 1),
+            vec![7, 8],
+            "the displayed ASCII 1 must not anchor inside the skipped keycap"
+        );
+    }
+
+    #[test]
+    fn newline_heavy_history_fits_the_scroll_type_at_one_column() {
+        let mut activity = Activity::default();
+        for _ in 0..200 {
+            activity.push('·', "\n".repeat(1000));
+        }
+        render(&activity, 1, 1);
+        assert!(activity.view.borrow().max_scroll < usize::from(u16::MAX));
+        activity.scroll(KeyCode::Home);
+        assert_eq!(activity.view.borrow().scroll, 0);
+        activity.scroll(KeyCode::End);
+        render(&activity, 1, 1);
+        assert_eq!(
+            activity.view.borrow().scroll,
+            activity.view.borrow().max_scroll
+        );
+    }
+
+    #[test]
+    fn summary_discloses_multiline_and_width_truncation() {
+        let mut activity = Activity::default();
+        activity.push('·', "first\nsecond".into());
+        assert!(activity.summary(0, 80).ends_with('…'));
+        let summary = activity.summary(0, 10);
+        assert!(Line::raw(&summary).width() <= 10);
+        assert!(summary.ends_with('…'));
+    }
+}

--- a/crates/irlume-cli/src/tui/freshness.rs
+++ b/crates/irlume-cli/src/tui/freshness.rs
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! Observation age and bounded refresh generations, independent of I/O and UI.
+
+use std::time::{Duration, Instant};
+
+#[derive(Clone, Copy, Debug)]
+pub(super) enum Source {
+    Live,
+    Health,
+    Preferences,
+    Wallet,
+    Recovery,
+    Profiles,
+    Cameras,
+    CameraPrivacy,
+    Qualification,
+    Machine,
+    FingerprintReader,
+    Fingerprint,
+    Apps,
+}
+
+impl Source {
+    pub const ALL: [Self; 13] = [
+        Self::Live,
+        Self::Health,
+        Self::Preferences,
+        Self::Wallet,
+        Self::Recovery,
+        Self::Profiles,
+        Self::Cameras,
+        Self::CameraPrivacy,
+        Self::Qualification,
+        Self::Machine,
+        Self::FingerprintReader,
+        Self::Fingerprint,
+        Self::Apps,
+    ];
+
+    pub fn max_age(self) -> Duration {
+        Duration::from_secs(match self {
+            Self::Live => 4,
+            Self::Health
+            | Self::Preferences
+            | Self::Wallet
+            | Self::Recovery
+            | Self::CameraPrivacy => 20,
+            Self::Profiles => 60,
+            Self::Machine | Self::FingerprintReader | Self::Fingerprint => 30,
+            Self::Apps => 10,
+            // Classification is bound to a still-current passive inventory
+            // epoch; qualification is an explicitly historical observation.
+            Self::Cameras | Self::Qualification => u64::MAX,
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) enum Worker {
+    Live,
+    Light,
+    Profiles,
+    Cameras,
+    Qualification,
+    Machine,
+    Apps,
+}
+
+#[derive(Default)]
+pub(super) struct Freshness {
+    observations: [Observation; 13],
+    cycles: [RefreshCycle; 7],
+}
+
+impl Freshness {
+    pub fn observation(&self, source: Source) -> Observation {
+        self.observations[source as usize]
+    }
+    pub fn observation_mut(&mut self, source: Source) -> &mut Observation {
+        &mut self.observations[source as usize]
+    }
+    pub fn cycle(&self, worker: Worker) -> RefreshCycle {
+        self.cycles[worker as usize]
+    }
+    pub fn cycle_mut(&mut self, worker: Worker) -> &mut RefreshCycle {
+        &mut self.cycles[worker as usize]
+    }
+    pub fn usable(&self, source: Source, now: Instant) -> bool {
+        self.observation(source).usable(now, source.max_age())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub(super) struct Observation {
+    pub last_success: Option<Instant>,
+    unavailable: bool,
+}
+
+impl Observation {
+    pub fn record(&mut self, success: bool, at: Instant) {
+        self.unavailable = !success;
+        if success {
+            self.last_success = Some(at);
+        }
+    }
+
+    pub fn invalidate(&mut self) {
+        self.unavailable = true;
+    }
+
+    pub fn usable(self, now: Instant, max_age: Duration) -> bool {
+        !self.unavailable
+            && self
+                .last_success
+                .is_some_and(|at| now.saturating_duration_since(at) <= max_age)
+    }
+
+    pub fn describe(self, now: Instant, max_age: Duration, loading: bool) -> String {
+        match (self.last_success, self.usable(now, max_age)) {
+            (Some(at), true) => format!(
+                "checked {}s ago",
+                now.saturating_duration_since(at).as_secs()
+            ),
+            (Some(at), false) => format!(
+                "unavailable; last successful check {}s ago{}",
+                now.saturating_duration_since(at).as_secs(),
+                if loading { "; updating" } else { "" }
+            ),
+            (None, _) if loading => "checking…".into(),
+            (None, _) => "unavailable; not observed".into(),
+        }
+    }
+}
+
+/// One receiver at a time. Only explicit invalidation queues a replacement;
+/// an ordinary timer tick can never starve a slow worker by changing its epoch.
+#[derive(Clone, Copy, Debug, Default)]
+pub(super) struct RefreshCycle {
+    generation: u64,
+    running: Option<u64>,
+    pending: bool,
+    pub completed: Option<Instant>,
+}
+
+impl RefreshCycle {
+    pub fn begin(&mut self) -> bool {
+        if self.running.is_some() {
+            return false;
+        }
+        self.running = Some(self.generation);
+        self.pending = false;
+        true
+    }
+
+    pub fn invalidate(&mut self) {
+        self.generation = self.generation.wrapping_add(1);
+        self.pending = true;
+    }
+
+    pub fn finish(&mut self, now: Instant) -> bool {
+        self.completed = Some(now);
+        // Synthetic receiver fixtures can omit begin; production cannot.
+        let observed = self.running.take().unwrap_or(self.generation);
+        let current = observed == self.generation;
+        if !current {
+            self.pending = true;
+        }
+        current
+    }
+
+    pub fn due(self, now: Instant, interval: Duration) -> bool {
+        self.running.is_none()
+            && (self.pending
+                || self
+                    .completed
+                    .is_none_or(|at| now.saturating_duration_since(at) >= interval))
+    }
+
+    pub fn pending(self) -> bool {
+        self.pending && self.running.is_none()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn successful_observation_expires_even_without_new_input() {
+        let now = Instant::now();
+        let mut state = Observation::default();
+        assert!(!state.usable(now, Duration::from_secs(4)));
+        state.record(true, now);
+        assert!(state.usable(now + Duration::from_secs(3), Duration::from_secs(4)));
+        assert!(!state.usable(now + Duration::from_secs(5), Duration::from_secs(4)));
+        assert!(state
+            .describe(now + Duration::from_secs(5), Duration::from_secs(4), false)
+            .contains("unavailable"));
+    }
+
+    #[test]
+    fn failure_does_not_refresh_success_age_and_recovery_is_explicit() {
+        let now = Instant::now();
+        let mut state = Observation::default();
+        state.record(true, now);
+        state.record(false, now + Duration::from_secs(1));
+        assert_eq!(state.last_success, Some(now));
+        assert!(!state.usable(now + Duration::from_secs(2), Duration::from_secs(30)));
+        state.record(true, now + Duration::from_secs(3));
+        assert!(state.usable(now + Duration::from_secs(3), Duration::from_secs(30)));
+    }
+
+    #[test]
+    fn invalidated_worker_cannot_publish_and_gets_one_replacement() {
+        let now = Instant::now();
+        let mut cycle = RefreshCycle::default();
+        assert!(cycle.begin());
+        cycle.invalidate();
+        cycle.invalidate();
+        assert!(!cycle.begin());
+        assert!(!cycle.finish(now));
+        assert!(cycle.pending());
+        assert!(cycle.begin());
+        assert!(!cycle.pending());
+        assert!(!cycle.begin());
+        assert!(cycle.finish(now));
+        assert!(!cycle.pending());
+    }
+
+    #[test]
+    fn timer_checks_do_not_invalidate_or_duplicate_slow_work() {
+        let now = Instant::now();
+        let mut cycle = RefreshCycle::default();
+        assert!(cycle.begin());
+        for seconds in 0..60 {
+            assert!(!cycle.due(now + Duration::from_secs(seconds), Duration::from_secs(1)));
+            assert!(!cycle.begin());
+        }
+        assert!(cycle.finish(now + Duration::from_secs(60)));
+        assert!(!cycle.due(now + Duration::from_secs(89), Duration::from_secs(30)));
+        assert!(cycle.due(now + Duration::from_secs(90), Duration::from_secs(30)));
+    }
+}

--- a/crates/irlume-cli/src/tui/live_tests.rs
+++ b/crates/irlume-cli/src/tui/live_tests.rs
@@ -1,0 +1,602 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Synthetic observation, generation, and selection regressions. No I/O.
+
+fn live_test_snapshot() -> irlume_common::live::LiveStatusSnapshot {
+    serde_json::from_value(serde_json::json!({
+        "live_schema":1, "daemon_instance":"11111111111111111111111111111111",
+        "daemon_uptime_ms":60000, "state_revision":0, "stage":"ready",
+        "worker":null, "background":[], "waiting":[], "tracking_available":true,
+        "cameras":{"state":"current", "supervisor_id":"22222222222222222222222222222222",
+            "revision":1, "observed_ago_ms":3600000, "reason":null,
+            "candidates":[{"instance_id":"33333333333333333333333333333333",
+                "generation":1,"endpoint_paths":["/dev/video40","/dev/video42"]}]}
+    }))
+    .unwrap()
+}
+
+fn live_test_health() -> HealthInfo {
+    HealthInfo {
+        tier: "secure".into(),
+        rgb_dev: Some("/dev/video40".into()),
+        ir_dev: Some("/dev/video42".into()),
+        mesh: true,
+        adapter: false,
+        rgb_pad: Some(irlume_common::PadModelStatus::Loaded),
+        ir_pad: Some(irlume_common::PadModelStatus::Loaded),
+        version: env!("CARGO_PKG_VERSION").into(),
+        apparmor: None,
+    }
+}
+
+fn live_test_app() -> App {
+    let mut app = test_app();
+    let now = Instant::now();
+    app.clock_override = Some(now);
+    app.mark_fixture_observations_fresh(now);
+    app.health = Some(live_test_health());
+    app.apply_live_snapshot(live_test_snapshot(), now);
+    app
+}
+
+fn live_test_pair() -> irlume_common::CameraPairInfo {
+    irlume_common::CameraPairInfo {
+        rgb: "/dev/video40".into(),
+        ir: "/dev/video42".into(),
+        id: None,
+        fixed: false,
+        privacy: false,
+    }
+}
+
+fn live_test_land_profiles(app: &mut App, profiles: Vec<ProfileSummary>) {
+    let (tx, rx) = mpsc::channel();
+    app.profiles_load = Some(rx);
+    tx.send(ProfilesOutcome::Loaded { profiles }).unwrap();
+    app.poll();
+}
+
+fn live_test_land_cameras(app: &mut App) {
+    let (tx, rx) = mpsc::channel();
+    app.camera_load = Some(rx);
+    tx.send(CameraListing {
+        pairs: Some(vec![live_test_pair()]),
+    })
+    .unwrap();
+    app.poll();
+}
+
+#[test]
+fn live_freshness_partial_status_failure_cannot_borrow_sibling_success() {
+    let mut app = live_test_app();
+    let before = app.now();
+    app.recovery = Some(RecoveryInfo {
+        encrypted: true,
+        recovery_set: true,
+        tpm_present: true,
+        key_present: true,
+    });
+    app.profiles_loaded = true;
+    app.clock_override = Some(before + Duration::from_secs(2));
+    app.apply_light(LightState {
+        observed_at: [Some(app.now()), None, None, None],
+        daemon_up: true,
+        reach: crate::commands::DaemonReach::Running,
+        health: Some(live_test_health()),
+        preferences: None,
+        keyring_armed: None,
+        keyring_policy: None,
+        keyring_kind: None,
+        recovery: None,
+    });
+    assert!(app.source_usable(Source::Health));
+    assert!(!app.source_usable(Source::Recovery));
+    assert!(app.recovery.is_none());
+    assert_eq!(
+        app.freshness.observation(Source::Recovery).last_success,
+        Some(before)
+    );
+    assert!(app
+        .source_status(Source::Recovery)
+        .contains("last successful check 2s ago"));
+    assert!(app.profiles_load.is_none());
+}
+
+#[test]
+fn live_freshness_profile_identity_survives_invalidation_and_reorder() {
+    let mut app = live_test_app();
+    app.profiles = vec![profile("Alice", &["a"]), profile("Bob", &["b"])];
+    app.sel = 3; // Bob's scan, not its numeric position after the next load.
+    app.invalidate_source(Source::Profiles);
+    assert!(app.profiles.is_empty());
+    live_test_land_profiles(
+        &mut app,
+        vec![profile("Bob", &["b"]), profile("Alice", &["a"])],
+    );
+    assert_eq!(
+        app.selected_profile_row(),
+        Some(("Bob".into(), Some("b".into())))
+    );
+    app.invalidate_source(Source::Profiles);
+    live_test_land_profiles(&mut app, vec![profile("Alice", &["a"])]);
+    assert!(
+        app.selected_profile_row().is_none(),
+        "removed identity must not select a different scan"
+    );
+}
+
+#[test]
+fn live_freshness_old_profile_result_is_discarded_with_one_pending_replacement() {
+    let mut app = live_test_app();
+    assert!(app.freshness.cycle_mut(Worker::Profiles).begin());
+    app.invalidate_daemon_observations();
+    live_test_land_profiles(&mut app, vec![profile("old", &["old"])]);
+    assert!(app.profiles.is_empty());
+    assert!(app.freshness.cycle(Worker::Profiles).pending());
+    assert!(app.freshness.cycle_mut(Worker::Profiles).begin());
+    assert!(!app.freshness.cycle_mut(Worker::Profiles).begin());
+    live_test_land_profiles(&mut app, vec![profile("new", &["new"])]);
+    assert_eq!(app.profiles[0].name, "new");
+    assert!(!app.freshness.cycle(Worker::Profiles).pending());
+}
+
+#[test]
+fn live_freshness_profile_timer_is_visible_idle_and_completion_bounded() {
+    let mut app = live_test_app();
+    let now = app.now();
+    app.screen = SC_PROFILES;
+    app.freshness.cycle_mut(Worker::Profiles).begin();
+    app.freshness.cycle_mut(Worker::Profiles).finish(now);
+    assert!(!app.profiles_refresh_due(now + Duration::from_secs(29), true));
+    assert!(app.profiles_refresh_due(now + Duration::from_secs(30), true));
+    assert!(!app.profiles_refresh_due(now + Duration::from_secs(30), false));
+    for screen in [SC_WELCOME, SC_REPAIR, SC_DONE] {
+        app.screen = screen;
+        assert!(app.profiles_refresh_due(now + Duration::from_secs(61), true));
+    }
+    app.screen = SC_SETTINGS;
+    assert!(!app.profiles_refresh_due(now + Duration::from_secs(90), true));
+    app.screen = SC_PROFILES;
+    let (_sender, op) = fake_op();
+    app.op = Some(op);
+    assert!(!app.profiles_refresh_due(now + Duration::from_secs(90), true));
+}
+
+#[test]
+fn live_freshness_fingerprint_list_failure_is_unknown_not_zero_enrollment() {
+    let mut app = live_test_app();
+    app.screen = SC_FINGERPRINT;
+    let (tx, rx) = mpsc::channel();
+    app.probes_load = Some(rx);
+    tx.send(Probes {
+        fp_present: Some(true),
+        fp_enrollment_observed: false,
+        fp: FpInfo {
+            available: true,
+            device: Some("Synthetic reader".into()),
+            enrolled: vec![],
+            method: "fingerprint".into(),
+        },
+        ..Probes::default()
+    })
+    .unwrap();
+    app.poll();
+    assert!(app.source_usable(Source::FingerprintReader));
+    assert!(!app.source_usable(Source::Fingerprint));
+    let text = draw_text(&app);
+    assert!(
+        text.contains("enrollment observation unavailable"),
+        "{text}"
+    );
+    assert!(!app
+        .repair
+        .iter()
+        .any(|check| check.detail.contains("no finger is enrolled")));
+    assert_eq!(
+        app.hub_rows()
+            .iter()
+            .find(|(_, _, screen)| *screen == SC_FINGERPRINT)
+            .map(|(_, state, _)| *state),
+        Some(None)
+    );
+}
+
+#[test]
+fn live_freshness_expiry_and_tracking_failure_never_claim_idle_or_camera_ready() {
+    let mut app = live_test_app();
+    assert!(app.live_summary().contains("worker idle"));
+    assert!(app.caps.ir_pair);
+    let mut live = live_test_snapshot();
+    live.tracking_available = false;
+    app.apply_live_snapshot(live, app.now());
+    assert!(!app.live_summary().contains("idle"));
+    assert!(app.live_summary().contains("unavailable"));
+    app.clock_override = Some(app.now() + Duration::from_secs(5));
+    app.expire_observations(app.now());
+    assert!(app.current_inventory().is_none());
+    assert!(!app.caps.rgb && !app.caps.ir_pair);
+    assert!(!app.live_summary().contains("idle"));
+}
+
+#[test]
+fn live_freshness_background_qualification_is_separate_from_worker_idle() {
+    let mut app = live_test_app();
+    let mut live = live_test_snapshot();
+    live.background.push(
+        serde_json::from_value(serde_json::json!({
+            "operation_id":"44444444444444444444444444444444", "kind":"capture_qualification",
+            "elapsed_ms":2300,"cancellation_requested":false
+        }))
+        .unwrap(),
+    );
+    app.apply_live_snapshot(live, app.now());
+    assert!(!app.live_summary().contains("idle"));
+    let details = app.live_details();
+    assert!(
+        details.contains("Background: capture qualification · 2s"),
+        "{details}"
+    );
+}
+
+#[test]
+fn live_freshness_same_inventory_keeps_roles_despite_old_publication_age() {
+    let mut app = live_test_app();
+    live_test_land_cameras(&mut app);
+    app.classified_epoch = app.camera_epoch.clone();
+    let epoch = app.classified_epoch.clone();
+    app.apply_live_snapshot(live_test_snapshot(), app.now());
+    assert!(
+        app.current_inventory().is_some(),
+        "stable supervisor publication age is not RPC age"
+    );
+    assert!(app.source_usable(Source::Cameras));
+    assert_eq!(app.classified_epoch, epoch);
+    assert_eq!(app.pairs.len(), 1);
+}
+
+#[test]
+fn live_freshness_path_reuse_does_not_retarget_camera_selection() {
+    let mut app = live_test_app();
+    live_test_land_cameras(&mut app);
+    app.cam_sel = 0;
+    let mut replaced = live_test_snapshot();
+    replaced.cameras.revision = 2;
+    replaced.cameras.candidates[0].generation = 2;
+    replaced.cameras.candidates[0].instance_id = "55555555555555555555555555555555".into();
+    app.apply_live_snapshot(replaced, app.now());
+    assert!(app.pairs.is_empty());
+    live_test_land_cameras(&mut app);
+    assert!(
+        app.pairs.get(app.cam_sel).is_none(),
+        "same endpoint names with a new instance are a different camera"
+    );
+}
+
+#[test]
+fn live_freshness_inventory_loss_clears_pending_camera_confirmation() {
+    let mut app = live_test_app();
+    live_test_land_cameras(&mut app);
+    app.screen = SC_CAMERAS;
+    app.cam_sel = 0;
+    app.on_key(KeyCode::Enter);
+    assert!(app.confirm.is_some());
+    assert!(app.camera_confirmation.is_some());
+    app.clock_override = Some(app.now() + Duration::from_secs(5));
+    app.expire_observations(app.now());
+    assert!(app.confirm.is_none());
+    assert!(app.camera_confirmation.is_none());
+    assert!(app.suspend.is_none());
+    assert!(!app.caps.rgb);
+}
+
+#[test]
+fn live_freshness_unclassified_candidate_is_visible_at_40_by_12() {
+    let mut app = live_test_app();
+    app.screen = SC_CAMERAS;
+    let mut terminal = Terminal::new(TestBackend::new(40, 12)).unwrap();
+    terminal.draw(|frame| app.draw(frame)).unwrap();
+    let text = rendered(&terminal);
+    assert!(text.contains("Attached; inspect roles"), "{text}");
+    assert!(!text.contains("No UVC candidates"), "{text}");
+}
+
+#[test]
+fn live_freshness_f4_click_owns_its_hit_region_during_an_operation() {
+    let mut app = live_test_app();
+    let (_sender, op) = fake_op();
+    app.op = Some(op);
+    let mut terminal = Terminal::new(TestBackend::new(80, 24)).unwrap();
+    terminal.draw(|frame| app.draw(frame)).unwrap();
+    let rect = app
+        .click_targets
+        .borrow()
+        .iter()
+        .find_map(|(rect, click)| matches!(click, Click::Key(KeyCode::F(4))).then_some(*rect))
+        .unwrap();
+    app.on_click(rect.x, rect.y, Rect::new(0, 0, 80, 24));
+    assert!(app.show_live);
+    assert!(!app.activity_open);
+    assert!(app.op.is_some());
+    app.on_key(KeyCode::Esc);
+    assert!(!app.show_live);
+    assert!(app.op.is_some());
+}
+
+#[test]
+fn live_freshness_a_later_confirmation_owns_input_over_f4() {
+    let mut app = live_test_app();
+    app.on_key(KeyCode::F(4));
+    app.confirm = Some((
+        "Synthetic confirmation".into(),
+        "Inspect",
+        ConfirmAct::CameraQualification,
+    ));
+    assert!(!app.live_overlay_visible());
+    app.on_key(KeyCode::Esc);
+    assert!(
+        app.confirm.is_none(),
+        "Esc dismisses the visible confirmation, not the obscured F4 overlay"
+    );
+    assert!(app.show_live);
+    assert!(app.qualification_load.is_none());
+}
+
+#[test]
+fn live_freshness_starting_and_unknown_replies_are_not_described_as_no_response() {
+    for stage in [
+        irlume_common::live::LiveStage::Starting,
+        irlume_common::live::LiveStage::Unknown,
+    ] {
+        let mut app = live_test_app();
+        let mut snapshot = live_test_snapshot();
+        snapshot.stage = stage;
+        app.apply_live_snapshot(snapshot, app.now());
+        app.screen = SC_WELCOME;
+        let text = draw_text(&app);
+        assert!(text.contains("daemon responded"), "{text}");
+        assert!(!text.contains("service is not responding"), "{text}");
+    }
+}
+
+#[test]
+fn live_freshness_done_cannot_claim_all_set_after_live_expiry() {
+    let mut app = live_test_app();
+    app.screen = SC_DONE;
+    app.profiles_loaded = true;
+    app.profiles = vec![profile("Alice", &["a"])];
+    app.probes_landed = true;
+    app.probes.login_wired = true;
+    assert!(draw_text(&app).contains("All set"));
+    app.clock_override = Some(app.now() + Duration::from_secs(5));
+    app.expire_observations(app.now());
+    app.screen = SC_DONE;
+    let text = draw_text(&app);
+    assert!(!text.contains("All set"), "{text}");
+    assert!(text.contains("readiness unavailable"), "{text}");
+}
+
+#[test]
+fn live_freshness_known_uvc_history_is_bounded_to_configured_endpoints() {
+    let mut app = live_test_app();
+    for revision in 2..50 {
+        let mut snapshot = live_test_snapshot();
+        snapshot.cameras.revision = revision;
+        snapshot.cameras.candidates[0]
+            .endpoint_paths
+            .push(format!("/dev/video{}", 100 + revision));
+        app.apply_live_snapshot(snapshot, app.now());
+    }
+    assert!(app.known_uvc_paths.len() <= 2);
+    assert!(app.known_uvc_paths.contains(&"/dev/video40".into()));
+}
+
+#[test]
+fn live_freshness_capture_qualification_is_a_separate_explicit_request() {
+    use std::io::{BufRead, Write};
+    let _guard = dead_socket();
+    let socket = std::env::temp_dir().join(format!(
+        "irlume-qualification-fixture-{}.sock",
+        std::process::id()
+    ));
+    let listener = std::os::unix::net::UnixListener::bind(&socket).unwrap();
+    listener.set_nonblocking(true).unwrap();
+    std::env::set_var("IRLUME_SOCKET", &socket);
+    let server = std::thread::spawn(move || {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let mut stream = loop {
+            match listener.accept() {
+                Ok((stream, _)) => break stream,
+                Err(error)
+                    if error.kind() == std::io::ErrorKind::WouldBlock
+                        && Instant::now() < deadline =>
+                {
+                    std::thread::sleep(Duration::from_millis(5))
+                }
+                Err(error) => panic!("qualification fixture accept did not finish: {error}"),
+            }
+        };
+        stream
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .unwrap();
+        let mut line = String::new();
+        std::io::BufReader::new(&stream)
+            .read_line(&mut line)
+            .unwrap();
+        let request: Request = serde_json::from_str(&line).unwrap();
+        writeln!(
+            stream,
+            "{}",
+            serde_json::to_string(&Response::Error("fixture: unavailable".into())).unwrap()
+        )
+        .unwrap();
+        request
+    });
+    let mut app = live_test_app();
+    app.screen = SC_CAMERAS;
+    app.on_key(KeyCode::Char('c'));
+    assert!(app.confirm.is_some());
+    assert!(
+        app.qualification_load.is_none(),
+        "disclosure must precede the request"
+    );
+    app.on_key(KeyCode::Char('y'));
+    let request = server.join().unwrap();
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while app.qualification_load.is_some() && Instant::now() < deadline {
+        app.poll();
+        std::thread::sleep(Duration::from_millis(5));
+    }
+    std::fs::remove_file(socket).unwrap();
+    assert!(matches!(request, Request::CaptureModeStatus));
+    assert!(app.qualification_load.is_none());
+    assert!(app.camera_load.is_none());
+    assert!(!app.source_usable(Source::Qualification));
+}
+
+#[test]
+fn live_freshness_unavailable_tracking_does_not_present_background_as_current() {
+    let mut app = live_test_app();
+    let mut snapshot = live_test_snapshot();
+    snapshot.tracking_available = false;
+    snapshot.background.push(
+        serde_json::from_value(serde_json::json!({
+            "operation_id":"44444444444444444444444444444444", "kind":"capture_qualification",
+            "elapsed_ms":2300,"cancellation_requested":false
+        }))
+        .unwrap(),
+    );
+    app.apply_live_snapshot(snapshot, app.now());
+    let text = app.live_details();
+    assert!(text.contains("activity unavailable"), "{text}");
+    assert!(
+        !text.contains("Background:"),
+        "unavailable metadata cannot look current: {text}"
+    );
+}
+
+#[test]
+fn live_freshness_open_camera_page_survives_removal_and_unavailability() {
+    let mut app = live_test_app();
+    app.screen = SC_CAMERAS;
+    let mut snapshot = live_test_snapshot();
+    snapshot.cameras.revision = 2;
+    snapshot.cameras.candidates.clear();
+    app.apply_live_snapshot(snapshot, app.now());
+    assert_eq!(app.screen, SC_CAMERAS);
+    assert!(draw_text(&app).contains("No UVC candidates"));
+    app.invalidate_source(Source::Live);
+    app.expire_observations(app.now());
+    app.recompute_visible();
+    assert_eq!(app.screen, SC_CAMERAS);
+    assert!(draw_text(&app).contains("Current camera inventory unavailable"));
+    assert!(app.camera_load.is_none() && app.qualification_load.is_none());
+}
+
+#[test]
+fn live_freshness_unknown_reader_cannot_start_enrollment_or_claim_absence() {
+    let mut app = live_test_app();
+    app.screen = SC_FINGERPRINT;
+    app.fp.available = true;
+    app.invalidate_source(Source::FingerprintReader);
+    for key in ['a', 't'] {
+        app.on_key(KeyCode::Char(key));
+        assert!(app.suspend.is_none());
+        let (_, message) = app.activity.last().unwrap();
+        assert!(message.contains("observation unavailable"));
+        assert!(!message.contains("no fingerprint reader"));
+    }
+}
+
+#[test]
+fn live_freshness_manual_camera_refresh_preserves_identity_and_queues_one_replacement() {
+    let mut app = live_test_app();
+    let mut snapshot = live_test_snapshot();
+    snapshot.cameras.revision = 2;
+    let mut candidate = snapshot.cameras.candidates[0].clone();
+    candidate.instance_id = "66666666666666666666666666666666".into();
+    candidate.endpoint_paths = vec!["/dev/video60".into(), "/dev/video62".into()];
+    snapshot.cameras.candidates.push(candidate);
+    app.apply_live_snapshot(snapshot, app.now());
+    let second = irlume_common::CameraPairInfo {
+        rgb: "/dev/video60".into(),
+        ir: "/dev/video62".into(),
+        id: None,
+        fixed: false,
+        privacy: false,
+    };
+    app.pairs = vec![live_test_pair(), second.clone()];
+    app.cam_sel = 1;
+    app.screen = SC_CAMERAS;
+    app.classified_epoch = app.camera_epoch.clone();
+    app.freshness.cycle_mut(Worker::Cameras).begin();
+    let (old_sender, old_receiver) = mpsc::channel();
+    app.camera_load = Some(old_receiver); // prevents any I/O from the manual key
+    app.on_key(KeyCode::Char('r'));
+    assert!(app.pairs.is_empty());
+    old_sender
+        .send(CameraListing {
+            pairs: Some(vec![live_test_pair(), second.clone()]),
+        })
+        .unwrap();
+    app.poll();
+    assert!(app.pairs.is_empty(), "pre-refresh listing cannot publish");
+    assert!(
+        app.cameras_refresh_due(true),
+        "one requested replacement remains due even at the same inventory epoch"
+    );
+    assert!(app.freshness.cycle_mut(Worker::Cameras).begin());
+    assert!(!app.freshness.cycle_mut(Worker::Cameras).begin());
+    let (sender, receiver) = mpsc::channel();
+    app.camera_load = Some(receiver);
+    sender
+        .send(CameraListing {
+            pairs: Some(vec![second, live_test_pair()]),
+        })
+        .unwrap();
+    app.poll();
+    assert_eq!(app.pairs[app.cam_sel].rgb, "/dev/video60");
+    assert!(!app.cameras_refresh_due(true));
+}
+
+#[test]
+fn live_freshness_observed_empty_camera_selection_stays_clear_through_failure_and_replacement() {
+    let mut app = live_test_app();
+    live_test_land_cameras(&mut app);
+    let (sender, receiver) = mpsc::channel();
+    app.camera_load = Some(receiver);
+    sender
+        .send(CameraListing {
+            pairs: Some(vec![]),
+        })
+        .unwrap();
+    app.poll();
+    assert!(app.pairs_known && app.pairs.is_empty());
+    let (sender, receiver) = mpsc::channel();
+    app.camera_load = Some(receiver);
+    sender.send(CameraListing { pairs: None }).unwrap();
+    app.poll();
+    assert!(!app.pairs_known);
+    let mut snapshot = live_test_snapshot();
+    snapshot.cameras.revision = 2;
+    snapshot.cameras.candidates[0].instance_id = "77777777777777777777777777777777".into();
+    app.apply_live_snapshot(snapshot, app.now());
+    live_test_land_cameras(&mut app);
+    assert_eq!(app.pairs.len(), 1);
+    assert!(
+        app.pairs.get(app.cam_sel).is_none(),
+        "an observed empty selection cannot silently select a replacement camera"
+    );
+}
+
+#[test]
+fn live_freshness_observed_empty_profiles_do_not_select_a_new_person() {
+    let mut app = live_test_app();
+    live_test_land_profiles(&mut app, vec![profile("Alice", &["a"])]);
+    live_test_land_profiles(&mut app, vec![]);
+    assert!(app.profiles_loaded && app.profiles.is_empty());
+    app.invalidate_source(Source::Profiles);
+    live_test_land_profiles(&mut app, vec![profile("Bob", &["b"])]);
+    assert!(
+        app.selected_profile_row().is_none(),
+        "an empty prior selection cannot become another person"
+    );
+}

--- a/crates/irlume-cli/src/tui/visual_tests.rs
+++ b/crates/irlume-cli/src/tui/visual_tests.rs
@@ -1,0 +1,608 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Included inside tui::tests. Only synthetic state and TestBackend rendering:
+// never App::new, poll, enter_screen, or an operation/command dispatch.
+
+fn visual_fixture(screen: usize) -> App {
+    let mut app = test_app();
+    app.user = "synthetic-sample".into();
+    app.screen = screen;
+    app.advanced = true;
+    app.visible = (0..SCREENS.len()).collect();
+    app.caps = irlume_camera::Caps {
+        ir_pair: true,
+        rgb: true,
+    };
+    app.reported_caps = app.caps;
+    let now = Instant::now();
+    app.clock_override = Some(now);
+    let live = visual_live_snapshot("ready", true);
+    app.live_epoch = Some((live.daemon_instance, live.state_revision));
+    app.camera_epoch = Some(CameraEpoch {
+        supervisor: live.cameras.supervisor_id.clone().unwrap(),
+        revision: live.cameras.revision,
+    });
+    app.known_uvc_paths = vec!["/dev/video40".into(), "/dev/video42".into()];
+    app.live = Some(live);
+    app.daemon_up = true;
+    app.daemon_reach = crate::commands::DaemonReach::Running;
+    app.profiles_loaded = true;
+    app.profiles = vec![
+        profile(
+            "Synthetic daily profile",
+            &["sample-front", "sample-glasses", "sample-side"],
+        ),
+        profile("Synthetic alternate profile", &["sample-front"]),
+    ];
+    app.probes_landed = true;
+    app.preferences = Some(preference_fixture(true));
+    app.health = Some(HealthInfo {
+        tier: "secure".into(),
+        rgb_dev: Some("/dev/video40".into()),
+        ir_dev: Some("/dev/video42".into()),
+        mesh: true,
+        adapter: false,
+        rgb_pad: Some(irlume_common::PadModelStatus::Loaded),
+        ir_pad: Some(irlume_common::PadModelStatus::Loaded),
+        version: "synthetic fixture".into(),
+        apparmor: None,
+    });
+    app.fp_present = true;
+    app.fp = FpInfo {
+        available: true,
+        device: Some("Synthetic reader".into()),
+        enrolled: vec!["right-index-finger".into()],
+        method: "face".into(),
+    };
+    app.keyring_armed = Some(true);
+    app.recovery = Some(RecoveryInfo {
+        encrypted: true,
+        recovery_set: false,
+        tpm_present: true,
+        key_present: true,
+    });
+    app.repair = vec![
+        Check {
+            label: "Synthetic daemon status".into(),
+            sev: Sev::Ok,
+            detail: "Fixture state only; no daemon was contacted".into(),
+            fix: Fix::None,
+        },
+        Check {
+            label: "Synthetic recovery reminder".into(),
+            sev: Sev::Warn,
+            detail: "Sample warning with enough text to exercise a narrow layout".into(),
+            fix: Fix::None,
+        },
+    ];
+    for index in 0..24 {
+        app.log(
+            '·',
+            format!("Synthetic sample event {index:02}: no operation was performed"),
+        );
+    }
+    app.log('!', "Synthetic long activity entry: this is deliberately longer than one terminal row. It represents a sample explanation that should wrap and remain readable in session history; it contains no hardware observation or real-user information.");
+    app.log(
+        '✓',
+        "Synthetic latest result: fixture rendering completed; no authentication attempted",
+    );
+    app.mark_fixture_observations_fresh(now);
+    app
+}
+
+fn visual_assert_no_work(app: &App) {
+    visual_assert_expected_work(app, None);
+}
+
+fn visual_assert_expected_work(app: &App, synthetic_op: Option<&str>) {
+    visual_assert_expected_state(app, synthetic_op, None);
+}
+
+fn visual_assert_expected_state(
+    app: &App,
+    synthetic_op: Option<&str>,
+    synthetic_enroll: Option<&str>,
+) {
+    assert_eq!(app.op.as_ref().map(|op| op.label.as_str()), synthetic_op);
+    assert_eq!(
+        app.enroll.as_ref().map(|enroll| enroll.profile.as_str()),
+        synthetic_enroll
+    );
+    assert!(app.suspend.is_none());
+    assert!(
+        app.live_load.is_none()
+            && app.qualification_load.is_none()
+            && app.light_load.is_none()
+            && app.probes_load.is_none()
+            && app.profiles_load.is_none()
+            && app.camera_load.is_none()
+            && app.heavy_load.is_none()
+            && app.keyring_load.is_none()
+    );
+}
+
+fn visual_frame(app: &App, label: &str, width: u16, height: u16) -> serde_json::Value {
+    visual_frame_with_op(app, label, width, height, None)
+}
+
+fn visual_frame_with_op(
+    app: &App,
+    label: &str,
+    width: u16,
+    height: u16,
+    synthetic_op: Option<&str>,
+) -> serde_json::Value {
+    visual_frame_with_state(app, label, width, height, synthetic_op, None)
+}
+
+fn visual_frame_with_state(
+    app: &App,
+    label: &str,
+    width: u16,
+    height: u16,
+    synthetic_op: Option<&str>,
+    synthetic_enroll: Option<&str>,
+) -> serde_json::Value {
+    visual_assert_expected_state(app, synthetic_op, synthetic_enroll);
+    let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+    terminal.draw(|frame| app.draw_window(frame)).unwrap();
+    visual_assert_expected_state(app, synthetic_op, synthetic_enroll);
+    let buffer = terminal.backend().buffer();
+    assert_eq!(buffer.area, Rect::new(0, 0, width, height));
+    assert_eq!(
+        buffer.content.len(),
+        usize::from(width) * usize::from(height)
+    );
+    assert!(
+        buffer
+            .content
+            .iter()
+            .any(|cell| !cell.symbol().trim().is_empty()),
+        "blank {label}"
+    );
+    for (target, _) in app.click_targets.borrow().iter() {
+        if !target.is_empty() {
+            assert!(
+                target.x < width
+                    && target.y < height
+                    && target.right() <= width
+                    && target.bottom() <= height,
+                "{label} {width}x{height}: click target {target:?} exceeds frame"
+            );
+        }
+    }
+    let mut styles = Vec::<serde_json::Value>::new();
+    let mut cells = Vec::with_capacity(buffer.content.len());
+    for cell in &buffer.content {
+        let style = serde_json::json!({
+            "fg": format!("{:?}", cell.fg), "bg": format!("{:?}", cell.bg),
+            "modifiers": format!("{:?}", cell.modifier),
+            "diff": format!("{:?}", cell.diff_option),
+        });
+        let index = styles
+            .iter()
+            .position(|known| *known == style)
+            .unwrap_or_else(|| {
+                styles.push(style);
+                styles.len() - 1
+            });
+        cells.push(serde_json::json!([cell.symbol(), index]));
+    }
+    serde_json::json!({"label":label, "width":width, "height":height,
+        "synthetic":true, "styles":styles, "cells":cells})
+}
+
+fn visual_live_snapshot(stage: &str, connected: bool) -> irlume_common::live::LiveStatusSnapshot {
+    serde_json::from_value(serde_json::json!({
+        "live_schema":1, "daemon_instance":"11111111111111111111111111111111",
+        "daemon_uptime_ms":60000, "state_revision":0, "stage":stage,
+        "worker":null, "background":[], "waiting":[], "tracking_available":true,
+        "cameras":{"state":"current", "supervisor_id":"22222222222222222222222222222222",
+            "revision":1, "observed_ago_ms":0, "reason":null,
+            "candidates":if connected { serde_json::json!([{
+                "instance_id":"33333333333333333333333333333333", "generation":1,
+                "endpoint_paths":["/dev/video40","/dev/video42"]
+            }]) } else { serde_json::json!([]) }}
+    }))
+    .unwrap()
+}
+
+fn visual_live_fixture(screen: usize, snapshot: irlume_common::live::LiveStatusSnapshot) -> App {
+    let mut app = visual_fixture(screen);
+    let now = Instant::now();
+    app.clock_override = Some(now);
+    // Landing copied fixture metadata schedules no request; the normal polling
+    // loop is never called. Refresh generations may become pending in memory.
+    app.apply_live_snapshot(snapshot, now);
+    app.mark_fixture_observations_fresh(now);
+    app.screen = screen;
+    visual_assert_no_work(&app);
+    app
+}
+
+#[test]
+fn synthetic_visual_gallery_all_screens_and_overlays() {
+    use sha2::Digest;
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    // The key cases below only open UI overlays. A dead socket is an extra
+    // guard if a future shortcut accidentally starts a request; no polling or
+    // execution loop runs, and visual_assert_no_work rejects worker state.
+    let _guard = dead_socket();
+    let mut frames = Vec::new();
+    for (screen, name) in SCREENS.iter().enumerate() {
+        for (width, height) in [(80, 24), (100, 30), (120, 40)] {
+            let app = visual_fixture(screen);
+            let frame = visual_frame(&app, name, width, height);
+            if width >= 80 {
+                let text: String = frame["cells"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .map(|cell| cell[0].as_str().unwrap())
+                    .collect();
+                assert!(
+                    text.contains(name),
+                    "missing screen name {name} at {width}x{height}"
+                );
+            }
+            frames.push(frame);
+        }
+    }
+    for (label, screen, key) in [
+        ("Context help", SC_SETTINGS, KeyCode::Char('?')),
+        ("More actions F2", SC_SETTINGS, KeyCode::F(2)),
+        ("Sections F3", SC_SETTINGS, KeyCode::F(3)),
+        ("Current observations F4", SC_SETTINGS, KeyCode::F(4)),
+        ("Preferences action focus F6", SC_SETTINGS, KeyCode::F(6)),
+        ("Full Activity Shift+L", SC_WELCOME, KeyCode::Char('L')),
+    ] {
+        for (width, height) in [(80, 24), (100, 30), (120, 40)] {
+            let mut app = visual_fixture(screen);
+            // Seed page geometry before opening or focusing the UI overlay.
+            let _ = visual_frame(&app, "before overlay", width, height);
+            app.on_key(key);
+            match key {
+                KeyCode::Char('?') => assert!(app.show_help),
+                KeyCode::F(2) => assert!(app.more_actions.is_some()),
+                KeyCode::F(3) => assert!(app.sections.is_some()),
+                KeyCode::F(4) => assert!(app.show_live),
+                KeyCode::F(6) => assert!(app.focused_action().is_some()),
+                KeyCode::Char('L') => assert!(app.activity_history_open),
+                _ => unreachable!(),
+            }
+            frames.push(visual_frame(&app, label, width, height));
+        }
+    }
+    for (width, height) in [(80, 24), (100, 30), (120, 40)] {
+        let mut first_run = visual_fixture(SC_WELCOME);
+        first_run.profiles.clear();
+        assert!(first_run.is_first_run());
+        frames.push(visual_frame(
+            &first_run,
+            "Synthetic first run",
+            width,
+            height,
+        ));
+        first_run.on_key(KeyCode::F(6));
+        assert!(first_run.focused_action().is_some());
+        frames.push(visual_frame(
+            &first_run,
+            "First-run action focus F6",
+            width,
+            height,
+        ));
+
+        // Only a channel and Op value: fake_op spawns no worker, and no poll
+        // is performed. The busy label must survive all history-only keys.
+        let mut busy = visual_fixture(SC_IDENTIFY);
+        let (_sender, mut op) = fake_op();
+        op.label = "Synthetic pending request; no operation is running".into();
+        busy.op = Some(op);
+        let expected = Some("Synthetic pending request; no operation is running");
+        frames.push(visual_frame_with_op(
+            &busy,
+            "Synthetic busy state",
+            width,
+            height,
+            expected,
+        ));
+        busy.on_key(KeyCode::Char('L'));
+        for key in [
+            KeyCode::Char('e'),
+            KeyCode::Char('q'),
+            KeyCode::F(3),
+            KeyCode::F(6),
+        ] {
+            busy.on_key(key);
+            visual_assert_expected_work(&busy, expected);
+            assert!(busy.activity_history_open && !busy.quit);
+        }
+        frames.push(visual_frame_with_op(
+            &busy,
+            "Busy state full Activity",
+            width,
+            height,
+            expected,
+        ));
+        busy.on_key(KeyCode::Esc);
+        assert!(!busy.activity_history_open && !busy.quit);
+        visual_assert_expected_work(&busy, expected);
+
+        let long_detail = (0..48)
+            .map(|index| {
+                format!("Synthetic detail {index:02}: a fixture explanation; no action happened.\n")
+            })
+            .collect::<String>()
+            + "SYNTHETIC_DIALOG_TAIL";
+        for is_error in [false, true] {
+            let mut dialog = visual_fixture(SC_RECOVERY);
+            let label = if is_error {
+                dialog.error = Some(long_detail.clone());
+                "Synthetic long error"
+            } else {
+                dialog.confirm = Some((
+                    long_detail.clone(),
+                    "Forget",
+                    ConfirmAct::Daemon(Request::RecoveryForget {
+                        user: "synthetic-sample".into(),
+                    }),
+                ));
+                "Synthetic confirmation"
+            };
+            frames.push(visual_frame(&dialog, label, width, height));
+            assert!(dialog.dialog_view.get().1 > 0);
+            for _ in 0..128 {
+                dialog.on_key(KeyCode::PageDown);
+            }
+            assert!(if is_error {
+                dialog.error.is_some()
+            } else {
+                dialog.confirm.is_some()
+            });
+            assert_eq!(
+                dialog.act_scroll, 0,
+                "dialog reading must not scroll Activity"
+            );
+            let frame = visual_frame(&dialog, &format!("{label} scrolled tail"), width, height);
+            let text: String = frame["cells"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|cell| cell[0].as_str().unwrap())
+                .collect();
+            assert!(
+                text.contains("SYNTHETIC_DIALOG_TAIL"),
+                "dialog tail unreachable at {width}x{height}"
+            );
+            frames.push(frame);
+        }
+
+        let mut input = visual_fixture(SC_RECOVERY);
+        input.input = Some((
+            "Synthetic masked input; no real secret".into(),
+            "synthetic-placeholder".into(),
+            Pending::RecoveryRestorePw,
+        ));
+        let frame = visual_frame(&input, "Synthetic masked input", width, height);
+        let text: String = frame["cells"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|cell| cell[0].as_str().unwrap())
+            .collect();
+        assert!(!text.contains("synthetic-placeholder"));
+        frames.push(frame);
+        visual_assert_no_work(&input);
+
+        for state in ["guidance", "countdown", "stalled"] {
+            let mut app = visual_fixture(SC_PROFILES);
+            // Pure in-memory channel/report fixtures. No enrollment worker,
+            // camera request, poll, cancellation or command is invoked.
+            let (_sender, mut enrollment) = fake_enroll(0, 4);
+            enrollment.profile = "Synthetic enrollment".into();
+            enrollment.captured = 1;
+            enrollment.last = Some(good_report("Synthetic guidance: hold still"));
+            if state == "countdown" {
+                enrollment.count = Some(3);
+            } else if state == "stalled" {
+                enrollment.stalled = Some("Synthetic guide timeout; no camera was opened".into());
+            }
+            let stop = enrollment.stop.clone();
+            app.enroll = Some(enrollment);
+            frames.push(visual_frame_with_state(
+                &app,
+                &format!("Synthetic enrollment {state}"),
+                width,
+                height,
+                None,
+                Some("Synthetic enrollment"),
+            ));
+            assert!(
+                !stop.load(Ordering::Relaxed),
+                "drawing cannot request cancellation"
+            );
+        }
+    }
+    for (width, height) in [(80, 24), (100, 30), (120, 40)] {
+        let ready = visual_live_fixture(SC_WELCOME, visual_live_snapshot("ready", false));
+        frames.push(visual_frame(
+            &ready,
+            "Synthetic live daemon idle",
+            width,
+            height,
+        ));
+
+        let mut work = visual_live_snapshot("ready", true);
+        work.worker = Some(irlume_common::live::LiveWorkerOperation {
+            operation_id: irlume_common::diagnostics::OperationId::from_bytes([4; 16]),
+            kind: irlume_common::live::LiveOperationKind::Enrollment,
+            elapsed_ms: 12000,
+            cancellation_requested: true,
+        });
+        work.waiting.push(irlume_common::live::LiveWaitingCount {
+            kind: irlume_common::live::LiveOperationKind::Authentication,
+            count: 1,
+        });
+        let mut busy = visual_live_fixture(SC_PROFILES, work);
+        frames.push(visual_frame(
+            &busy,
+            "Synthetic external daemon work",
+            width,
+            height,
+        ));
+        busy.activity_history_open = true;
+        frames.push(visual_frame(
+            &busy,
+            "Synthetic live work and session history",
+            width,
+            height,
+        ));
+        busy.show_live = true;
+        frames.push(visual_frame(
+            &busy,
+            "Synthetic current work details F4",
+            width,
+            height,
+        ));
+
+        let starting = visual_live_fixture(SC_WELCOME, visual_live_snapshot("starting", false));
+        frames.push(visual_frame(
+            &starting,
+            "Synthetic daemon starting",
+            width,
+            height,
+        ));
+
+        let mut background = visual_live_snapshot("ready", true);
+        background
+            .background
+            .push(irlume_common::live::LiveWorkerOperation {
+                operation_id: irlume_common::diagnostics::OperationId::from_bytes([5; 16]),
+                kind: irlume_common::live::LiveOperationKind::CaptureQualification,
+                elapsed_ms: 5000,
+                cancellation_requested: false,
+            });
+        let mut background = visual_live_fixture(SC_CAMERAS, background);
+        background.show_live = true;
+        frames.push(visual_frame(
+            &background,
+            "Synthetic automatic qualification details",
+            width,
+            height,
+        ));
+
+        let mut unavailable = visual_live_fixture(SC_WELCOME, visual_live_snapshot("ready", false));
+        unavailable.invalidate_source(Source::Live);
+        frames.push(visual_frame(
+            &unavailable,
+            "Synthetic live status unavailable",
+            width,
+            height,
+        ));
+
+        let arrived = visual_live_fixture(SC_CAMERAS, visual_live_snapshot("ready", true));
+        frames.push(visual_frame(
+            &arrived,
+            "Synthetic attached camera awaiting inspection",
+            width,
+            height,
+        ));
+
+        let mut classified = visual_live_fixture(SC_CAMERAS, visual_live_snapshot("ready", true));
+        classified.pairs = vec![irlume_common::CameraPairInfo {
+            rgb: "/dev/video40".into(),
+            ir: "/dev/video42".into(),
+            id: Some("synthetic".into()),
+            fixed: true,
+            privacy: false,
+        }];
+        classified.pairs_known = true;
+        classified.health.as_mut().unwrap().rgb_dev = Some("/dev/video40".into());
+        classified.health.as_mut().unwrap().ir_dev = Some("/dev/video42".into());
+        frames.push(visual_frame(
+            &classified,
+            "Synthetic connected classified camera",
+            width,
+            height,
+        ));
+        classified.invalidate_source(Source::CameraPrivacy);
+        frames.push(visual_frame(
+            &classified,
+            "Synthetic camera privacy observation unavailable",
+            width,
+            height,
+        ));
+
+        let mut removed = visual_live_fixture(SC_CAMERAS, visual_live_snapshot("ready", true));
+        let mut empty = visual_live_snapshot("ready", false);
+        empty.cameras.revision = 2;
+        removed.apply_live_snapshot(empty, removed.now());
+        removed.screen = SC_CAMERAS;
+        assert!(removed
+            .camera_choice("/dev/video40", "/dev/video42")
+            .is_none());
+        frames.push(visual_frame(
+            &removed,
+            "Synthetic camera disconnected",
+            width,
+            height,
+        ));
+
+        let mut stale = visual_live_fixture(SC_SETTINGS, visual_live_snapshot("ready", false));
+        let expired = stale.now() + Duration::from_secs(65);
+        stale.clock_override = Some(expired);
+        stale.expire_observations(expired);
+        assert!(!stale.source_usable(Source::Preferences));
+        frames.push(visual_frame(
+            &stale,
+            "Synthetic expired preferences",
+            width,
+            height,
+        ));
+    }
+    for (width, height) in [(40, 12), (79, 24), (80, 23), (30, 8), (20, 6)] {
+        let app = visual_fixture(SC_SETTINGS);
+        let frame = visual_frame(&app, "Window too small", width, height);
+        let text: String = frame["cells"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|cell| cell[0].as_str().unwrap())
+            .collect();
+        assert!(text.contains("Window too small"));
+        assert!(text.contains("Minimum: 80 × 24"));
+        assert!(!text.contains("Preferences"));
+        assert!(app.click_targets.borrow().is_empty());
+        frames.push(frame);
+    }
+    assert_eq!(frames.len(), SCREENS.len() * 3 + 95);
+    if let Some(output) = std::env::var_os("IRLUME_TUI_GALLERY_DIR") {
+        let directory = std::path::PathBuf::from(output);
+        assert!(
+            directory.is_absolute(),
+            "gallery directory must be absolute"
+        );
+        std::fs::create_dir_all(&directory).unwrap();
+        let document = serde_json::json!({
+            "schema":1, "synthetic":true,
+            "description":"Synthetic fixtures rendered by the actual Irlume Ratatui draw functions; no live data or operations",
+            "cell_order":"row-major; cells are [symbol, style-index]",
+            "color_encoding":"Ratatui Color Debug; Reset means the terminal default",
+            "tui_source_sha256": sha2::Sha256::digest(include_bytes!("../tui.rs")).iter().map(|byte| format!("{byte:02x}")).collect::<String>(),
+            "visual_test_sha256": sha2::Sha256::digest(include_bytes!("visual_tests.rs")).iter().map(|byte| format!("{byte:02x}")).collect::<String>(),
+            "activity_source_sha256": sha2::Sha256::digest(include_bytes!("activity.rs")).iter().map(|byte| format!("{byte:02x}")).collect::<String>(),
+            "actions_source_sha256": sha2::Sha256::digest(include_bytes!("actions.rs")).iter().map(|byte| format!("{byte:02x}")).collect::<String>(),
+            "freshness_source_sha256": sha2::Sha256::digest(include_bytes!("freshness.rs")).iter().map(|byte| format!("{byte:02x}")).collect::<String>(),
+            "frames":frames,
+        });
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(directory.join("gallery.json"))
+            .unwrap();
+        serde_json::to_writer(&mut file, &document).unwrap();
+        file.write_all(b"\n").unwrap();
+    }
+}

--- a/crates/irlume-cli/src/uninstall.rs
+++ b/crates/irlume-cli/src/uninstall.rs
@@ -298,15 +298,35 @@ fn remove_source_files() -> Result<String, String> {
         let _ = std::fs::remove_dir_all(d);
     }
 
-    let removed = targets
-        .iter()
-        .filter(|p| p.exists() && std::fs::remove_file(p).is_ok())
-        .count();
+    let desktop_removed = remove_source_desktop_files(Path::new("/usr/local/share"))
+        .map_err(|e| format!("could not remove the source-installed desktop entry: {e}"))?;
+    let removed = desktop_removed
+        + targets
+            .iter()
+            .filter(|p| p.exists() && std::fs::remove_file(p).is_ok())
+            .count();
     let _ = systemctl(&["daemon-reload"]);
     if removed == 0 {
         return Err("found no source-installed files to remove (already gone?)".into());
     }
     Ok(format!("removed {removed} source-installed file(s)"))
+}
+
+/// Only the two files placed by install-host.sh. Leave system package entries,
+/// user overrides, and the shared applications/icon directories alone.
+fn remove_source_desktop_files(share: &Path) -> std::io::Result<usize> {
+    let mut removed = 0;
+    for relative in [
+        "applications/io.github.archledger.Irlume.desktop",
+        "icons/hicolor/scalable/apps/io.github.archledger.Irlume.svg",
+    ] {
+        match std::fs::remove_file(share.join(relative)) {
+            Ok(()) => removed += 1,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(removed)
 }
 
 /// Remove irlume artifacts a package `remove` leaves behind: the admin-created
@@ -744,6 +764,47 @@ fn stdin_is_tty() -> bool {
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn source_desktop_removal_preserves_neighbors_and_is_idempotent() {
+        let root = std::env::temp_dir().join(format!(
+            "irlume-desktop-removal-{}-{}",
+            std::process::id(),
+            rand::random::<u64>()
+        ));
+        for relative in [
+            "applications/io.github.archledger.Irlume.desktop",
+            "icons/hicolor/scalable/apps/io.github.archledger.Irlume.svg",
+        ] {
+            let file = root.join(relative);
+            std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+            std::fs::write(&file, b"irlume fixture").unwrap();
+            std::fs::write(file.with_file_name("unrelated"), b"keep").unwrap();
+        }
+        assert_eq!(super::remove_source_desktop_files(&root).unwrap(), 2);
+        assert_eq!(super::remove_source_desktop_files(&root).unwrap(), 0);
+        for dir in ["applications", "icons/hicolor/scalable/apps"] {
+            assert_eq!(
+                std::fs::read(root.join(dir).join("unrelated")).unwrap(),
+                b"keep"
+            );
+        }
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn source_desktop_removal_reports_errors_without_removing_directories() {
+        let root = std::env::temp_dir().join(format!(
+            "irlume-desktop-removal-error-{}-{}",
+            std::process::id(),
+            rand::random::<u64>()
+        ));
+        let unexpected_dir = root.join("applications/io.github.archledger.Irlume.desktop");
+        std::fs::create_dir_all(&unexpected_dir).unwrap();
+        assert!(super::remove_source_desktop_files(&root).is_err());
+        assert!(unexpected_dir.is_dir());
+        std::fs::remove_dir_all(root).unwrap();
+    }
 
     /// A destructive verb must not guess. `--keep-data` mistyped is the whole
     /// reason this exists: it used to be ignored, and with `--yes` beside it the

--- a/crates/irlume-common/src/lib.rs
+++ b/crates/irlume-common/src/lib.rs
@@ -16,6 +16,8 @@ pub mod config;
 pub mod dbglog;
 pub mod diagnostics;
 pub mod gkr_wire;
+pub mod live;
+pub mod live_camera;
 pub mod memlock;
 pub mod pam_service;
 pub mod platform;
@@ -573,6 +575,12 @@ pub enum Request {
     /// under /etc/irlume, which is not an arbitrary peer's to change. (This said
     /// "root or self", which never matched the dispatch gate.)
     SetCameras { rgb: String, ir: String },
+    /// Apply a camera choice only while its observed device generation exists.
+    SetCamerasIfCurrent {
+        rgb: String,
+        ir: String,
+        expected: live_camera::CameraSelection,
+    },
     /// Add scans to an existing profile ("improve recognition"). PRIVILEGED.
     /// Add scans to an existing profile, in the recognizer space the daemon
     /// has loaded. Also how a profile gains a second recognizer's templates
@@ -689,6 +697,8 @@ pub enum Request {
     CameraDiagnostics,
     /// Read the daemon's bounded, structurally share-safe diagnostic snapshot.
     SupportSnapshot { since_ms: u64 },
+    /// Copy current daemon worker metadata and passive camera inventory.
+    LiveStatus,
     /// Explicit root-only bounded camera probe for a support report.
     SupportProbe { since_ms: u64 },
     /// Root-only subscription to one bounded daemon-authored diagnostic trace.
@@ -1178,6 +1188,7 @@ pub enum Response {
     },
     /// Structurally share-safe daemon facts and recent typed events.
     SupportSnapshot(Box<diagnostics::SupportSnapshot>),
+    LiveStatus(Box<live::LiveStatusSnapshot>),
     /// Explicit support probe result with its contemporaneous safe snapshot.
     SupportProbe(Box<diagnostics::SupportProbeResult>),
     /// Trace subscription accepted with daemon-applied bounds. Subsequent
@@ -2755,3 +2766,19 @@ pub const KWALLET_INIT_PATH: &str = "/usr/libexec/irlume/irlume-kwallet-init";
 /// [`KWALLET_INIT_PATH`]: takes a secret on stdin, only meaningful inside a PAM
 /// transaction, overridable via `IRLUME_GKR_UNLOCK` for tests.
 pub const GKR_UNLOCK_PATH: &str = "/usr/libexec/irlume/irlume-gkr-unlock";
+
+#[cfg(test)]
+mod live_status_request_tests {
+    #[test]
+    fn live_status_request_is_a_payload_free_read() {
+        let request = serde_json::from_str::<super::Request>(r#""LiveStatus""#);
+        assert!(
+            request.is_ok(),
+            "LiveStatus must be an additive payload-free request"
+        );
+        assert_eq!(
+            serde_json::to_value(request.unwrap()).unwrap(),
+            "LiveStatus"
+        );
+    }
+}

--- a/crates/irlume-common/src/live.rs
+++ b/crates/irlume-common/src/live.rs
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! Read-only, process-local daemon worker observations; not a device-wide audit.
+
+use crate::{diagnostics::OperationId, live_camera::CameraInventorySnapshot};
+use serde::{Deserialize, Deserializer, Serialize};
+
+pub const LIVE_SCHEMA_VERSION: u32 = 1;
+pub const MAX_WAITING_KINDS: usize = 18;
+pub const MAX_BACKGROUND_OPERATIONS: usize = 4;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LiveStage {
+    Starting,
+    Ready,
+    Rebuilding,
+    Stopping,
+    #[serde(other)]
+    Unknown,
+}
+
+/// Static work categories deliberately carry no request fields or outcomes.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LiveOperationKind {
+    Authentication,
+    WalletAuthentication,
+    Enrollment,
+    Framing,
+    Identification,
+    CameraEnumeration,
+    CameraSetup,
+    CaptureQualification,
+    CameraDiagnostics,
+    ProfileRead,
+    ProfileUpdate,
+    SensorReadiness,
+    WalletRead,
+    WalletUpdate,
+    RecoveryUpdate,
+    Compatibility,
+    Status,
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct LiveWorkerOperation {
+    pub operation_id: OperationId,
+    pub kind: LiveOperationKind,
+    pub elapsed_ms: u64,
+    /// A request to stop, not evidence that the work or camera has stopped.
+    pub cancellation_requested: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct LiveWaitingCount {
+    pub kind: LiveOperationKind,
+    pub count: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct LiveStatusSnapshot {
+    pub live_schema: u32,
+    pub daemon_instance: OperationId,
+    pub daemon_uptime_ms: u64,
+    /// Invalidation hint after potentially state-changing work completes,
+    /// including failed/unknown outcomes. This is not a successful-write count.
+    pub state_revision: u64,
+    pub stage: LiveStage,
+    pub worker: Option<LiveWorkerOperation>,
+    /// Known automatic tasks outside the request worker, not all OS processes.
+    pub background: Vec<LiveWorkerOperation>,
+    pub waiting: Vec<LiveWaitingCount>,
+    pub cameras: CameraInventorySnapshot,
+    /// False means worker/queue tracking is unavailable, never idle.
+    pub tracking_available: bool,
+}
+
+fn bounded_rows<'de, T: Deserialize<'de>, D: Deserializer<'de>, const MAX: usize>(
+    deserializer: D,
+) -> Result<Vec<T>, D::Error> {
+    struct RowsVisitor<T, const MAX: usize>(std::marker::PhantomData<T>);
+    impl<'de, T: Deserialize<'de>, const MAX: usize> serde::de::Visitor<'de> for RowsVisitor<T, MAX> {
+        type Value = Vec<T>;
+        fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "at most {MAX} live status rows")
+        }
+        fn visit_seq<A: serde::de::SeqAccess<'de>>(
+            self,
+            mut seq: A,
+        ) -> Result<Self::Value, A::Error> {
+            let mut rows = Vec::with_capacity(seq.size_hint().unwrap_or(0).min(MAX));
+            while let Some(row) = seq.next_element()? {
+                if rows.len() == MAX {
+                    return Err(serde::de::Error::custom("too many live status rows"));
+                }
+                rows.push(row);
+            }
+            Ok(rows)
+        }
+    }
+    deserializer.deserialize_seq(RowsVisitor::<T, MAX>(std::marker::PhantomData))
+}
+fn deserialize_waiting<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Vec<LiveWaitingCount>, D::Error> {
+    bounded_rows::<_, _, MAX_WAITING_KINDS>(deserializer)
+}
+fn deserialize_background<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Vec<LiveWorkerOperation>, D::Error> {
+    bounded_rows::<_, _, MAX_BACKGROUND_OPERATIONS>(deserializer)
+}
+
+impl<'de> Deserialize<'de> for LiveStatusSnapshot {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        struct Wire {
+            live_schema: u32,
+            daemon_instance: OperationId,
+            daemon_uptime_ms: u64,
+            state_revision: u64,
+            stage: LiveStage,
+            worker: Option<LiveWorkerOperation>,
+            #[serde(deserialize_with = "deserialize_background")]
+            background: Vec<LiveWorkerOperation>,
+            #[serde(deserialize_with = "deserialize_waiting")]
+            waiting: Vec<LiveWaitingCount>,
+            cameras: CameraInventorySnapshot,
+            tracking_available: bool,
+        }
+        let wire = Wire::deserialize(deserializer)?;
+        if wire.live_schema != LIVE_SCHEMA_VERSION
+            || wire.daemon_instance.as_bytes() == &[0; 16]
+            || wire.waiting.len() > MAX_WAITING_KINDS
+            || wire
+                .waiting
+                .iter()
+                .try_fold(0_u64, |sum, row| sum.checked_add(row.count))
+                .is_none()
+            || wire.waiting.iter().enumerate().any(|(index, row)| {
+                row.count == 0
+                    || wire.waiting[..index]
+                        .iter()
+                        .any(|prior| prior.kind == row.kind)
+            })
+            || wire.background.iter().enumerate().any(|(index, task)| {
+                task.operation_id.as_bytes() == &[0; 16]
+                    || task.elapsed_ms > wire.daemon_uptime_ms
+                    || wire
+                        .worker
+                        .as_ref()
+                        .is_some_and(|worker| worker.operation_id == task.operation_id)
+                    || wire.background[..index]
+                        .iter()
+                        .any(|prior| prior.operation_id == task.operation_id)
+            })
+            || wire.worker.as_ref().is_some_and(|worker| {
+                worker.operation_id.as_bytes() == &[0; 16]
+                    || worker.elapsed_ms > wire.daemon_uptime_ms
+            })
+        {
+            return Err(serde::de::Error::custom("invalid live status snapshot"));
+        }
+        Ok(Self {
+            live_schema: wire.live_schema,
+            daemon_instance: wire.daemon_instance,
+            daemon_uptime_ms: wire.daemon_uptime_ms,
+            state_revision: wire.state_revision,
+            stage: wire.stage,
+            worker: wire.worker,
+            background: wire.background,
+            waiting: wire.waiting,
+            cameras: wire.cameras,
+            tracking_available: wire.tracking_available,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn wire() -> serde_json::Value {
+        serde_json::json!({
+            "live_schema":1, "daemon_instance":"11111111111111111111111111111111",
+            "daemon_uptime_ms":100, "state_revision":0, "stage":"ready", "worker":null,
+            "waiting":[], "background":[], "tracking_available":true,
+            "cameras":{"state":"uninitialized", "supervisor_id":null, "revision":0,
+                "observed_ago_ms":null, "reason":null, "candidates":[]}
+        })
+    }
+    #[test]
+    fn live_status_wire_has_no_request_payload_and_accepts_future_labels_as_unknown() {
+        let mut value = wire();
+        value["stage"] = "future-stage".into();
+        value["waiting"] = serde_json::json!([{"kind":"future-operation", "count":1}]);
+        let parsed: LiveStatusSnapshot = serde_json::from_value(value).unwrap();
+        assert_eq!(parsed.stage, LiveStage::Unknown);
+        assert_eq!(parsed.waiting[0].kind, LiveOperationKind::Unknown);
+        let response = crate::Response::LiveStatus(Box::new(parsed));
+        let encoded = serde_json::to_string(&response).unwrap();
+        assert!(serde_json::from_str::<crate::Response>(&encoded).is_ok());
+        for private in ["user", "profile", "password", "score", "service"] {
+            assert!(!encoded.contains(&format!("\"{private}\"")));
+        }
+    }
+    #[test]
+    fn live_status_wire_rejects_invalid_schema_bounds_ids_and_counts() {
+        for (field, bad) in [
+            ("live_schema", serde_json::json!(2)),
+            (
+                "daemon_instance",
+                serde_json::json!("00000000000000000000000000000000"),
+            ),
+            (
+                "waiting",
+                serde_json::json!([{"kind":"enrollment","count":u64::MAX},{"kind":"authentication","count":1}]),
+            ),
+            (
+                "waiting",
+                serde_json::json!([{"kind":"enrollment","count":0}]),
+            ),
+            (
+                "waiting",
+                serde_json::json!([{"kind":"enrollment","count":1},{"kind":"enrollment","count":2}]),
+            ),
+            (
+                "waiting",
+                serde_json::json!(vec![
+                    serde_json::json!({"kind":"enrollment","count":1});
+                    MAX_WAITING_KINDS + 1
+                ]),
+            ),
+            (
+                "worker",
+                serde_json::json!({"operation_id":"22222222222222222222222222222222", "kind":"enrollment", "elapsed_ms":101, "cancellation_requested":false}),
+            ),
+        ] {
+            let mut value = wire();
+            value[field] = bad;
+            assert!(
+                serde_json::from_value::<LiveStatusSnapshot>(value).is_err(),
+                "{field}"
+            );
+        }
+    }
+    #[test]
+    fn live_background_wire_rejects_overflow_duplicate_identity_and_impossible_elapsed() {
+        let task = serde_json::json!({"operation_id":"22222222222222222222222222222222", "kind":"capture_qualification", "elapsed_ms":10, "cancellation_requested":false});
+        for rows in [
+            vec![task.clone(); MAX_BACKGROUND_OPERATIONS + 1],
+            vec![task.clone(), task.clone()],
+            {
+                let mut invalid = task.clone();
+                invalid["elapsed_ms"] = 101.into();
+                vec![invalid]
+            },
+            {
+                let mut invalid = task.clone();
+                invalid["operation_id"] = "00000000000000000000000000000000".into();
+                vec![invalid]
+            },
+        ] {
+            let mut value = wire();
+            value["background"] = serde_json::json!(rows);
+            assert!(serde_json::from_value::<LiveStatusSnapshot>(value).is_err());
+        }
+        let mut value = wire();
+        value["worker"] = task.clone();
+        value["background"] = serde_json::json!([task]);
+        assert!(serde_json::from_value::<LiveStatusSnapshot>(value).is_err());
+    }
+}

--- a/crates/irlume-common/src/live_camera.rs
+++ b/crates/irlume-common/src/live_camera.rs
@@ -1,0 +1,452 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! Copied UVC connection inventory, not camera qualification or physical activity.
+
+use serde::{Deserialize, Serialize};
+
+/// Maximum number of candidates in a live status reply. Overflow is unavailable,
+/// never an apparently complete truncated inventory.
+pub const MAX_CAMERA_CANDIDATES: usize = 32;
+/// Maximum endpoint count per physical group.
+pub const MAX_CAMERA_ENDPOINTS: usize = 16;
+/// Linux video node names need no arbitrary filesystem path in this interface.
+pub const MAX_CAMERA_ENDPOINT_BYTES: usize = 96;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CameraInventoryState {
+    #[default]
+    Uninitialized,
+    Current,
+    Refreshing,
+    Unavailable,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CameraInventoryReason {
+    Monitor,
+    Snapshot,
+    Inventory,
+    Bounds,
+    WorkerStopped,
+}
+
+/// One connected UVC physical group. Endpoints may include metadata nodes;
+/// their RGB/IR roles, usability and privacy state are deliberately unknown.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "CandidateWire")]
+pub struct CameraCandidate {
+    pub instance_id: String,
+    pub generation: u64,
+    pub endpoint_paths: Vec<String>,
+}
+
+/// A publication revision has meaning only with its supervisor ID. An unchanged
+/// poll does not advance it. `observed_ago_ms` ages the last complete passive
+/// census, not a video probe or proof of current streaming/idle state.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "SnapshotWire")]
+pub struct CameraInventorySnapshot {
+    pub state: CameraInventoryState,
+    pub supervisor_id: Option<String>,
+    pub revision: u64,
+    pub observed_ago_ms: Option<u64>,
+    pub reason: Option<CameraInventoryReason>,
+    pub candidates: Vec<CameraCandidate>,
+}
+
+/// A user's selected connection identity carried through confirmation and any
+/// administrator prompt. It conveys no role, capability or authorization proof.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "SelectionWire")]
+pub struct CameraSelection {
+    pub supervisor_id: String,
+    pub candidate: CameraCandidate,
+}
+
+impl CameraSelection {
+    /// Validate a bounded selection guard before accepting it from the wire.
+    ///
+    /// # Errors
+    /// Returns a static reason for malformed supervisor or candidate metadata.
+    pub fn validate(&self) -> Result<(), &'static str> {
+        if !valid_id(&self.supervisor_id) {
+            return Err("invalid camera supervisor identity");
+        }
+        self.candidate.validate()
+    }
+
+    /// Require the same still-connected candidate before a camera switch. This
+    /// only matches a copied snapshot; the caller owns the mutation boundary.
+    #[must_use]
+    pub fn matches(&self, snapshot: &CameraInventorySnapshot, rgb: &str, ir: &str) -> bool {
+        self.validate().is_ok()
+            && snapshot.validate().is_ok()
+            && snapshot.state == CameraInventoryState::Current
+            && snapshot.supervisor_id.as_deref() == Some(self.supervisor_id.as_str())
+            && snapshot.candidates.contains(&self.candidate)
+            && rgb != ir
+            && self.candidate.endpoint_paths.iter().any(|p| p == rgb)
+            && self.candidate.endpoint_paths.iter().any(|p| p == ir)
+    }
+}
+
+impl CameraInventorySnapshot {
+    /// Validate the closed, bounded display contract without accessing hardware.
+    ///
+    /// # Errors
+    /// Returns a static reason for malformed identity, bounds or state metadata.
+    pub fn validate(&self) -> Result<(), &'static str> {
+        if self.candidates.len() > MAX_CAMERA_CANDIDATES {
+            return Err("too many camera candidates");
+        }
+        if self
+            .supervisor_id
+            .as_deref()
+            .is_some_and(|id| !valid_id(id))
+        {
+            return Err("invalid camera supervisor identity");
+        }
+        let mut ids = std::collections::BTreeSet::new();
+        let mut endpoints = std::collections::BTreeSet::new();
+        for candidate in &self.candidates {
+            candidate.validate()?;
+            if !ids.insert(&candidate.instance_id)
+                || candidate
+                    .endpoint_paths
+                    .iter()
+                    .any(|p| !endpoints.insert(p))
+            {
+                return Err("duplicate camera identity or endpoint");
+            }
+        }
+        match self.state {
+            CameraInventoryState::Uninitialized => {
+                if self.supervisor_id.is_some()
+                    || self.revision != 0
+                    || self.observed_ago_ms.is_some()
+                    || self.reason.is_some()
+                    || !self.candidates.is_empty()
+                {
+                    return Err("invalid uninitialized camera inventory");
+                }
+            }
+            CameraInventoryState::Current | CameraInventoryState::Refreshing => {
+                if self.supervisor_id.is_none()
+                    || self.revision == 0
+                    || self.reason.is_some()
+                    || (self.state == CameraInventoryState::Current
+                        && self.observed_ago_ms.is_none())
+                {
+                    return Err("invalid published camera inventory");
+                }
+            }
+            CameraInventoryState::Unavailable => {
+                if self.reason.is_none() || !self.candidates.is_empty() {
+                    return Err("invalid unavailable camera inventory");
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl CameraCandidate {
+    /// Validate the bounded connection key and literal endpoint names.
+    ///
+    /// # Errors
+    /// Returns a static reason for invalid identity, generation or endpoints.
+    pub fn validate(&self) -> Result<(), &'static str> {
+        if !valid_id(&self.instance_id) || self.generation == 0 {
+            return Err("invalid camera candidate identity");
+        }
+        if self.endpoint_paths.is_empty() || self.endpoint_paths.len() > MAX_CAMERA_ENDPOINTS {
+            return Err("invalid camera endpoint count");
+        }
+        let mut paths = std::collections::BTreeSet::new();
+        for path in &self.endpoint_paths {
+            let Some(name) = path.strip_prefix("/dev/") else {
+                return Err("invalid camera endpoint");
+            };
+            if name.is_empty()
+                || path.len() > MAX_CAMERA_ENDPOINT_BYTES
+                || !name
+                    .bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.'))
+                || name == "."
+                || name == ".."
+                || !paths.insert(path)
+            {
+                return Err("invalid camera endpoint");
+            }
+        }
+        Ok(())
+    }
+}
+
+fn valid_id(id: &str) -> bool {
+    id.len() == 32
+        && id
+            .bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+        && id.bytes().any(|b| b != b'0')
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CandidateWire {
+    instance_id: String,
+    generation: u64,
+    #[serde(deserialize_with = "bounded_vec::<_, _, MAX_CAMERA_ENDPOINTS>")]
+    endpoint_paths: Vec<String>,
+}
+
+impl TryFrom<CandidateWire> for CameraCandidate {
+    type Error = &'static str;
+    fn try_from(w: CandidateWire) -> Result<Self, Self::Error> {
+        let value = Self {
+            instance_id: w.instance_id,
+            generation: w.generation,
+            endpoint_paths: w.endpoint_paths,
+        };
+        value.validate()?;
+        Ok(value)
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SnapshotWire {
+    state: CameraInventoryState,
+    supervisor_id: Option<String>,
+    revision: u64,
+    observed_ago_ms: Option<u64>,
+    reason: Option<CameraInventoryReason>,
+    #[serde(deserialize_with = "bounded_vec::<_, _, MAX_CAMERA_CANDIDATES>")]
+    candidates: Vec<CameraCandidate>,
+}
+
+impl TryFrom<SnapshotWire> for CameraInventorySnapshot {
+    type Error = &'static str;
+    fn try_from(w: SnapshotWire) -> Result<Self, Self::Error> {
+        let value = Self {
+            state: w.state,
+            supervisor_id: w.supervisor_id,
+            revision: w.revision,
+            observed_ago_ms: w.observed_ago_ms,
+            reason: w.reason,
+            candidates: w.candidates,
+        };
+        value.validate()?;
+        Ok(value)
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SelectionWire {
+    supervisor_id: String,
+    candidate: CameraCandidate,
+}
+
+impl TryFrom<SelectionWire> for CameraSelection {
+    type Error = &'static str;
+    fn try_from(w: SelectionWire) -> Result<Self, Self::Error> {
+        let value = Self {
+            supervisor_id: w.supervisor_id,
+            candidate: w.candidate,
+        };
+        value.validate()?;
+        Ok(value)
+    }
+}
+
+fn bounded_vec<'de, D, T, const MAX: usize>(deserializer: D) -> Result<Vec<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    struct Bounded<T, const MAX: usize>(std::marker::PhantomData<T>);
+    impl<'de, T: Deserialize<'de>, const MAX: usize> serde::de::Visitor<'de> for Bounded<T, MAX> {
+        type Value = Vec<T>;
+        fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "at most {MAX} entries")
+        }
+        fn visit_seq<A: serde::de::SeqAccess<'de>>(
+            self,
+            mut seq: A,
+        ) -> Result<Self::Value, A::Error> {
+            let mut values = Vec::new();
+            while let Some(value) = seq.next_element()? {
+                if values.len() == MAX {
+                    return Err(serde::de::Error::custom("camera inventory bound exceeded"));
+                }
+                values.push(value);
+            }
+            Ok(values)
+        }
+    }
+    deserializer.deserialize_seq(Bounded::<T, MAX>(std::marker::PhantomData))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn current() -> CameraInventorySnapshot {
+        CameraInventorySnapshot {
+            state: CameraInventoryState::Current,
+            supervisor_id: Some("11111111111111111111111111111111".into()),
+            revision: 1,
+            observed_ago_ms: Some(0),
+            reason: None,
+            candidates: vec![],
+        }
+    }
+    fn candidate() -> CameraCandidate {
+        CameraCandidate {
+            instance_id: "22222222222222222222222222222222".into(),
+            generation: 1,
+            endpoint_paths: vec!["/dev/video0".into()],
+        }
+    }
+    #[test]
+    fn live_camera_current_empty_is_distinct_from_uninitialized_and_unavailable() {
+        for value in [
+            CameraInventorySnapshot::default(),
+            current(),
+            CameraInventorySnapshot {
+                state: CameraInventoryState::Unavailable,
+                reason: Some(CameraInventoryReason::Monitor),
+                ..Default::default()
+            },
+        ] {
+            let json = serde_json::to_string(&value).unwrap();
+            assert_eq!(
+                serde_json::from_str::<CameraInventorySnapshot>(&json).unwrap(),
+                value
+            );
+        }
+        let mut invalid = current();
+        invalid.observed_ago_ms = None;
+        assert!(serde_json::from_value::<CameraInventorySnapshot>(
+            serde_json::to_value(invalid).unwrap()
+        )
+        .is_err());
+    }
+    #[test]
+    fn live_camera_wire_rejects_unknown_fields_duplicates_and_unbounded_candidates() {
+        let mut value = current();
+        value.candidates = vec![candidate()];
+        assert!(value.validate().is_ok());
+        let mut wire = serde_json::to_value(&value).unwrap();
+        wire["streaming"] = true.into();
+        assert!(serde_json::from_value::<CameraInventorySnapshot>(wire).is_err());
+        value.candidates.push(candidate());
+        assert!(value.validate().is_err());
+        value.candidates = vec![candidate(); MAX_CAMERA_CANDIDATES + 1];
+        assert!(serde_json::from_value::<CameraInventorySnapshot>(
+            serde_json::to_value(value).unwrap()
+        )
+        .is_err());
+    }
+    #[test]
+    fn live_camera_wire_rejects_unsafe_names_zero_generation_and_invented_roles() {
+        for endpoint in [
+            "/dev/../shadow",
+            "/dev/video0\u{1b}[2J",
+            "/tmp/video0",
+            "/dev/..",
+        ] {
+            let mut c = candidate();
+            c.endpoint_paths = vec![endpoint.into()];
+            assert!(c.validate().is_err());
+        }
+        let mut c = candidate();
+        c.generation = 0;
+        assert!(c.validate().is_err());
+        c = candidate();
+        c.instance_id = "0".repeat(32);
+        assert!(c.validate().is_err());
+        let mut wire = serde_json::to_value(candidate()).unwrap();
+        wire["role"] = "rgb".into();
+        assert!(serde_json::from_value::<CameraCandidate>(wire).is_err());
+    }
+
+    #[test]
+    fn live_camera_maximum_payload_leaves_room_in_the_64kib_response_envelope() {
+        let mut snapshot = current();
+        for n in 1..=MAX_CAMERA_CANDIDATES {
+            snapshot.candidates.push(CameraCandidate {
+                instance_id: format!("{n:032x}"),
+                generation: u64::MAX,
+                endpoint_paths: (0..MAX_CAMERA_ENDPOINTS)
+                    .map(|endpoint| {
+                        let start = format!("/dev/camera{n}_{endpoint}_");
+                        format!(
+                            "{start}{}",
+                            "v".repeat(MAX_CAMERA_ENDPOINT_BYTES - start.len())
+                        )
+                    })
+                    .collect(),
+            });
+        }
+        let json = serde_json::to_vec(&snapshot).unwrap();
+        assert!(snapshot.validate().is_ok());
+        assert!(
+            json.len() < 60 * 1024,
+            "must leave room for LiveStatus fields"
+        );
+        assert_eq!(
+            serde_json::from_slice::<CameraInventorySnapshot>(&json).unwrap(),
+            snapshot
+        );
+        snapshot.candidates.push(candidate());
+        assert!(snapshot.validate().is_err());
+    }
+
+    #[test]
+    fn live_camera_selection_requires_current_exact_continuity_and_both_endpoints() {
+        let mut snapshot = current();
+        let mut selected = candidate();
+        selected.endpoint_paths.push("/dev/video2".into());
+        snapshot.candidates.push(selected.clone());
+        let guard = CameraSelection {
+            supervisor_id: snapshot.supervisor_id.clone().unwrap(),
+            candidate: selected,
+        };
+        assert!(guard.matches(&snapshot, "/dev/video0", "/dev/video2"));
+        assert!(!guard.matches(&snapshot, "/dev/video0", "/dev/video0"));
+        assert!(!guard.matches(&snapshot, "/dev/video0", "/dev/video9"));
+        for state in [
+            CameraInventoryState::Refreshing,
+            CameraInventoryState::Unavailable,
+            CameraInventoryState::Uninitialized,
+        ] {
+            let mut changed = snapshot.clone();
+            changed.state = state;
+            assert!(!guard.matches(&changed, "/dev/video0", "/dev/video2"));
+        }
+        let mut changed = snapshot.clone();
+        changed.candidates.clear();
+        assert!(!guard.matches(&changed, "/dev/video0", "/dev/video2"));
+        changed = snapshot.clone();
+        changed.candidates[0].generation += 1;
+        assert!(!guard.matches(&changed, "/dev/video0", "/dev/video2"));
+        changed = snapshot.clone();
+        changed.candidates[0].instance_id = "3".repeat(32);
+        assert!(!guard.matches(&changed, "/dev/video0", "/dev/video2"));
+        changed = snapshot.clone();
+        changed.supervisor_id = Some("4".repeat(32));
+        assert!(!guard.matches(&changed, "/dev/video0", "/dev/video2"));
+        let json = serde_json::to_value(&guard).unwrap();
+        assert_eq!(
+            serde_json::from_value::<CameraSelection>(json.clone()).unwrap(),
+            guard
+        );
+        let mut invalid = json;
+        invalid["supervisor_id"] = "fake".into();
+        assert!(serde_json::from_value::<CameraSelection>(invalid).is_err());
+    }
+}

--- a/crates/irlume-daemon/src/arbiter.rs
+++ b/crates/irlume-daemon/src/arbiter.rs
@@ -100,6 +100,7 @@ pub fn classify(req: &Request) -> Class {
         | RetryReset { .. } // connection-only operation; never a camera job
         | ListProfiles { .. }
         | SupportSnapshot { .. }
+        | LiveStatus
         // Served directly by its connection thread before this classification
         // is consulted; Status documents that it never belongs to the camera
         // worker if a caller reaches this seam independently.
@@ -133,6 +134,7 @@ pub fn classify(req: &Request) -> Class {
         // identity plus a path existence check, which is why it is a write and
         // not a capture.
         SetCameras { .. }
+        | SetCamerasIfCurrent { .. }
         | DeleteProfile { .. }
         | DeleteScan { .. }
         | ForgetRecognizer { .. }

--- a/crates/irlume-daemon/src/diagnostics.rs
+++ b/crates/irlume-daemon/src/diagnostics.rs
@@ -14,7 +14,7 @@ use std::collections::VecDeque;
 use std::io::Read as _;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::{Receiver, RecvTimeoutError, SyncSender, TrySendError};
-use std::sync::{Arc, Mutex, Weak};
+use std::sync::{Arc, Mutex, OnceLock, Weak};
 use std::time::{Duration, Instant};
 
 pub(crate) trait Clock: Send + Sync {
@@ -46,6 +46,7 @@ struct Shared {
     entropy: Mutex<Option<std::fs::File>>,
     fallback_sequence: AtomicU64,
     trace: Mutex<Option<Weak<TraceSubscriber>>>,
+    live: OnceLock<crate::live::LiveState>,
 }
 
 const TRACE_CHANNEL_CAPACITY: usize = 1_024;
@@ -105,7 +106,7 @@ impl DiagnosticState {
     where
         C: Clock + 'static,
     {
-        Self {
+        let state = Self {
             shared: Arc::new(Shared {
                 clock,
                 inner: Mutex::new(Inner {
@@ -115,8 +116,27 @@ impl DiagnosticState {
                 entropy: Mutex::new(std::fs::File::open("/dev/urandom").ok()),
                 fallback_sequence: AtomicU64::new(0),
                 trace: Mutex::new(None),
+                live: OnceLock::new(),
             }),
-        }
+        };
+        let _ = state.shared.live.set(crate::live::LiveState::new(
+            state.next_operation_id(),
+            Arc::clone(&state.shared.clock),
+        ));
+        state
+    }
+
+    pub(crate) fn live(&self) -> &crate::live::LiveState {
+        // Initialized before DiagnosticState can escape its only constructor.
+        self.shared.live.get().expect("live state initialized")
+    }
+
+    /// Track the known automatic camera task without inventing request/history
+    /// records. The guard owns only copied observation metadata.
+    pub(crate) fn begin_background_qualification(&self) -> crate::live::LiveGuard {
+        let guard = self.live().register_background(self.next_operation_id());
+        guard.running();
+        guard
     }
 
     pub(crate) fn begin(&self, operation: OperationClass) -> OperationScope {
@@ -530,7 +550,6 @@ pub(crate) struct OperationScope {
 }
 
 impl OperationScope {
-    #[cfg(test)]
     pub(crate) const fn operation_id(&self) -> OperationId {
         self.operation_id
     }

--- a/crates/irlume-daemon/src/live.rs
+++ b/crates/irlume-daemon/src/live.rs
@@ -1,0 +1,687 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! Bounded copied worker observations. Guards never own cameras or requests.
+
+use crate::{arbiter::CancelToken, diagnostics::Clock};
+use irlume_common::{
+    diagnostics::OperationId, live::*, live_camera::CameraInventorySnapshot, Request,
+};
+use std::collections::BTreeMap;
+use std::sync::{
+    atomic::{AtomicU8, Ordering},
+    Arc, Mutex, OnceLock,
+};
+
+#[derive(Clone)]
+pub(crate) struct LiveState(Arc<Shared>);
+struct Shared {
+    clock: Arc<dyn Clock>,
+    instance: OperationId,
+    inner: Mutex<Inner>,
+    cancel: OnceLock<CancelToken>,
+}
+struct Inner {
+    stage: LiveStage,
+    revision: u64,
+    waiting: BTreeMap<LiveOperationKind, u64>,
+    worker: Option<Worker>,
+    background: Vec<Worker>,
+    available: bool,
+}
+struct Worker {
+    id: OperationId,
+    kind: LiveOperationKind,
+    started_ms: u64,
+    cancelled: bool,
+}
+const CREATED: u8 = 0;
+const WAITING: u8 = 1;
+const RUNNING: u8 = 2;
+const FINISHED: u8 = 3;
+const UNTRACKED: u8 = 4;
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Lane {
+    Worker,
+    Background,
+}
+
+pub(crate) struct WorkerLifetime(LiveState);
+impl Drop for WorkerLifetime {
+    fn drop(&mut self) {
+        self.0.set_stage(LiveStage::Stopping);
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct LiveGuard(Arc<Registration>);
+struct Registration {
+    state: LiveState,
+    id: OperationId,
+    kind: LiveOperationKind,
+    changes_state: bool,
+    lane: Lane,
+    // Only accessed under state.inner; Atomic supplies interior mutability for
+    // shared guards without introducing an opposite lock order.
+    phase: AtomicU8,
+}
+
+impl LiveState {
+    pub(crate) fn new(instance: OperationId, clock: Arc<dyn Clock>) -> Self {
+        Self(Arc::new(Shared {
+            clock,
+            instance,
+            cancel: OnceLock::new(),
+            inner: Mutex::new(Inner {
+                stage: LiveStage::Starting,
+                revision: 0,
+                waiting: BTreeMap::new(),
+                worker: None,
+                background: Vec::new(),
+                available: true,
+            }),
+        }))
+    }
+    pub(crate) fn worker_lifetime(&self) -> WorkerLifetime {
+        WorkerLifetime(self.clone())
+    }
+    pub(crate) fn set_cancel_token(&self, token: CancelToken) {
+        let _ = self.0.cancel.set(token);
+    }
+    fn lock(&self) -> std::sync::MutexGuard<'_, Inner> {
+        self.0.inner.lock().unwrap_or_else(|error| {
+            let mut inner = error.into_inner();
+            inner.available = false;
+            inner
+        })
+    }
+    pub(crate) fn set_stage(&self, stage: LiveStage) {
+        let mut inner = self.lock();
+        // Shutdown wins over a concurrent startup/rebuild publication.
+        if inner.stage != LiveStage::Stopping {
+            inner.stage = stage;
+        }
+    }
+    pub(crate) fn register(
+        &self,
+        id: OperationId,
+        kind: LiveOperationKind,
+        changes_state: bool,
+    ) -> LiveGuard {
+        self.register_in_lane(id, kind, changes_state, Lane::Worker)
+    }
+    fn register_in_lane(
+        &self,
+        id: OperationId,
+        kind: LiveOperationKind,
+        changes_state: bool,
+        lane: Lane,
+    ) -> LiveGuard {
+        LiveGuard(Arc::new(Registration {
+            state: self.clone(),
+            id,
+            kind,
+            changes_state,
+            lane,
+            phase: AtomicU8::new(CREATED),
+        }))
+    }
+    pub(crate) fn register_background(&self, id: OperationId) -> LiveGuard {
+        self.register_in_lane(
+            id,
+            LiveOperationKind::CaptureQualification,
+            true,
+            Lane::Background,
+        )
+    }
+    pub(crate) fn snapshot(&self, cameras: CameraInventorySnapshot) -> LiveStatusSnapshot {
+        let inner = self.lock();
+        // Capture once: elapsed must never exceed the same snapshot's uptime.
+        let now_ms = self.0.clock.now_ms();
+        let worker = inner.worker.as_ref().map(|worker| {
+            // Read the shared stop bit under the tracker lock. The previous
+            // worker is removed before the next arbiter.take resets that bit.
+            let requested = self.0.cancel.get().is_some_and(|token| {
+                if matches!(
+                    worker.kind,
+                    LiveOperationKind::Authentication | LiveOperationKind::WalletAuthentication
+                ) {
+                    token.cancel_requested()
+                } else {
+                    token.stop_requested()
+                }
+            });
+            LiveWorkerOperation {
+                operation_id: worker.id,
+                kind: worker.kind,
+                elapsed_ms: now_ms.saturating_sub(worker.started_ms),
+                cancellation_requested: worker.cancelled || requested,
+            }
+        });
+        LiveStatusSnapshot {
+            live_schema: LIVE_SCHEMA_VERSION,
+            daemon_instance: self.0.instance,
+            daemon_uptime_ms: now_ms,
+            state_revision: inner.revision,
+            stage: inner.stage,
+            worker,
+            background: inner
+                .background
+                .iter()
+                .map(|task| LiveWorkerOperation {
+                    operation_id: task.id,
+                    kind: task.kind,
+                    elapsed_ms: now_ms.saturating_sub(task.started_ms),
+                    cancellation_requested: task.cancelled,
+                })
+                .collect(),
+            waiting: inner
+                .waiting
+                .iter()
+                .map(|(&kind, &count)| LiveWaitingCount { kind, count })
+                .collect(),
+            cameras,
+            tracking_available: inner.available,
+        }
+    }
+}
+impl LiveGuard {
+    pub(crate) fn waiting(&self) {
+        let mut inner = self.0.state.lock();
+        // A fast worker may have claimed/completed before submit returns.
+        if self.0.phase.load(Ordering::Relaxed) != CREATED {
+            return;
+        }
+        if self.0.lane != Lane::Worker {
+            inner.available = false;
+            return;
+        }
+        let count = inner.waiting.entry(self.0.kind).or_default();
+        if let Some(next) = count.checked_add(1) {
+            *count = next;
+        } else {
+            inner.available = false;
+        }
+        self.0.phase.store(WAITING, Ordering::Relaxed);
+    }
+    pub(crate) fn running(&self) {
+        let mut inner = self.0.state.lock();
+        match self.0.phase.load(Ordering::Relaxed) {
+            WAITING => remove_waiter(&mut inner, self.0.kind),
+            CREATED => {}
+            _ => return,
+        }
+        self.0.phase.store(RUNNING, Ordering::Relaxed);
+        let duplicate_id = inner
+            .worker
+            .as_ref()
+            .is_some_and(|worker| worker.id == self.0.id)
+            || inner.background.iter().any(|task| task.id == self.0.id);
+        let full = match self.0.lane {
+            Lane::Worker => inner.worker.is_some(),
+            Lane::Background => inner.background.len() == MAX_BACKGROUND_OPERATIONS,
+        };
+        if duplicate_id || full {
+            // Keep existing owners intact. This registration did run, so its
+            // eventual completion still invalidates potentially changed state.
+            inner.available = false;
+            self.0.phase.store(UNTRACKED, Ordering::Relaxed);
+            return;
+        }
+        let worker = Worker {
+            id: self.0.id,
+            kind: self.0.kind,
+            started_ms: self.0.state.0.clock.now_ms(),
+            cancelled: false,
+        };
+        match self.0.lane {
+            Lane::Worker => inner.worker = Some(worker),
+            Lane::Background => inner.background.push(worker),
+        }
+    }
+    pub(crate) fn cancel(&self) {
+        let mut inner = self.0.state.lock();
+        if self.0.phase.load(Ordering::Relaxed) == RUNNING {
+            let task = match self.0.lane {
+                Lane::Worker => inner
+                    .worker
+                    .as_mut()
+                    .filter(|worker| worker.id == self.0.id),
+                Lane::Background => inner
+                    .background
+                    .iter_mut()
+                    .find(|worker| worker.id == self.0.id),
+            };
+            if let Some(task) = task {
+                task.cancelled = true;
+            }
+        }
+    }
+    pub(crate) fn finish_waiting(&self) {
+        let mut inner = self.0.state.lock();
+        match self.0.phase.load(Ordering::Relaxed) {
+            WAITING => remove_waiter(&mut inner, self.0.kind),
+            CREATED => {}
+            _ => return,
+        }
+        self.0.phase.store(FINISHED, Ordering::Relaxed);
+    }
+    pub(crate) fn finish(&self) {
+        self.0.finish();
+    }
+}
+fn remove_waiter(inner: &mut Inner, kind: LiveOperationKind) {
+    match inner.waiting.get_mut(&kind) {
+        Some(count) if *count > 1 => *count -= 1,
+        Some(_) => {
+            inner.waiting.remove(&kind);
+        }
+        None => inner.available = false,
+    }
+}
+impl Registration {
+    fn finish(&self) {
+        let mut inner = self.state.lock();
+        match self.phase.swap(FINISHED, Ordering::Relaxed) {
+            WAITING => remove_waiter(&mut inner, self.kind),
+            phase @ (RUNNING | UNTRACKED) => {
+                if phase == RUNNING {
+                    match self.lane {
+                        Lane::Worker => {
+                            if inner
+                                .worker
+                                .as_ref()
+                                .is_some_and(|worker| worker.id == self.id)
+                            {
+                                inner.worker = None;
+                            } else {
+                                inner.available = false;
+                            }
+                        }
+                        Lane::Background => {
+                            if let Some(index) = inner
+                                .background
+                                .iter()
+                                .position(|worker| worker.id == self.id)
+                            {
+                                inner.background.swap_remove(index);
+                            } else {
+                                inner.available = false;
+                            }
+                        }
+                    }
+                }
+                // Completion invalidates even after an error or unwind: writes
+                // may have happened before the final response became unknown.
+                if self.changes_state {
+                    if let Some(next) = inner.revision.checked_add(1) {
+                        inner.revision = next;
+                    } else {
+                        inner.available = false;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+impl Drop for Registration {
+    fn drop(&mut self) {
+        self.finish();
+    }
+}
+
+/// Observer reads never register or advance invalidation. Exhaustive on purpose.
+pub(crate) fn request_kind(req: &Request) -> Option<(LiveOperationKind, bool)> {
+    use LiveOperationKind as K;
+    use Request::*;
+    Some(match req {
+        Authenticate { .. } => (K::Authentication, false),
+        UnsealPassword { .. } | UnsealKeyring { .. } => (K::WalletAuthentication, false),
+        Enroll { .. } | EnrollmentSession { .. } | AddScan { .. } => (K::Enrollment, true),
+        PositionSample { .. } | PositionSession { .. } => (K::Framing, false),
+        Identify => (K::Identification, false),
+        ListCameras => (K::CameraEnumeration, false),
+        SetCameras { .. } | SetCamerasIfCurrent { .. } => (K::CameraSetup, true),
+        SetupIrEmitter { dry_run } => (K::CameraSetup, !dry_run),
+        TuneCaptureMode { .. } => (K::CaptureQualification, true),
+        CaptureModeStatus | CameraDiagnostics | SelfTest { .. } | SupportProbe { .. } => {
+            (K::CameraDiagnostics, false)
+        }
+        ListProfiles { .. } => (K::ProfileRead, false),
+        DeleteProfile { .. }
+        | DeleteScan { .. }
+        | ForgetRecognizer { .. }
+        | RenameProfile { .. }
+        | RenameScan { .. }
+        | SetRequireEyesOpen { .. } => (K::ProfileUpdate, true),
+        FaceSensorStatus { user: Some(_) } => (K::SensorReadiness, false),
+        KeyringInfo { .. } => (K::WalletRead, false),
+        SealPassword { .. } | ResealPassword { .. } | ForgetPassword { .. } => {
+            (K::WalletUpdate, true)
+        }
+        ReleaseTokenForDisarm { .. } => (K::WalletRead, false),
+        RecoverySetup { .. } | RecoveryRestore { .. } | RecoveryForget { .. } => {
+            (K::RecoveryUpdate, true)
+        }
+        CaptureEarMedian { .. } | SetClosureCalibration { .. } => (K::Compatibility, false),
+        LiveStatus
+        | SupportSnapshot { .. }
+        | TraceSubscribe { .. }
+        | Ping
+        | Health
+        | PreferencesStatus
+        | FaceSensorStatus { user: None }
+        | HasSealedPassword { .. }
+        | KeyringMetadata { .. }
+        | RecoveryStatus { .. }
+        | RetryStatus { .. }
+        | RetryReset { .. } => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicU64;
+    #[derive(Default)]
+    struct TestClock(AtomicU64);
+    impl Clock for TestClock {
+        fn now_ms(&self) -> u64 {
+            self.0.load(Ordering::Relaxed)
+        }
+    }
+    fn setup() -> (LiveState, Arc<TestClock>) {
+        let clock = Arc::new(TestClock::default());
+        (
+            LiveState::new(OperationId::from_bytes([1; 16]), clock.clone()),
+            clock,
+        )
+    }
+    fn snapshot(state: &LiveState) -> LiveStatusSnapshot {
+        state.snapshot(CameraInventorySnapshot::default())
+    }
+    fn guard(state: &LiveState, id: u8, mutation: bool) -> LiveGuard {
+        state.register(
+            OperationId::from_bytes([id; 16]),
+            LiveOperationKind::Enrollment,
+            mutation,
+        )
+    }
+    #[test]
+    fn live_tracker_distinguishes_waiting_running_and_completion() {
+        let (state, clock) = setup();
+        let task = guard(&state, 2, true);
+        task.waiting();
+        assert_eq!(snapshot(&state).waiting[0].count, 1);
+        assert!(snapshot(&state).worker.is_none());
+        clock.0.store(25, Ordering::Relaxed);
+        task.running();
+        clock.0.store(75, Ordering::Relaxed);
+        assert_eq!(snapshot(&state).worker.unwrap().elapsed_ms, 50);
+        assert!(snapshot(&state).waiting.is_empty());
+        task.finish();
+        let done = snapshot(&state);
+        assert!(done.worker.is_none());
+        assert_eq!(done.state_revision, 1);
+    }
+    #[test]
+    fn live_tracker_late_admission_cannot_downgrade_running_or_finished() {
+        let (state, _) = setup();
+        let task = guard(&state, 2, true);
+        task.running();
+        task.waiting();
+        assert!(snapshot(&state).worker.is_some());
+        assert!(snapshot(&state).waiting.is_empty());
+        task.finish();
+        task.waiting();
+        task.running();
+        assert!(snapshot(&state).worker.is_none());
+        assert_eq!(snapshot(&state).state_revision, 1);
+    }
+    #[test]
+    fn live_tracker_clone_drop_does_not_release_worker_but_last_drop_does() {
+        let (state, _) = setup();
+        let task = guard(&state, 2, true);
+        let other = task.clone();
+        task.running();
+        drop(task);
+        assert!(snapshot(&state).worker.is_some());
+        drop(other);
+        assert!(snapshot(&state).worker.is_none());
+        assert_eq!(snapshot(&state).state_revision, 1);
+    }
+    #[test]
+    fn live_tracker_old_cancel_and_finish_cannot_touch_next_worker() {
+        let (state, _) = setup();
+        let old = guard(&state, 2, true);
+        old.running();
+        old.finish();
+        let next = guard(&state, 3, true);
+        next.running();
+        old.cancel();
+        old.finish();
+        let current = snapshot(&state).worker.unwrap();
+        assert_eq!(current.operation_id, OperationId::from_bytes([3; 16]));
+        assert!(!current.cancellation_requested);
+        next.cancel();
+        assert!(snapshot(&state).worker.unwrap().cancellation_requested);
+    }
+    #[test]
+    fn live_tracker_waiting_drop_and_refusal_do_not_invalidate_state() {
+        let (state, _) = setup();
+        let never_admitted = guard(&state, 2, true);
+        drop(never_admitted);
+        let waiting = guard(&state, 3, true);
+        waiting.waiting();
+        drop(waiting);
+        assert!(snapshot(&state).waiting.is_empty());
+        assert_eq!(snapshot(&state).state_revision, 0);
+    }
+    #[test]
+    fn live_tracker_observers_and_failed_mutations_have_distinct_revision_semantics() {
+        let (state, _) = setup();
+        assert!(request_kind(&Request::LiveStatus).is_none());
+        assert!(request_kind(&Request::SupportSnapshot { since_ms: 60_000 }).is_none());
+        for _ in 0..100 {
+            assert_eq!(snapshot(&state).state_revision, 0);
+        }
+        let failed_or_unknown = guard(&state, 2, true);
+        failed_or_unknown.running();
+        failed_or_unknown.finish();
+        assert_eq!(snapshot(&state).state_revision, 1);
+        let read = guard(&state, 3, false);
+        read.running();
+        read.finish();
+        assert_eq!(snapshot(&state).state_revision, 1);
+    }
+    #[test]
+    fn live_tracker_stages_and_large_waiting_sets_are_bounded() {
+        let (state, _) = setup();
+        state.set_stage(LiveStage::Rebuilding);
+        assert_eq!(snapshot(&state).stage, LiveStage::Rebuilding);
+        let tasks: Vec<_> = (0..1000)
+            .map(|_| {
+                let g = guard(&state, 2, false);
+                g.waiting();
+                g
+            })
+            .collect();
+        assert_eq!(snapshot(&state).waiting.len(), 1);
+        assert_eq!(snapshot(&state).waiting[0].count, 1000);
+        drop(tasks);
+        assert!(snapshot(&state).waiting.is_empty());
+    }
+    #[test]
+    fn live_tracker_unwind_cleans_running_metadata() {
+        let (state, _) = setup();
+        let copy = state.clone();
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+            let g = guard(&copy, 2, true);
+            g.running();
+            panic!("synthetic unwind");
+        }));
+        assert!(snapshot(&state).worker.is_none());
+        assert_eq!(snapshot(&state).state_revision, 1);
+    }
+    #[test]
+    fn live_tracker_waiting_cancellation_cannot_finish_a_running_worker() {
+        let (state, _) = setup();
+        let queued = guard(&state, 2, true);
+        queued.waiting();
+        queued.finish_waiting();
+        queued.running();
+        assert!(snapshot(&state).worker.is_none());
+        let running = guard(&state, 3, true);
+        running.running();
+        running.finish_waiting();
+        assert!(snapshot(&state).worker.is_some());
+        assert_eq!(snapshot(&state).state_revision, 0);
+        running.finish();
+        assert_eq!(snapshot(&state).state_revision, 1);
+    }
+    #[test]
+    fn live_tracker_worker_unwind_stops_stage_and_cannot_be_republished_ready() {
+        let (state, _) = setup();
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _lifetime = state.worker_lifetime();
+            state.set_stage(LiveStage::Ready);
+            panic!("synthetic worker panic");
+        }));
+        state.set_stage(LiveStage::Ready);
+        assert_eq!(snapshot(&state).stage, LiveStage::Stopping);
+    }
+    #[test]
+    fn live_tracker_shared_stop_distinguishes_authentication_preemption() {
+        let (state, _) = setup();
+        let token = CancelToken::new();
+        state.set_cancel_token(token.clone());
+        let auth = state.register(
+            OperationId::from_bytes([2; 16]),
+            LiveOperationKind::Authentication,
+            false,
+        );
+        auth.running();
+        token.request_stop();
+        assert!(!snapshot(&state).worker.unwrap().cancellation_requested);
+        token.request_cancel();
+        assert!(snapshot(&state).worker.unwrap().cancellation_requested);
+        auth.finish();
+        token.reset();
+        let enrollment = guard(&state, 3, true);
+        enrollment.running();
+        assert!(!snapshot(&state).worker.unwrap().cancellation_requested);
+        token.request_stop();
+        assert!(snapshot(&state).worker.unwrap().cancellation_requested);
+    }
+    #[test]
+    fn live_tracker_revision_overflow_and_poison_report_unavailable() {
+        let (state, _) = setup();
+        state.lock().revision = u64::MAX;
+        let operation = guard(&state, 2, true);
+        operation.running();
+        operation.finish();
+        assert_eq!(snapshot(&state).state_revision, u64::MAX);
+        assert!(!snapshot(&state).tracking_available);
+        let (poisoned, _) = setup();
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _lock = poisoned.0.inner.lock().unwrap();
+            panic!("synthetic poison");
+        }));
+        assert!(!snapshot(&poisoned).tracking_available);
+    }
+    #[test]
+    fn live_background_is_separate_from_worker_and_shared_cancellation() {
+        let (state, clock) = setup();
+        let token = CancelToken::new();
+        state.set_cancel_token(token.clone());
+        let worker = guard(&state, 2, false);
+        worker.running();
+        clock.0.store(10, Ordering::Relaxed);
+        let background = state.register_background(OperationId::from_bytes([3; 16]));
+        background.running();
+        clock.0.store(50, Ordering::Relaxed);
+        token.request_cancel();
+        let live = snapshot(&state);
+        assert!(live.tracking_available);
+        assert_eq!(
+            live.worker.unwrap().operation_id,
+            OperationId::from_bytes([2; 16])
+        );
+        assert_eq!(live.background.len(), 1);
+        assert_eq!(live.background[0].elapsed_ms, 40);
+        assert!(!live.background[0].cancellation_requested);
+        background.finish();
+        let done = snapshot(&state);
+        assert!(done.background.is_empty());
+        assert!(done.worker.is_some());
+        assert_eq!(done.state_revision, 1);
+    }
+    #[test]
+    fn live_background_unwind_releases_only_background_and_invalidates() {
+        let (state, _) = setup();
+        let worker = guard(&state, 2, false);
+        worker.running();
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let background = state.register_background(OperationId::from_bytes([3; 16]));
+            background.running();
+            assert_eq!(snapshot(&state).background.len(), 1);
+            panic!("synthetic background unwind");
+        }));
+        let live = snapshot(&state);
+        assert!(live.tracking_available);
+        assert!(live.worker.is_some());
+        assert!(live.background.is_empty());
+        assert_eq!(live.state_revision, 1);
+    }
+    #[test]
+    fn live_background_overflow_is_unavailable_and_never_grows_the_wire() {
+        let (state, _) = setup();
+        let tasks: Vec<_> = (2..=6)
+            .map(|id| {
+                let background = state.register_background(OperationId::from_bytes([id; 16]));
+                background.running();
+                background
+            })
+            .collect();
+        let live = snapshot(&state);
+        assert!(!live.tracking_available);
+        assert_eq!(live.background.len(), MAX_BACKGROUND_OPERATIONS);
+        drop(tasks);
+        assert!(snapshot(&state).background.is_empty());
+    }
+    #[test]
+    fn live_background_clone_drop_retains_owner_until_last_copy() {
+        let (state, _) = setup();
+        let worker = guard(&state, 2, false);
+        worker.running();
+        let background = state.register_background(OperationId::from_bytes([3; 16]));
+        let other = background.clone();
+        background.running();
+        drop(background);
+        assert_eq!(snapshot(&state).background.len(), 1);
+        drop(other);
+        let done = snapshot(&state);
+        assert!(done.background.is_empty());
+        assert!(done.worker.is_some());
+        assert_eq!(done.state_revision, 1);
+    }
+    #[test]
+    fn live_background_duplicate_registration_cannot_release_existing_owner() {
+        let (state, _) = setup();
+        let owner = state.register_background(OperationId::from_bytes([2; 16]));
+        owner.running();
+        let duplicate = state.register_background(OperationId::from_bytes([2; 16]));
+        duplicate.running();
+        duplicate.finish();
+        let live = snapshot(&state);
+        assert!(!live.tracking_available);
+        assert_eq!(live.background.len(), 1);
+        assert_eq!(
+            live.background[0].operation_id,
+            OperationId::from_bytes([2; 16])
+        );
+        owner.finish();
+        assert!(snapshot(&state).background.is_empty());
+    }
+}

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -60,6 +60,7 @@ pub(crate) mod test_support {
 mod arbiter;
 mod diagnostics;
 mod enrollment_session;
+mod live;
 mod operation_authorization;
 mod position_session;
 mod retry_recovery;
@@ -603,12 +604,20 @@ fn main() {
     let engine_ready = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     let arbiter = std::sync::Arc::new(arbiter::Arbiter::<Queued>::new());
     let diagnostic_state = std::sync::Arc::new(diagnostics::DiagnosticState::default());
+    diagnostic_state
+        .live()
+        .set_cancel_token(arbiter.cancel_token());
     {
         let arbiter = std::sync::Arc::clone(&arbiter);
         let engine_ready = std::sync::Arc::clone(&engine_ready);
+        let diagnostic_state = std::sync::Arc::clone(&diagnostic_state);
         std::thread::Builder::new()
             .name("irlume-startup".into())
             .spawn(move || {
+            // Descriptor monitoring is independent of model readiness, but its
+            // initialization must not delay the already-bound accept loop.
+            // LiveStatus only copies an existing publication; it never starts it.
+            irlume_auth::initialize_camera_monitor();
             eprintln!("irlumed: loading models (det={det}, model={model})…");
             // The recognizer's verified bytes come back and go straight into the
             // engine below (#346), so the 260MB file is read and hashed once per
@@ -655,7 +664,7 @@ fn main() {
             if !ir_dev.is_empty() {
                 eprintln!(
                     "irlumed: IR emitter verification deferred to the first authentication \
-                     (no camera opens at boot; every capture re-applies the known control)"
+                     (capture re-applies the known control)"
                 );
             }
             // Background auto-requalification (#586 gap): when the stored
@@ -670,6 +679,7 @@ fn main() {
             if !ir_dev.is_empty() && permits_background_requalification(startup_policy) {
                 let rgb_for_requalify = rgb_dev.clone();
                 let ir_for_requalify = ir_dev.clone();
+                let requalification_diagnostics = std::sync::Arc::clone(&diagnostic_state);
                 std::thread::Builder::new()
                     .name("irlume-requalify".into())
                     .spawn(move || {
@@ -689,6 +699,10 @@ fn main() {
                                      qualification; running a background requalification \\
                                      (the IR emitter fires for up to a minute)"
                                 );
+                                // This task bypasses the request worker. Its
+                                // separate guard begins only for actual probe
+                                // work, and drops on success, error or unwind.
+                                let _live_background = requalification_diagnostics.begin_background_qualification();
                                 match run_capture_mode_probe(
                                     &rgb_for_requalify,
                                     &ir_for_requalify,
@@ -914,9 +928,11 @@ fn main() {
             // read yet cannot be prioritised.
             let _worker = {
                 let arbiter = std::sync::Arc::clone(&arbiter);
+                let diagnostic_state = std::sync::Arc::clone(&diagnostic_state);
                 std::thread::Builder::new()
                     .name("irlume-camera".into())
                     .spawn(move || {
+                        let _live_worker_lifetime = diagnostic_state.live().worker_lifetime();
                         // The engine asks this between whole captures, so a long
                         // enrolment yields the camera to an authentication instead of
                         // making it wait for ten scans, and the watchdog (#141) reads
@@ -941,6 +957,7 @@ fn main() {
                             // the slot first, exactly as the normal path does, so the
                             // uid is not locked out of the camera.
                             if !link.claim() {
+                                link.finish_activity();
                                 scope.finish(
                                     irlume_common::diagnostics::CategoricalOutcome::Cancelled,
                                 );
@@ -970,6 +987,7 @@ fn main() {
                             let resp = match outcome {
                                 Ok(resp) => resp,
                                 Err(_) => {
+                                    diagnostic_state.live().set_stage(irlume_common::live::LiveStage::Rebuilding);
                                     eprintln!(
                                         "irlumed: request handler PANICKED; this request was denied \
                                          (PAM falls back to the password). Rebuilding the engine for a \
@@ -1017,9 +1035,11 @@ fn main() {
                                              with the existing engine"
                                         ),
                                     }
+                                    diagnostic_state.live().set_stage(irlume_common::live::LiveStage::Ready);
                                     Response::Error("request failed".into()).into()
                                 }
                             };
+                            link.finish_activity();
                             scope.finish(categorical_outcome(&resp.response));
                             // The client may already be gone; its thread owns that.
                             let _ = reply.send(resp);
@@ -1027,6 +1047,7 @@ fn main() {
                             // last job's timestamp behind would read as a wedge (#141).
                             note_worker_idle();
                         }
+                        diagnostic_state.live().set_stage(irlume_common::live::LiveStage::Stopping);
                     })
                     .unwrap_or_else(|e| {
                         // Without the worker nothing can be served, and a daemon that
@@ -1040,6 +1061,7 @@ fn main() {
                 // engine-free path. Release pairs with the Acquire load there,
                 // so a thread that sees `true` also sees the worker it needs.
                 engine_ready.store(true, std::sync::atomic::Ordering::Release);
+                diagnostic_state.live().set_stage(irlume_common::live::LiveStage::Ready);
             })
             .unwrap_or_else(|e| {
                 eprintln!("irlumed: could not start the startup thread: {e}");
@@ -1173,6 +1195,9 @@ fn main() {
             Err(e) => eprintln!("irlumed: accept error: {e}"),
         }
     }
+    diagnostic_state
+        .live()
+        .set_stage(irlume_common::live::LiveStage::Stopping);
     arbiter.close();
     // The accept loop above only ends if the listener dies; nothing to join.
 }
@@ -1573,6 +1598,7 @@ struct Queued {
 #[derive(Default)]
 struct ClientLink {
     state: std::sync::Mutex<ClientState>,
+    activity: Option<live::LiveGuard>,
 }
 
 #[derive(Default)]
@@ -1598,6 +1624,9 @@ impl ClientLink {
             return false;
         }
         *state = ClientState::Running;
+        if let Some(activity) = &self.activity {
+            activity.running();
+        }
         true
     }
 
@@ -1606,6 +1635,12 @@ impl ClientLink {
     /// this boundary into the next job's freshly reset shared token.
     fn released(&self) {
         *self.lock() = ClientState::Released;
+    }
+
+    fn finish_activity(&self) {
+        if let Some(activity) = &self.activity {
+            activity.finish();
+        }
     }
 
     /// Connection side: abandon this request and stop it if it owns the camera.
@@ -1618,7 +1653,16 @@ impl ClientLink {
         let running = matches!(*state, ClientState::Running);
         *state = ClientState::Abandoned;
         if running {
+            if let Some(activity) = &self.activity {
+                activity.cancel();
+            }
             stop.request_cancel();
+        } else {
+            // A cancelled queued request is no longer waiting for worker work.
+            // RUNNING completion is left to the worker, even after disconnect.
+            if let Some(activity) = &self.activity {
+                activity.finish_waiting();
+            }
         }
         running
     }
@@ -2813,7 +2857,8 @@ fn serve_peer(
             // startup instead of replacing them with a generic starting reply.
             if matches!(
                 req,
-                Request::SupportSnapshot { .. }
+                Request::LiveStatus
+                    | Request::SupportSnapshot { .. }
                     | Request::FaceSensorStatus { .. }
                     | Request::PreferencesStatus
             ) {
@@ -2886,7 +2931,15 @@ fn serve_peer(
                 };
             let scope = diagnostic_state.begin(diagnostic_operation_class(&req));
             let (reply, answer) = std::sync::mpsc::channel();
-            let link = std::sync::Arc::new(ClientLink::default());
+            let activity = live::request_kind(&req).map(|(kind, changes_state)| {
+                diagnostic_state
+                    .live()
+                    .register(scope.operation_id(), kind, changes_state)
+            });
+            let link = std::sync::Arc::new(ClientLink {
+                activity: activity.clone(),
+                ..ClientLink::default()
+            });
             let queued = Queued {
                 authorization,
                 session,
@@ -2905,6 +2958,9 @@ fn serve_peer(
                 record_refusal(peer.uid);
                 scope.finish(irlume_common::diagnostics::CategoricalOutcome::Unavailable);
                 return respond(stream, &Response::Error(refusal.message().into()));
+            }
+            if let Some(activity) = &activity {
+                activity.waiting();
             }
             // Wait for the worker, checking between slices whether the client is
             // still there. A polkit dialog the user dismissed (or that closed on a
@@ -3277,7 +3333,7 @@ fn posture(req: &Request) -> RequestPosture<'_> {
         },
         // Root-only and account-free: system-wide camera policy under /etc,
         // and a self-test whose raw liveness numbers are a spoof-tuning oracle.
-        SetCameras { .. } => RequestPosture {
+        SetCameras { .. } | SetCamerasIfCurrent { .. } => RequestPosture {
             privilege: RootOnly {
                 command: "set_cameras",
             },
@@ -3350,7 +3406,8 @@ fn posture(req: &Request) -> RequestPosture<'_> {
         | ListCameras
         | CameraDiagnostics
         | CaptureModeStatus
-        | SupportSnapshot { .. } => RequestPosture {
+        | SupportSnapshot { .. }
+        | LiveStatus => RequestPosture {
             privilege: AnyPeer,
             user: None,
             enrollment: Reads,
@@ -3360,15 +3417,15 @@ fn posture(req: &Request) -> RequestPosture<'_> {
 
 /// The engine-derived facts `Health` reports, published once the engine is
 /// built (and again after a panic rebuild) so status requests can answer on
-/// the connection thread without touching the engine. The socket binds only
-/// after the first publish, so no connection can observe the empty state.
+/// the connection thread without touching the engine. Camera switches update
+/// the selection fields. Before the engine is ready, Health reports startup.
 #[derive(Clone, Default)]
 struct EngineBits {
     mesh: bool,
     adapter: bool,
     rgb_pad: Option<irlume_common::PadModelStatus>,
     ir_pad: Option<irlume_common::PadModelStatus>,
-    /// The camera facts as the ENGINE observed them when it loaded, so
+    /// The engine's camera selection and tier at load or the latest switch, so
     /// `Health` can answer from memory. Probing them per request opened
     /// video nodes on a connection thread, outside the camera worker's
     /// serialization, which is a second opener racing the worker's own
@@ -3388,32 +3445,42 @@ fn publish_engine_bits_raw(bits: EngineBits) {
     *engine_bits().lock().unwrap_or_else(|e| e.into_inner()) = bits;
 }
 
+/// Publish the engine's changed selection without discovering or opening any
+/// device. Physical connection state belongs to the passive inventory.
+fn publish_engine_camera_selection(engine: &irlume_auth::Engine) {
+    let mut bits = engine_bits().lock().unwrap_or_else(|e| e.into_inner());
+    copy_engine_camera_selection(&mut bits, engine);
+}
+
+fn copy_engine_camera_selection(bits: &mut EngineBits, engine: &irlume_auth::Engine) {
+    bits.rgb_dev = (!engine.rgb_device().is_empty()).then(|| engine.rgb_device().to_owned());
+    bits.ir_dev = (!engine.ir_device().is_empty()).then(|| engine.ir_device().to_owned());
+    bits.tier = if bits.rgb_dev.is_none() && bits.ir_dev.is_none() {
+        "none"
+    } else if engine.tier() == irlume_auth::Tier::Secure {
+        "secure"
+    } else {
+        "convenience"
+    }
+    .into();
+}
+
 fn publish_engine_bits(
     engine: &irlume_auth::Engine,
     rgb_pad: irlume_common::PadModelStatus,
     ir_pad: irlume_common::PadModelStatus,
 ) {
-    // Dual retains its discovery path. Experimental IR uses configured sysfs
-    // evidence only; status publication must not cause an RGB camera open.
-    let devices = select_engine_devices(irlume_common::config::observe_face_sensor_policy());
-    let rgb_dev = devices.rgb_available.then_some(devices.rgb);
-    let ir_dev = devices.ir_available.then_some(devices.ir);
-    let tier = if ir_dev.is_some() {
-        "secure"
-    } else if rgb_dev.is_some() {
-        "convenience"
-    } else {
-        "none"
-    };
-    publish_engine_bits_raw(EngineBits {
+    // All fields come from this engine. A second discovery could select a
+    // different pair after hotplug and open devices merely to publish status.
+    let mut bits = EngineBits {
         mesh: engine.has_mesh(),
         adapter: engine.has_ir_adapter(),
         rgb_pad: Some(rgb_pad),
         ir_pad: Some(ir_pad),
-        tier: tier.into(),
-        rgb_dev,
-        ir_dev,
-    });
+        ..EngineBits::default()
+    };
+    copy_engine_camera_selection(&mut bits, engine);
+    publish_engine_bits_raw(bits);
 }
 
 /// One user's enrollment as the status path may report it, published by the
@@ -3785,6 +3852,19 @@ fn dispatch_status_with_diagnostics(
     if let Some(resp) = pregate(req, peer) {
         return Some(resp);
     }
+    if matches!(req, Request::LiveStatus) {
+        return Some(match diagnostic_state {
+            Some(state) => Response::LiveStatus(Box::new(
+                state
+                    .live()
+                    .snapshot(irlume_auth::camera_inventory_snapshot()),
+            )),
+            None => Response::OperationError {
+                code: irlume_common::OperationErrorCode::OperationFailed,
+                retryable: false,
+            },
+        });
+    }
     if let Request::SupportSnapshot { since_ms } = req {
         return Some(match diagnostic_state {
             Some(state) => Response::SupportSnapshot(Box::new(
@@ -3811,12 +3891,12 @@ fn dispatch_status_with_diagnostics(
         },
         Request::Ping => Response::Pong,
         Request::Health => {
-            // MEMORY ONLY. The camera facts were probed once when the engine
-            // loaded and published with the rest of the bits; probing here
+            // MEMORY ONLY. Camera selection is published when the engine
+            // loads or a camera switch changes it; probing here
             // opened video nodes on a connection thread while the worker
-            // might be streaming them (#187 review). A camera that appears
-            // or vanishes is picked up at the next engine (re)load, which is
-            // also when the daemon could act on it.
+            // might be streaming them (#187 review). These are engine selection
+            // and tier observations; current connection state is independently
+            // reported by LiveStatus's passive inventory.
             Response::Health {
                 tier: bits.tier.clone(),
                 rgb_dev: bits.rgb_dev.clone(),
@@ -4395,6 +4475,7 @@ fn diagnostic_operation_class(req: &Request) -> irlume_common::diagnostics::Oper
         | ListCameras
         | CameraDiagnostics => OperationClass::CameraDiagnostics,
         SetCameras { .. }
+        | SetCamerasIfCurrent { .. }
         | FaceSensorStatus { .. }
         | PreferencesStatus
         | ListProfiles { .. }
@@ -4409,6 +4490,7 @@ fn diagnostic_operation_class(req: &Request) -> irlume_common::diagnostics::Oper
         | Ping
         | Health
         | SupportSnapshot { .. }
+        | LiveStatus
         | TraceSubscribe { .. }
         | SealPassword { .. }
         | HasSealedPassword { .. }
@@ -4458,6 +4540,57 @@ fn camera_path_is_serializable(path: &str) -> bool {
         || (std::path::Path::new(path).is_absolute()
             && path.trim() == path
             && !path.chars().any(char::is_control))
+}
+
+/// Shared mutation after request posture and any continuity guard have passed.
+fn set_camera_devices(rgb: &str, ir: &str, engine: &mut irlume_auth::Engine) -> Response {
+    // Root only (posture table): this persists to /etc and repoints the
+    // camera the daemon trusts, and an attacker who could set it to a
+    // v4l2loopback node feeds recorded video into the match path
+    // (spoof) or bricks face auth (DoS).
+    if !camera_path_is_serializable(rgb) || !camera_path_is_serializable(ir) {
+        return Response::Error(
+            "camera paths must be empty or absolute, without control characters or surrounding whitespace"
+                .into(),
+        );
+    }
+    engine.set_devices(rgb, ir);
+    publish_engine_camera_selection(engine);
+    let mut msg = format!("cameras set to rgb={rgb} ir={ir}");
+    // Record each node's stable device identity (vid:pid:serial) next to
+    // its path so select_pair can survive a udev renumber: after an
+    // upgrade shuffles /dev/videoN, the identity re-anchors the pin to the
+    // right sensor instead of trusting a now-stale number. An empty value
+    // clears a stale id when the current node has no USB descriptor.
+    let rgb_id = irlume_auth::device_identity(rgb).unwrap_or_default();
+    let ir_id = irlume_auth::device_identity(ir).unwrap_or_default();
+    // One publication, under the file's own lock. The four writes were
+    // individually atomic and collectively not: a reader racing the
+    // sequence could see one camera's RGB path beside another's IR path,
+    // a write failing partway left the earlier keys published, and an
+    // unlocked rewrite could erase a locked writer's keys (#365, #374).
+    // `write_camera_pin` now takes the lock AND builds the whole file
+    // once, so the pin lands whole or not at all.
+    if let Err(e) = irlume_common::config::write_camera_pin(rgb, ir, &rgb_id, &ir_id) {
+        msg = format!("{msg} (live only; could not persist: {e})");
+    }
+    eprintln!("irlumed: {msg}");
+    Response::Ok(msg)
+}
+
+fn set_cameras_if_current(
+    rgb: &str,
+    ir: &str,
+    expected: &irlume_common::live_camera::CameraSelection,
+    inventory: &irlume_common::live_camera::CameraInventorySnapshot,
+    engine: &mut irlume_auth::Engine,
+) -> Response {
+    if !expected.matches(inventory, rgb, ir) {
+        return Response::Error(
+            "camera connection changed or its current inventory is unavailable; select the camera again in the TUI".into(),
+        );
+    }
+    set_camera_devices(rgb, ir, engine)
 }
 
 #[cfg(test)]
@@ -4622,6 +4755,7 @@ fn dispatch_scoped_session_inner(
         | Request::KeyringMetadata { .. }
         | Request::RecoveryStatus { .. }
         | Request::SupportSnapshot { .. }
+        | Request::LiveStatus
         | Request::TraceSubscribe { .. } => {
             Response::Error("status request routed past its handler".into())
         }
@@ -4914,39 +5048,14 @@ fn dispatch_scoped_session_inner(
                 Err(e) => Response::Error(e.to_string()),
             }
         }
-        Request::SetCameras { rgb, ir } => {
-            // Root only (posture table): this persists to /etc and repoints the
-            // camera the daemon trusts, and an attacker who could set it to a
-            // v4l2loopback node feeds recorded video into the match path
-            // (spoof) or bricks face auth (DoS).
-            if !camera_path_is_serializable(&rgb) || !camera_path_is_serializable(&ir) {
-                return Response::Error(
-                    "camera paths must be empty or absolute, without control characters or surrounding whitespace"
-                        .into(),
-                );
-            }
-            engine.set_devices(&rgb, &ir);
-            let mut msg = format!("cameras set to rgb={rgb} ir={ir}");
-            // Record each node's stable device identity (vid:pid:serial) next to
-            // its path so select_pair can survive a udev renumber: after an
-            // upgrade shuffles /dev/videoN, the identity re-anchors the pin to the
-            // right sensor instead of trusting a now-stale number. An empty value
-            // clears a stale id when the current node has no USB descriptor.
-            let rgb_id = irlume_auth::device_identity(&rgb).unwrap_or_default();
-            let ir_id = irlume_auth::device_identity(&ir).unwrap_or_default();
-            // One publication, under the file's own lock. The four writes were
-            // individually atomic and collectively not: a reader racing the
-            // sequence could see one camera's RGB path beside another's IR path,
-            // a write failing partway left the earlier keys published, and an
-            // unlocked rewrite could erase a locked writer's keys (#365, #374).
-            // `write_camera_pin` now takes the lock AND builds the whole file
-            // once, so the pin lands whole or not at all.
-            if let Err(e) = irlume_common::config::write_camera_pin(&rgb, &ir, &rgb_id, &ir_id) {
-                msg = format!("{msg} (live only; could not persist: {e})");
-            }
-            eprintln!("irlumed: {msg}");
-            Response::Ok(msg)
-        }
+        Request::SetCamerasIfCurrent { rgb, ir, expected } => set_cameras_if_current(
+            &rgb,
+            &ir,
+            &expected,
+            &irlume_auth::camera_inventory_snapshot(),
+            engine,
+        ),
+        Request::SetCameras { rgb, ir } => set_camera_devices(&rgb, &ir, engine),
         Request::Enroll {
             user,
             profile,
@@ -7207,8 +7316,9 @@ mod tests {
         //
         // `include_str!` and not a runtime read: a renamed or deleted module
         // is then a compile error rather than a silently smaller scan.
-        let sources: [(&str, &str); 10] = [
+        let sources: [(&str, &str); 11] = [
             ("main.rs", include_str!("main.rs")),
+            ("live.rs", include_str!("live.rs")),
             ("users.rs", include_str!("users.rs")),
             (
                 "retry_throttle.rs",
@@ -7616,6 +7726,18 @@ mod tests {
             reset: false,
         },
         Identify => Request::Identify,
+        SetCamerasIfCurrent => Request::SetCamerasIfCurrent {
+            rgb: "/dev/video0".into(),
+            ir: "/dev/video1".into(),
+            expected: irlume_common::live_camera::CameraSelection {
+                supervisor_id: "11111111111111111111111111111111".into(),
+                candidate: irlume_common::live_camera::CameraCandidate {
+                    instance_id: "22222222222222222222222222222222".into(),
+                    generation: 1,
+                    endpoint_paths: vec!["/dev/video0".into(), "/dev/video1".into()],
+                },
+            },
+        },
         SetCameras => Request::SetCameras {
             rgb: "/dev/video0".into(),
             ir: "/dev/video2".into(),
@@ -7678,6 +7800,7 @@ mod tests {
         Health => Request::Health,
         CameraDiagnostics => Request::CameraDiagnostics,
         SupportSnapshot => Request::SupportSnapshot { since_ms: 60_000 },
+        LiveStatus => Request::LiveStatus,
         SupportProbe => Request::SupportProbe { since_ms: 60_000 },
         TraceSubscribe => Request::TraceSubscribe { duration_ms: 60_000, trace_schema: None },
         // The user-bearing form, so the traversal walk covers it.
@@ -8484,6 +8607,115 @@ mod tests {
         assert_eq!(snapshot.events().len(), 1);
         arbiter.close();
         assert!(arbiter.take().is_none(), "snapshot must never queue");
+    }
+
+    #[test]
+    fn live_status_answers_before_readiness_without_worker_or_history() {
+        use std::io::{BufRead as _, BufReader, Write as _};
+        let arbiter = arbiter::Arbiter::<Queued>::new();
+        let ready = std::sync::atomic::AtomicBool::new(false);
+        let diagnostics = diagnostics::DiagnosticState::default();
+        let seeded = diagnostics.begin(irlume_common::diagnostics::OperationClass::Authentication);
+        seeded.finish(irlume_common::diagnostics::CategoricalOutcome::Denied);
+        let before = diagnostics.snapshot(std::time::Duration::from_secs(60));
+        let mut instance = None;
+        for _ in 0..3 {
+            let response = with_serve_and_diagnostics(&arbiter, &ready, &diagnostics, |client| {
+                (&*client).write_all(b"\"LiveStatus\"\n").unwrap();
+                let mut line = String::new();
+                BufReader::new(client).read_line(&mut line).unwrap();
+                serde_json::from_str::<Response>(line.trim()).unwrap()
+            });
+            let Response::LiveStatus(snapshot) = response else {
+                panic!("expected memory-only live status");
+            };
+            assert_eq!(snapshot.stage, irlume_common::live::LiveStage::Starting);
+            assert!(snapshot.worker.is_none());
+            assert!(snapshot.waiting.is_empty());
+            assert!(snapshot.tracking_available);
+            assert_eq!(snapshot.state_revision, 0);
+            if let Some(previous) = instance {
+                assert_eq!(snapshot.daemon_instance, previous);
+            }
+            instance = Some(snapshot.daemon_instance);
+        }
+        let after = diagnostics.snapshot(std::time::Duration::from_secs(60));
+        // Ages advance while polling; retained identities, sequence and facts
+        // must remain unchanged, and no observer events may be appended.
+        let event_facts = |snapshot: &irlume_common::diagnostics::SupportSnapshot| {
+            snapshot
+                .events()
+                .iter()
+                .map(|event| {
+                    (
+                        event.sequence,
+                        event.operation_id,
+                        event.operation,
+                        event.kind.clone(),
+                    )
+                })
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(event_facts(&after), event_facts(&before));
+        arbiter.close();
+        assert!(arbiter.take().is_none(), "observer must never queue");
+    }
+
+    #[test]
+    fn live_status_client_link_preserves_owner_and_completion_after_disconnect() {
+        use irlume_common::live::LiveOperationKind;
+        let diagnostics = diagnostics::DiagnosticState::default();
+        let snapshot = || {
+            diagnostics
+                .live()
+                .snapshot(irlume_common::live_camera::CameraInventorySnapshot::default())
+        };
+        let token = arbiter::CancelToken::new();
+        let first = ClientLink {
+            activity: Some(
+                diagnostics.live().register(
+                    diagnostics
+                        .begin(irlume_common::diagnostics::OperationClass::Enrollment)
+                        .operation_id(),
+                    LiveOperationKind::Enrollment,
+                    true,
+                ),
+            ),
+            ..ClientLink::default()
+        };
+        first.activity.as_ref().unwrap().waiting();
+        assert!(first.claim());
+        assert!(first.abandon(&token));
+        assert!(snapshot().worker.unwrap().cancellation_requested);
+        assert_eq!(snapshot().state_revision, 0, "disconnect is not completion");
+        first.released();
+        first.finish_activity();
+        token.reset();
+        let second = ClientLink {
+            activity: Some(
+                diagnostics.live().register(
+                    diagnostics
+                        .begin(irlume_common::diagnostics::OperationClass::Authentication)
+                        .operation_id(),
+                    LiveOperationKind::Authentication,
+                    false,
+                ),
+            ),
+            ..ClientLink::default()
+        };
+        assert!(second.claim());
+        let second_id = snapshot().worker.unwrap().operation_id;
+        assert!(!first.abandon(&token));
+        first.finish_activity();
+        let live = snapshot();
+        assert_eq!(live.worker.as_ref().unwrap().operation_id, second_id);
+        assert!(!live.worker.unwrap().cancellation_requested);
+        assert!(!token.cancel_requested());
+        assert_eq!(live.state_revision, 1);
+        second.released();
+        second.finish_activity();
+        assert!(snapshot().worker.is_none());
+        assert_eq!(snapshot().state_revision, 1);
     }
 
     /// Exercise the production socket route: invalid intent is a recorded typed
@@ -12908,6 +13140,52 @@ mod tests {
     }
 
     #[test]
+    fn status_publication_does_not_rediscover_devices() {
+        let source = include_str!("main.rs");
+        let publication = source
+            .split("fn publish_engine_camera_selection(")
+            .nth(1)
+            .unwrap()
+            .split("/// One user's enrollment")
+            .next()
+            .unwrap();
+        assert!(!publication.contains("select_engine_devices"), "publishing status must copy the actual engine selection without a second camera discovery");
+        assert!(
+            !publication.contains("observe_face_sensor_policy"),
+            "status publication must not reselect from a newer policy"
+        );
+    }
+
+    #[test]
+    fn status_publication_copies_selected_paths_without_changing_model_facts() {
+        let _guard = env_lock();
+        let mut e = engine();
+        let original_paths = (e.rgb_device().to_owned(), e.ir_device().to_owned());
+        e.set_devices("/dev/irlume-no-probe-rgb", "/dev/irlume-no-probe-ir");
+        let mut bits = EngineBits {
+            mesh: true,
+            adapter: true,
+            ..EngineBits::default()
+        };
+        copy_engine_camera_selection(&mut bits, &e);
+        assert!(bits.mesh && bits.adapter);
+        assert_eq!(bits.rgb_dev.as_deref(), Some("/dev/irlume-no-probe-rgb"));
+        assert_eq!(bits.ir_dev.as_deref(), Some("/dev/irlume-no-probe-ir"));
+        let expected_tier = if e.tier() == irlume_auth::Tier::Secure {
+            "secure"
+        } else {
+            "convenience"
+        };
+        assert_eq!(bits.tier, expected_tier);
+        e.set_devices("", "");
+        copy_engine_camera_selection(&mut bits, &e);
+        assert!(bits.rgb_dev.is_none() && bits.ir_dev.is_none());
+        assert_eq!(bits.tier, "none");
+        assert!(bits.mesh && bits.adapter);
+        e.set_devices(&original_paths.0, &original_paths.1);
+    }
+
+    #[test]
     fn set_cameras_syntax_preserves_empty_stable_and_custom_paths() {
         for path in [
             "",
@@ -12929,9 +13207,95 @@ mod tests {
     }
 
     #[test]
+    fn set_cameras_if_current_checks_identity_before_engine_and_config_changes() {
+        use irlume_common::live_camera::{
+            CameraCandidate, CameraInventorySnapshot, CameraInventoryState, CameraSelection,
+        };
+        let _guard = env_lock();
+        let mut e = engine();
+        let previous_bits = engine_bits().lock().unwrap().clone();
+        let _sandbox = sandbox("guarded-setcam");
+        let (rgb, ir) = ("/dev/irlume-test-alt-rgb", "/dev/irlume-test-alt-ir");
+        let candidate = CameraCandidate {
+            instance_id: "22222222222222222222222222222222".into(),
+            generation: 1,
+            endpoint_paths: vec![rgb.into(), ir.into()],
+        };
+        let expected = CameraSelection {
+            supervisor_id: "11111111111111111111111111111111".into(),
+            candidate: candidate.clone(),
+        };
+        let inventory = CameraInventorySnapshot {
+            state: CameraInventoryState::Current,
+            supervisor_id: Some(expected.supervisor_id.clone()),
+            revision: 1,
+            observed_ago_ms: Some(0),
+            reason: None,
+            candidates: vec![candidate],
+        };
+        let unprivileged = dispatch(
+            Request::SetCamerasIfCurrent {
+                rgb: rgb.into(),
+                ir: ir.into(),
+                expected: expected.clone(),
+            },
+            &peer(NOBODY),
+            &mut e,
+        );
+        assert!(
+            matches!(unprivileged, Response::Error(ref message) if message.contains("requires root"))
+        );
+        assert_eq!((e.rgb_device(), e.ir_device()), (NO_RGB, NO_IR));
+        let pin = irlume_common::config::config_path("cameras.conf");
+        assert!(!pin.exists());
+
+        // Inject only copied metadata; no monitor, video node or camera capture
+        // is started. The same guarded helper is called by production dispatch.
+        assert!(matches!(
+            set_cameras_if_current(rgb, ir, &expected, &inventory, &mut e),
+            Response::Ok(_)
+        ));
+        assert_eq!((e.rgb_device(), e.ir_device()), (rgb, ir));
+        assert!(matches!(dispatch_status(&Request::Health, &peer(0)),
+            Some(Response::Health { rgb_dev: Some(ref selected_rgb), ir_dev: Some(ref selected_ir), .. })
+                if selected_rgb == rgb && selected_ir == ir));
+        let saved = std::fs::read(&pin).unwrap();
+        for change in ["refreshing", "removed", "replaced", "generation", "restart"] {
+            let mut changed = inventory.clone();
+            match change {
+                "refreshing" => changed.state = CameraInventoryState::Refreshing,
+                "removed" => changed.candidates.clear(),
+                "replaced" => {
+                    changed.candidates[0].instance_id = "33333333333333333333333333333333".into()
+                }
+                "generation" => changed.candidates[0].generation += 1,
+                "restart" => {
+                    changed.supervisor_id = Some("44444444444444444444444444444444".into())
+                }
+                _ => unreachable!(),
+            }
+            assert!(
+                matches!(set_cameras_if_current(rgb, ir, &expected, &changed, &mut e), Response::Error(ref message)
+                if message.contains("select the camera again")),
+                "{change}"
+            );
+            assert_eq!((e.rgb_device(), e.ir_device()), (rgb, ir), "{change}");
+            assert_eq!(std::fs::read(&pin).unwrap(), saved, "{change}");
+        }
+        assert!(matches!(
+            set_cameras_if_current(rgb, rgb, &expected, &inventory, &mut e),
+            Response::Error(_)
+        ));
+        assert_eq!(std::fs::read(&pin).unwrap(), saved);
+        e.set_devices(NO_RGB, NO_IR);
+        publish_engine_bits_raw(previous_bits);
+    }
+
+    #[test]
     fn set_cameras_requires_root_then_repoints_and_persists() {
         let _g = env_lock();
         let mut e = engine();
+        let previous_bits = engine_bits().lock().unwrap().clone();
         let sb = sandbox("setcam");
         let _ = &sb;
         match dispatch(
@@ -13000,6 +13364,7 @@ mod tests {
         }
         // Restore the shared engine's baseline devices.
         e.set_devices(NO_RGB, NO_IR);
+        publish_engine_bits_raw(previous_bits);
     }
 
     #[test]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,8 +15,9 @@
 The two untrusted clients, `pam_irlume.so` and the `irlume` CLI, reach the
 privileged daemon through a single `SO_PEERCRED`-checked Unix socket. Everything
 sensitive (the camera, IR emitter, ONNX models, enrolled templates, and the TPM)
-lives only inside `irlumed`, which serially handles one request at a time (the camera is one
-shared resource; RGB and IR capture within a request run concurrently):
+lives only inside `irlumed`. Its biometric worker serializes engine and camera
+work; connection threads also serve lightweight status requests. The camera is
+one shared resource; RGB and IR capture within a request can run concurrently:
 
 ```mermaid
 flowchart LR
@@ -65,6 +66,42 @@ flowchart LR
   login password is released only to a root peer. (We use a raw Unix socket +
   explicit peer check rather than D-Bus policy; that is the concrete hardening
   over the `visage` reference design.)
+
+## Live interface observations
+
+`LiveStatus` is an additive, unprivileged read on the peer-checked socket. It
+copies bounded metadata before engine readiness and without entering the
+biometric worker: daemon instance and stage, current worker operation, waiting
+counts, independently tracked background qualification, and the passive camera
+inventory. Polling does not create diagnostic
+history events, initialize monitors, open camera nodes or read the TPM.
+
+Worker registration follows admission, claim, cancellation request and actual
+completion. A cancellation request does not clear running work. Closed operation
+categories omit account names, request arguments and biometric outcomes. A
+state revision advances after potentially mutating work; it tells clients to
+invalidate their observations, not that a write succeeded. This is a logical
+mutation hint, not a disk-write audit: best-effort storage upgrades during a
+profile read do not recursively invalidate that read. Background qualification
+has its own scoped lifetime and does not infer cancellation from the foreground
+worker's stop signal.
+
+Camera connection metadata comes from the daemon's independently initialized
+udev/sysfs monitor. Its copied publication distinguishes current, refreshing,
+uninitialized and unavailable, including a valid empty UVC inventory. Instance
+and generation identify continuity within a supervisor lifetime. RGB/IR role
+classification remains a separate node-opening operation; passive connection
+metadata cannot establish roles, privacy state or physical streaming state.
+The TUI's camera switch carries the selected supervisor and candidate identity
+through sudo. `SetCamerasIfCurrent` checks that observation again before changing
+the pin. The distinct request prevents an older daemon from silently ignoring
+the continuity guard; the original headless `SetCameras` request remains available.
+
+The TUI tracks source freshness and invalidation generations separately. Old
+in-flight responses cannot satisfy a newer explicit refresh. A missing or
+unsupported live response becomes unavailable, not idle. Session history is a
+separate record of TUI observations; neither source claims to audit every process
+or prove physical camera/emitter shutdown.
 
 ## Authentication flow
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -80,6 +80,13 @@ Conventions that apply everywhere:
 
 ## TUI access
 
+Open **Irlume** from your desktop's application menu or run `irlume tui`. The desktop
+entry uses your desktop's terminal launcher and starts as your account.
+F3 chooses a section, F4 opens Current observations, F6 focuses page actions,
+and Shift+L opens detailed session history. The observations panel shows each
+source's age and availability; session history records earlier activity.
+Administrator access remains attached to the individual action.
+
 Press **F2** in the TUI to search additional CLI tasks, fill their options, and
 review the account and effects before running them. See the [workflow and parity
 reference](TUI.md), including multi-person profiles and appearance scans.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -16,13 +16,17 @@ you out.
 
 ## Guided setup (TUI)
 
-See [TUI workflows and CLI parity](TUI.md) for F2 More actions and the
-existing-person versus new-person enrollment flow.
+Open **Irlume** from the application menu. Your desktop opens it in a terminal;
+administrator approval is requested only by the actions that need it. You can
+also launch it directly:
 
 
 ```sh
 irlume tui
 ```
+
+Use a window of at least **80 columns × 24 rows**. Smaller windows show a resize
+message; enlarge the terminal to return to the same page or dialog.
 
 The TUI opens as a settings app with stable, grouped navigation and an
 **Overview** that shows live status plus the next recommended action. Use the
@@ -31,6 +35,13 @@ sidebar or click a status row to jump directly to a section; `Tab`/`⇧Tab` and
 (Cameras and Test Recognition), `[A]` expands recent activity, and `[?]` shows
 every action for the current section. Footer actions, selectable rows, and the
 sidebar can all be clicked.
+
+**F3** opens a section chooser, **F4** opens Current observations, and **F6**
+focuses page actions for keyboard use. The observations panel shows each source's
+age and availability; **Shift+L** opens full-height session history with timestamps
+and details of earlier activity.
+See [TUI workflows and CLI parity](TUI.md) for all controls, Activity's scope,
+and the existing-person versus new-person enrollment flow.
 
 1. **Overview**: follow the recommended action, or open any status row.
 2. **Faces**: `[e]` enrolls a face. Look at the camera; it guides your

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -1,11 +1,25 @@
 # TUI and CLI workflows
 
-Run `irlume tui` as your account. `--user ACCOUNT` selects the same account as
+Open **Irlume** from your desktop's application menu, or run `irlume tui` as your
+account. The menu entry asks your desktop to open its terminal application;
+it does not run the whole interface as root. A terminal-capable desktop launcher
+and an installed terminal are required. `--user ACCOUNT` selects the same account as
 the CLI; managing another account still requires the existing administrator
 permissions. Read the account name in the header before making changes.
 
-Tab and arrow keys navigate, Enter activates the selected item, and `?` shows
-this screen's shortcuts. `v` reveals technical sections. **F2 opens More actions**
+The minimum window size is **80 columns × 24 rows**. Below either dimension,
+only a resize message is shown with the current and required size. Enlarge the
+terminal to restore the current page or dialog; hidden controls cannot activate.
+Live observations continue refreshing. Esc can request cancellation of an active
+enrollment, and `q` exits (a general daemon task can keep running).
+
+Tab/Shift-Tab and Left/Right switch sections. **F3 opens Sections**, including
+on a supported narrow terminal where the sidebar is hidden. **F6 switches page/action
+focus**: use Up/Down to select a control and Enter or Space to activate it. The
+focused action scrolls into view and uses the same confirmation as its mouse
+button or shortcut. PageUp/PageDown reads the page while actions have focus;
+otherwise it scrolls Activity. `?` shows this screen's shortcuts. `v` reveals technical
+sections. **F2 opens More actions**
 from any idle screen. Type a task or CLI command to filter the list, use Up/Down
 to select, and Enter to open it. Esc closes the list or cancels a field.
 
@@ -24,6 +38,7 @@ Diagnostics or More actions). Over Activity it scrolls the activity history.
 The wheel also scrolls longer information/action panels, including Wallet,
 Recovery and Login. Long dialogs scroll within their own body while the buttons
 remain visible.
+Use Up/Down to scroll long non-text dialogs without activating their buttons.
 Press `M` to release mouse capture for the terminal's text selection and copy
 controls; press it again to resume mouse navigation.
 
@@ -38,6 +53,75 @@ menu are never shell commands. Paths beginning with `-` can use a `./` prefix.
 If a command fails or is interrupted, some changes may already have been
 applied. Review its terminal output and the refreshed status before retrying.
 An unsuccessful daemon-start command does not automatically resume enrollment.
+
+## Activity and device transparency
+
+**A** expands or collapses recent Activity. **Shift+L** opens full-height
+**Session history**; you can also click its History control. This view shows
+elapsed session timestamps, text status labels, and the retained message details.
+Use Up/Down, the wheel, PageUp/PageDown, Home and End to read history. End follows
+new messages; Esc or Shift+L closes history without running a page action.
+
+The compact strip shows one summary per message so a long older explanation
+cannot hide the newest result. Open history to read wrapped details. While you
+read older entries, arriving messages do not pull you to the bottom. History is
+bounded to 200 messages and 32 KiB of text; individual messages are bounded to
+4096 bytes. Omission/truncation is displayed, and history is kept only in this
+process's memory.
+
+Session history describes this TUI's actions and observations. Live daemon
+status separately shows the current worker operation, queued work, and automatic
+background camera qualification, including requests from another Irlume client.
+Press **F4** to open **Current observations**, with operation details and the age
+of each source. It continues refreshing while dialogs or
+an enrollment are open. The observer reads copied metadata; it does not capture
+frames or inspect the TPM. These observations are not a complete operating-system
+audit or proof of camera/IR-emitter shutdown. Explicit setup and test actions
+can use the camera or TPM and change configuration. F2 provides
+existing system/login history, diagnostics and explicit trace tools when more
+detail is needed; camera diagnostics explicitly discloses that it captures.
+
+Status fields carry observation freshness. A failed or expired check becomes
+unavailable; it does not mean OFF, an empty profile list, or an idle daemon.
+Each source is checked separately, so a successful camera refresh cannot make
+an older wallet result current. Live status is polled about once a second; other
+sources refresh at bounded intervals and after relevant changes. This is observed
+state, so a change can take time to reach the display. One-shot recognition and qualification results
+remain past observations until you explicitly run another test. An older daemon
+without live-status support is shown as unavailable for that source.
+
+The Cameras page automatically follows connected devices. New UVC candidates
+appear from the daemon's passive connection monitor, and disconnected choices
+are removed. When the page is open and idle, a changed inventory triggers a
+camera-role inspection; that inspection can open device nodes to identify RGB
+and infrared endpoints. It does not repeatedly run capture qualification.
+Inspection failure is shown separately from an empty device list. Selection
+follows device identity, and a connection change invalidates an open camera
+switch confirmation rather than silently choosing a replacement.
+
+During enrollment, click **Cancel enrollment** or press Esc to request cancellation.
+For a general daemon task, the **quit** control exits the TUI and explicitly says
+the task keeps running. Other page controls stay inactive during these operations.
+
+An action's start describes a request, not confirmed success. Cancellation is
+reported as requested until an outcome is known. A worker that ends without a
+result no longer leaves the interface permanently busy: Activity explains the
+unknown outcome or stale observation. Refresh status before retrying a mutation.
+
+## Appearance and accessibility
+
+Sections use blank rows and clear headings to separate related settings. Labels,
+values and controls have visible spacing; long explanations wrap inside scrollable
+panels. Supported narrow layouts (at least 80×24) keep navigation and dialog controls accessible.
+
+State badges combine text and symbols: green **ON**, neutral **OFF**, and amber
+**UNKNOWN**. Red is reserved for errors and adverse states; switching an optional
+setting off is not inherently an error. Selection and keyboard focus remain
+visible independently of color. The palette follows the terminal's colors
+without assuming that truecolor means a dark background.
+
+Set `NO_COLOR=1` to disable color, or `IRLUME_REDUCE_MOTION=1` to use static
+activity marks. Keyboard shortcuts remain available with mouse capture released.
 
 ## Preferences
 

--- a/docs/superpowers/plans/2026-09-11-tui-desktop-experience.md
+++ b/docs/superpowers/plans/2026-09-11-tui-desktop-experience.md
@@ -1,0 +1,81 @@
+# TUI desktop experience implementation plan
+
+**Goal:** Ship a discoverable, readable, interactive TUI with transparent session history, live daemon work, per-source freshness and automatic camera hotplug updates.
+
+**Architecture:** Keep the current thin client and daemon/CLI action boundaries.
+Extract cohesive visual/activity helpers where they reduce duplicated state and
+rendering logic; install a standard desktop entry through existing packaging.
+
+**Tech Stack:** Rust 1.88, locked Ratatui 0.30, Crossterm, shell/Python package checks.
+
+**Spec:** [TUI desktop experience](../specs/2026-09-11-tui-desktop-experience.md)
+
+## Constraints
+
+Preserve authorization, cancellation, existing daemon protocol behavior, saved configuration,
+keyboard shortcuts, NO_COLOR, and reduced-motion support. Use synthetic UI
+fixtures. Do not start a camera, install packages, or mutate live device state.
+
+## Work and validation order
+
+- [x] Inspect all existing TUI flows, tests, dependencies, CI, and packaging.
+- [x] Establish the baseline: 200 TUI tests passed on the normal host. Seven
+  sandbox-only failures were fake Unix-socket bind denials; no test was skipped.
+- [x] Desktop integration: add a static terminal desktop entry and SVG icon;
+  cover every supported package/source install and source removal path with a
+  real validation script and relevant existing package checks.
+- [x] Visual interaction: consolidate state styling; render Preferences as
+  actionable settings with clear focus and keyboard/mouse targets; retain
+  readable layouts and all safety confirmations across screens.
+- [x] Activity: reproduce long-message truncation and full-ring scrolling;
+  add a bounded history implementation, timestamps/status labels, compact
+  summaries, and a full-height readable viewer with follow/history controls.
+- [x] Worker lifecycle: add disconnected-channel regressions for status,
+  diagnostics, profiles, operations, and enrollment; clear stale busy states,
+  report unknown outcomes, and preserve normal completion before channel close.
+- [x] Integrate independent patches and run focused regression suites followed
+  by the complete CLI and appropriate workspace/packaging checks.
+- [x] Generate synthetic examples from actual Ratatui buffers and inspect them
+  at representative sizes and in color/no-color modes.
+- [x] Update TUI/setup/command documentation to match actual delivered controls.
+- [x] Independently review final diff, save evidence and exact resumption state,
+  record the untested desktop/distribution scope, and prepare publication under
+  the user's existing commit/push/PR/merge authorization.
+
+## Expanded live-state implementation
+
+- [x] Camera layer: publish a copied bounded passive inventory with explicit
+  validity, continuity identity, revision and age; initialize separately from
+  reads and recover from monitor failure without opening camera nodes.
+- [x] Daemon layer: add memory-only LiveStatus, bounded worker admission/running/
+  cancellation/finish accounting, independent background qualification, and
+  external-mutation invalidation revision.
+- [x] TUI: poll current work during dialogs; gate current-state claims per source,
+  preserve typed failure, and discard pre-invalidation worker completions.
+- [x] Cameras: automatically show attach/remove changes, classify only on a
+  changed inventory while visible/idle, preserve identity and invalidate stale
+  camera-switch confirmations, carrying the guard through sudo to the daemon. Keep capture
+  qualification a dated observation.
+- [x] Verify synthetic failure/recovery, queued/running races, old daemon,
+  hotplug/reused paths, no probe side effects, and actual rendered freshness cues.
+- [x] Refresh user documentation and visual examples against the final code;
+  rerun full checks and independent cross-layer reviews before publishing.
+
+## Final spacing and minimum window requirements
+
+- [x] Separate history controls with noninteractive gaps and separate session records
+  from the history explanation/status. Preserve internal compact renderer coverage.
+- [x] Add an 80×24 minimum at the terminal rendering/input boundary; below either
+  dimension show only a resize message. Preserve page/dialog state and keep safe
+  exit/enrollment cancellation available. Reject input across a size change until
+  the matching window has been drawn.
+- [x] Cover hidden approval, text input, mouse/wheel, restoration, tiny dimensions
+  and safe exit/cancellation with synthetic regressions.
+- [x] Verify the final 128-frame gallery at supported sizes and undersized boundaries,
+  and complete final local checks.
+
+Local validation completed: 2,435 workspace tests, 280 no-color TUI tests,
+formatter, Clippy, documentation and release build passed. Six desktop-integration
+tests and packaging parity passed; synthetic galleries contain 128 frames per
+color mode. Publication status and exact commit/CI evidence are tracked in the
+shared Irlume handoff, outside this implementation plan.

--- a/docs/superpowers/specs/2026-09-11-tui-desktop-experience.md
+++ b/docs/superpowers/specs/2026-09-11-tui-desktop-experience.md
@@ -1,0 +1,144 @@
+# Irlume desktop TUI experience
+
+## Purpose and scope
+
+Make the existing terminal interface the primary interactive place to set up,
+configure, and inspect Irlume. The user requested implementation and delegated
+visual design choices. Keep the existing Ratatui application, CLI actions,
+authorization checks, existing protocol behavior, and supported terminal environments.
+Extend the protocol additively where current daemon observations are missing.
+
+The audit covers Overview/first run, Faces, Fingerprint, Password Wallet,
+Recovery, Login & Apps, Diagnostics, Cameras, Test Recognition, Preferences,
+legacy Setup Status, action search, dialogs, and Activity. Changes should repair
+observed usability and correctness gaps, not add a second application framework.
+
+## Design decisions
+
+1. Use a consistent settings interface: grouped navigation, clear selected and
+   focused controls, keyboard and mouse access, visible action labels, and
+   layouts that remain usable in supported smaller terminals (at least 80×24). Preserve shortcut workflows
+   and all confirmations for security-sensitive actions.
+2. Use semantic state badges. Enabled is green, intentionally disabled is
+   neutral, unknown is amber, and errors are red. Always include a word and
+   glyph so color is never the only signal. Respect `NO_COLOR` and the terminal
+   theme; do not infer a dark background merely from truecolor support.
+3. Activity is this TUI session's history. Show elapsed timestamps, explicit
+   result labels, full readable details, and follow/history controls. Keep
+   bounded memory and a stable reading position when entries arrive or expire.
+   A compact summary must not let wrapped older messages hide the newest result.
+   Expanded history must make every retained line reachable by keyboard/mouse.
+4. State the limits of Activity honestly: it is not a complete operating-system
+   audit or proof that a camera is physically off. Link users to existing
+   diagnostic/history actions for additional daemon observations. Do not add
+   raw request, password, token, frame, template, or biometric export logging.
+5. A lost background worker must release its loading state. Retained historical
+   observations must not remain usable as current state after failure or expiry.
+   Explain that refresh failed and allow retry. A foreground
+   operation without a result has an unknown outcome, not success or confirmed
+   rollback. Refresh enrollment state after an interrupted enrollment worker.
+6. Install an Irlume application-menu entry with `Exec=irlume tui`,
+   `TryExec=irlume`, and `Terminal=true`, plus a scalable application icon.
+   Desktop environments select the terminal; no shell command construction,
+   terminal guessing, automatic sudo, or automatic authentication action is
+   introduced. Nix uses the installed executable's store path. Keep equivalent
+   assets in Fedora, Arch, Debian, PPA, Nix, and source install/uninstall flows.
+
+## Live observations and hotplug
+
+The user expanded the request to automatic, present-state observations across
+the TUI. This includes changes made through other Irlume clients while the TUI
+is open. A poll is an observation, not a promise of instantaneous knowledge:
+show observation age and explicit updating/unavailable states whenever freshness
+cannot be established. Never turn a failed read into an empty list or OFF badge.
+
+- Add a bounded, memory-only `LiveStatus` daemon response. It reports daemon
+  instance, uptime, lifecycle stage, the current worker operation and waiting
+  operation counts, independent automatic background qualification, and a
+  separately sourced passive camera inventory. Requests
+  for this response must not enter the camera worker, open devices, read the TPM,
+  initialize a monitor, or append observer events to history. Poll it about once
+  a second, including while dialogs and foreground operations are open. F4
+  opens scrollable Current observations with full operation and freshness details.
+- Live work uses closed categories and opaque operation identifiers. Do not
+  publish account names, request arguments, credentials, profile names, raw
+  errors, biometric outcomes or inference-stage data. Cancellation stays
+  requested until the operation actually ends. This describes daemon worker
+  activity, not every operating-system process or physical camera/emitter state.
+- Publish a state revision when potentially mutating daemon work finishes.
+  Clients use it as an invalidation hint, including on failure; it does not
+  assert that a mutation succeeded. This helps external changes invalidate
+  cached profile/settings observations without repeatedly reading the TPM.
+- Track each independently fallible data source separately: successful time,
+  failure/expiry, and an invalidation generation. A successful sibling read does
+  not freshen another result. Discard pre-mutation completions and schedule one
+  replacement when an explicit refresh arrives during an existing read.
+  Keep worker counts bounded. Label deliberate one-shot diagnostics as past
+  observations rather than automatically recapturing to make them current.
+- The daemon initializes its passive device monitor independently of status
+  queries. Its copied inventory distinguishes uninitialized, current,
+  refreshing and unavailable, including valid-empty versus failed-empty states.
+  Bounded passive recovery belongs to the monitor worker. A current UVC census
+  is not a universal census of all camera backends.
+- Show attached passive candidates immediately. RGB/IR role classification
+  remains a separate observation because sysfs alone cannot establish those
+  roles. While Cameras is visible and idle, classify at most once for a changed
+  inventory revision; do not repeatedly request capture qualification. Show
+  inspection progress/failure honestly. Remove disconnected choices and bind
+  retained classification and selection to instance/generation/endpoint identity.
+  Invalidate a pending camera switch when that identity changes, and recheck it
+  before executing the captured action. Carry the expected supervisor and
+  candidate identity through the administrator prompt in a distinct guarded
+  request. The daemon rechecks it before mutation; older daemons refuse that
+  request rather than silently dropping an optional guard field.
+
+A periodic refresh cannot establish physical device shutdown or observe a change
+that the underlying source cannot report. The interface must name its scope
+and uncertainty instead of making those claims.
+
+## Alternatives considered
+
+A color-only pass would leave interaction, clipped Activity messages, and menu
+discovery unresolved. A standalone graphical application would duplicate the
+current interface and add packaging/runtime obligations. A custom terminal
+launcher would duplicate desktop policy and terminal argument conventions.
+Improve the existing TUI and delegate terminal selection to the desktop entry.
+
+## Verification and acceptance
+
+- Establish the existing TUI test baseline with fake/dead daemon sockets.
+- Reproduce confirmed Activity and worker-loss defects with failing tests.
+- Exercise screen rendering, state semantics, focus, mouse hit targets, dialogs,
+  resizing, scrolling, and unknown states using Ratatui TestBackend.
+- Inspect rendered synthetic screen examples in color and without color;
+  never use enrolled data to produce review artifacts.
+- Validate the desktop file/icon and supported package/source install paths,
+  including source uninstall, without installing or changing this host.
+- Run the relevant real formatter, Clippy, build, tests, packaging checks,
+  and an independent final diff review. Record environmental limits accurately.
+- Exercise live-state guards with synthetic time, partial failure, old-worker
+  completion, external mutation, daemon restart, hotplug/reordering, lost
+  monitors and interrupted operations. Prove the live getter has no camera/TPM
+  side effects. Render current/updating/unavailable states and disconnected
+  selections; keep old-daemon behavior explicitly unavailable.
+
+No attended camera test or installed-system change is part of this UI work.
+
+## Primary references
+
+- [Desktop Entry specification](https://specifications.freedesktop.org/desktop-entry-spec/latest/)
+- [Ratatui 0.30 Style](https://docs.rs/ratatui/0.30.0/ratatui/style/struct.Style.html)
+- [NO_COLOR convention](https://no-color.org/)
+- Locked Ratatui/Crossterm sources and the repository's existing tests and package manifests.
+
+## Spacing and readability
+
+Separate headings, settings and actions with visible whitespace. Keep related labels
+and values together, wrap long explanations, and retain noninteractive gaps between
+neighboring buttons. Check narrow terminals as well as normal and wide layouts.
+
+Below 80 columns or 24 rows, show only a resize notice with current and required
+dimensions. Keep page/dialog state for enlargement and disable hidden controls.
+Check the actual size again for each input and require a matching completed draw
+to prevent an unseen confirmation across shrinking or enlarging. Keep safe exit
+and enrollment cancellation available; do not stop observations merely for resizing.

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -14,6 +14,7 @@
   lib,
   rustPlatform,
   pkg-config,
+  desktop-file-utils,
   clang,
   tpm2-tss,
   linux-pam,
@@ -98,6 +99,7 @@ rustPlatform.buildRustPackage {
 
   nativeBuildInputs = [
     pkg-config
+    desktop-file-utils
     clang
     rustPlatform.bindgenHook # sets LIBCLANG_PATH and the bindgen clang args
   ];
@@ -145,6 +147,13 @@ rustPlatform.buildRustPackage {
   # buildRustPackage installs the two bins to $out/bin. The PAM cdylib and the
   # model weights are not bins, so place them here.
   postInstall = ''
+    install -Dm0644 packaging/desktop/io.github.archledger.Irlume.desktop "$out/share/applications/io.github.archledger.Irlume.desktop"
+    install -Dm0644 packaging/desktop/io.github.archledger.Irlume.svg "$out/share/icons/hicolor/scalable/apps/io.github.archledger.Irlume.svg"
+    substituteInPlace "$out/share/applications/io.github.archledger.Irlume.desktop" \
+      --replace-fail 'Exec=irlume tui' "Exec=$out/bin/irlume tui" \
+      --replace-fail 'TryExec=irlume' "TryExec=$out/bin/irlume"
+    desktop-file-validate "$out/share/applications/io.github.archledger.Irlume.desktop"
+
     install -Dm0755 \
       "$(find target -name libpam_irlume.so -print -quit)" \
       "$out/lib/security/pam_irlume.so"

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -10,6 +10,8 @@ own recipe. Everything the daemon does at *runtime* stays capability-detected.
 | Artifact | Path |
 |---|---|
 | `irlumed`, `irlume` | `/usr/bin/` |
+| application menu entry | `/usr/share/applications/io.github.archledger.Irlume.desktop` |
+| application icon | `/usr/share/icons/hicolor/scalable/apps/io.github.archledger.Irlume.svg` |
 | `pam_irlume.so` | Fedora `/usr/lib64/security/` · Debian `/usr/lib/x86_64-linux-gnu/security/` · Arch `/usr/lib/security/` |
 | models (bundled) | `/usr/share/irlume/models/*.onnx` |
 | systemd units | `/usr/lib/systemd/system/irlumed.service` + `irlume-reconcile.path`/`.service` (self-heal watcher; all families incl. PPA enable the `.path`) |
@@ -35,6 +37,27 @@ the PAM service. Before a release, follow the [candidate upgrade and rollback
 checklist](../docs/RELEASING.md); recipe parity alone does not validate installation.
 
 ## Per-family
+
+The application-menu entry uses `Terminal=true` and directly runs `irlume tui`
+as the desktop user. Terminal selection belongs to the desktop; no specific
+emulator or universal terminal preference is assumed. It adds no sudo prompt
+or camera action at launch. A working terminal emulator remains necessary;
+`irlume tui` in an existing terminal is the fallback.
+
+All four FHS package recipes own the entry and SVG icon, so package removal
+removes them. Nix installs both under `$out/share` and binds Exec/TryExec to
+`$out/bin/irlume`; removing the package from the active profile/system removes
+its menu integration. The source host installer uses `/usr/local/share` and
+`/usr/local/bin/irlume`; source uninstall removes only its two desktop assets,
+leaving package-owned entries and user overrides alone. A source launcher has
+the same desktop ID as the packaged one and takes precedence while installed.
+
+`scripts/check-packaging-parity.sh` requires Python 3 and `desktop-file-validate`
+(desktop-file-utils). It runs `scripts/test-desktop-integration.py`, which
+validates the shared entry, checks package ownership and destinations, stages
+the actual install commands in temporary directories, and checks prefix
+bindings. Fedora and Nix also validate their installed entry during the build.
+These checks do not launch the TUI or prove desktop-session compatibility.
 
 - **Fedora** (`fedora/irlume.spec` + `../.packit.yaml`): Packit builds in Copr
   from signed GitHub tags. Bundles onnxruntime 1.28.1 (Source1 →

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -64,6 +64,8 @@ package() {
     cd "$srcdir/$pkgname"
     install -Dm0755 target/release/irlumed "$pkgdir/usr/bin/irlumed"
     install -Dm0755 target/release/irlume  "$pkgdir/usr/bin/irlume"
+    install -Dm0644 packaging/desktop/io.github.archledger.Irlume.desktop "$pkgdir/usr/share/applications/io.github.archledger.Irlume.desktop"
+    install -Dm0644 packaging/desktop/io.github.archledger.Irlume.svg "$pkgdir/usr/share/icons/hicolor/scalable/apps/io.github.archledger.Irlume.svg"
     install -Dm0644 target/release/libpam_irlume.so "$pkgdir/usr/lib/security/pam_irlume.so"
     # KDE wallet handoff helper. Not in /usr/bin: it is not a command a user
     # runs, it takes a secret on stdin, and it is only meaningful inside a PAM

--- a/packaging/debian/nfpm.yaml
+++ b/packaging/debian/nfpm.yaml
@@ -43,6 +43,18 @@ recommends:
   - fprintd
 
 contents:
+  - src: ../desktop/io.github.archledger.Irlume.desktop
+    dst: /usr/share/applications/io.github.archledger.Irlume.desktop
+    file_info:
+      mode: 0644
+      owner: root
+      group: root
+  - src: ../desktop/io.github.archledger.Irlume.svg
+    dst: /usr/share/icons/hicolor/scalable/apps/io.github.archledger.Irlume.svg
+    file_info:
+      mode: 0644
+      owner: root
+      group: root
   - src: ../polkit/org.irlume.enroll.policy
     dst: /usr/share/polkit-1/actions/org.irlume.enroll.policy
   - src: ../polkit/org.irlume.recovery-manage.policy

--- a/packaging/desktop/io.github.archledger.Irlume.desktop
+++ b/packaging/desktop/io.github.archledger.Irlume.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Name=Irlume
+GenericName=Authentication Settings
+Comment=Manage face and fingerprint sign-in
+Exec=irlume tui
+TryExec=irlume
+Icon=io.github.archledger.Irlume
+Terminal=true
+Categories=Settings;
+Keywords=Face;Fingerprint;Authentication;Login;

--- a/packaging/desktop/io.github.archledger.Irlume.svg
+++ b/packaging/desktop/io.github.archledger.Irlume.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256">
+  <!-- Project-owned scanner mark, adapted from docs/assets/banner.svg. -->
+  <defs>
+    <linearGradient id="ir" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#7c1d3f"/>
+      <stop offset="0.5" stop-color="#c0304f"/>
+      <stop offset="1" stop-color="#ff6a3d"/>
+    </linearGradient>
+  </defs>
+  <rect x="8" y="8" width="240" height="240" rx="48" fill="#0d1117"/>
+  <g transform="translate(128 128)">
+    <circle r="62" fill="none" stroke="url(#ir)" stroke-width="8"/>
+    <circle r="30" fill="none" stroke="url(#ir)" stroke-width="12"/>
+    <circle r="8" fill="#ff6a3d"/>
+    <path d="M -62 0 H 62" stroke="#ff6a3d" stroke-width="3" opacity="0.55"/>
+    <g stroke="url(#ir)" stroke-width="7" fill="none" stroke-linecap="round">
+      <path d="M -84 -58 V -80 H -62"/>
+      <path d="M 84 -58 V -80 H 62"/>
+      <path d="M -84 58 V 80 H -62"/>
+      <path d="M 84 58 V 80 H 62"/>
+    </g>
+  </g>
+</svg>

--- a/packaging/fedora/irlume.spec
+++ b/packaging/fedora/irlume.spec
@@ -43,6 +43,7 @@ BuildRequires:  dbus-devel
 BuildRequires:  tpm2-tss-devel
 BuildRequires:  systemd-devel
 BuildRequires:  systemd-rpm-macros
+BuildRequires:  desktop-file-utils
 # v4l2-sys-mit generates bindings at build time: bindgen dlopens libclang
 # and parses the kernel's videodev2.h; tss-esapi locates tss2 via pkg-config.
 BuildRequires:  clang-devel
@@ -56,6 +57,7 @@ BuildRequires:  selinux-policy-devel
 Requires:       polkit
 Requires:       pam
 Requires:       tpm2-tss
+Requires:       hicolor-icon-theme
 Recommends:     fprintd
 # Fedora enforces SELinux by default and the greeter can't reach the daemon
 # without the policy module; pull the subpackage in by default (weak dep, so
@@ -117,6 +119,9 @@ install -Dm0644 packaging/polkit/org.irlume.enroll.policy %{buildroot}%{_datadir
 install -Dm0644 packaging/polkit/org.irlume.recovery-manage.policy %{buildroot}%{_datadir}/polkit-1/actions/org.irlume.recovery-manage.policy
 install -Dm0755 target/release/irlumed %{buildroot}%{_bindir}/irlumed
 install -Dm0755 target/release/irlume  %{buildroot}%{_bindir}/irlume
+install -Dm0644 packaging/desktop/io.github.archledger.Irlume.desktop %{buildroot}%{_datadir}/applications/io.github.archledger.Irlume.desktop
+install -Dm0644 packaging/desktop/io.github.archledger.Irlume.svg %{buildroot}%{_datadir}/icons/hicolor/scalable/apps/io.github.archledger.Irlume.svg
+desktop-file-validate %{buildroot}%{_datadir}/applications/io.github.archledger.Irlume.desktop
 install -Dm0644 target/release/libpam_irlume.so %{buildroot}%{_libdir}/security/pam_irlume.so
 # The KDE wallet handoff helper. libexec, not bindir: it is not a command a
 # user runs, it takes a secret on stdin, and it is only meaningful inside a
@@ -254,6 +259,8 @@ restorecon /run/irlume.sock 2>/dev/null || :
 %doc README.md docs/SECURITY_AT_REST.md docs/MACHINE-API.md docs/INTEGRATION.md
 %{_bindir}/irlumed
 %{_bindir}/irlume
+%{_datadir}/applications/io.github.archledger.Irlume.desktop
+%{_datadir}/icons/hicolor/scalable/apps/io.github.archledger.Irlume.svg
 %{_libdir}/security/pam_irlume.so
 %dir %{_libexecdir}/%{name}
 %{_libexecdir}/%{name}/irlume-kwallet-init

--- a/packaging/ppa/debian/rules
+++ b/packaging/ppa/debian/rules
@@ -38,6 +38,10 @@ override_dh_installsystemd:
 	dh_installsystemd irlume-reconcile.path irlume-reconcile.service irlume-reconcile.timer
 
 override_dh_auto_install:
+	install -D -m0644 packaging/desktop/io.github.archledger.Irlume.desktop \
+		debian/irlume/usr/share/applications/io.github.archledger.Irlume.desktop
+	install -D -m0644 packaging/desktop/io.github.archledger.Irlume.svg \
+		debian/irlume/usr/share/icons/hicolor/scalable/apps/io.github.archledger.Irlume.svg
 	install -D -m0644 packaging/polkit/org.irlume.enroll.policy \
 		debian/irlume/usr/share/polkit-1/actions/org.irlume.enroll.policy
 	install -D -m0644 packaging/polkit/org.irlume.recovery-manage.policy \

--- a/scripts/check-packaging-parity.sh
+++ b/scripts/check-packaging-parity.sh
@@ -28,6 +28,10 @@ LANES=(
 
 fail=0
 
+echo "== desktop launcher and icon in supported install paths =="
+python3 scripts/test-desktop-integration.py || fail=1
+echo
+
 echo "== pamsm consumed from the maintained fork only =="
 # pamsm comes from the archledger/pam_sm_rust fork at an exact commit. The
 # in-tree vendored copy is gone; a source-complete build means Cargo can fetch

--- a/scripts/install-host.sh
+++ b/scripts/install-host.sh
@@ -59,6 +59,14 @@ install -Dm0644 "$REPO/packaging/polkit/org.irlume.recovery-manage.policy" \
   /usr/share/polkit-1/actions/org.irlume.recovery-manage.policy
 printf "%s\n" "Enrollment and recovery management require polkit and a desktop or registered terminal authentication agent."
 install -m 0755 "$REPO/target/release/irlumed" "$REPO/target/release/irlume" /usr/local/bin/
+install -Dm0644 "$REPO/packaging/desktop/io.github.archledger.Irlume.desktop" /usr/local/share/applications/io.github.archledger.Irlume.desktop
+install -Dm0644 "$REPO/packaging/desktop/io.github.archledger.Irlume.svg" /usr/local/share/icons/hicolor/scalable/apps/io.github.archledger.Irlume.svg
+# Bind this local menu entry to the binary placed above, even when another
+# package is installed. The desktop supplies the terminal and user identity.
+sed -i \
+    -e 's|^Exec=irlume tui$|Exec=/usr/local/bin/irlume tui|' \
+    -e 's|^TryExec=irlume$|TryExec=/usr/local/bin/irlume|' \
+    /usr/local/share/applications/io.github.archledger.Irlume.desktop
 
 install -Dm0755 "$REPO/target/release/irlume-password-verify" /usr/libexec/irlume-password-verify
 # Preserve administrator-owned recovery policy on subsequent development installs.

--- a/scripts/test-desktop-integration.py
+++ b/scripts/test-desktop-integration.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Offline desktop payload checks; never launch irlume or a terminal."""
+import configparser
+from pathlib import Path
+import re
+import shlex
+import stat
+import subprocess
+import tempfile
+import unittest
+import xml.etree.ElementTree as ET
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_ID = "io.github.archledger.Irlume"
+DESKTOP = f"{APP_ID}.desktop"
+ICON = f"{APP_ID}.svg"
+ASSETS = {
+    DESKTOP: f"applications/{DESKTOP}",
+    ICON: f"icons/hicolor/scalable/apps/{ICON}",
+}
+
+
+def commands(path):
+    text = (ROOT / path).read_text()
+    return [line.strip() for line in re.sub(r"\\\n\s*", " ", text).splitlines()
+            if not line.lstrip().startswith("#")]
+
+
+class DesktopIntegration(unittest.TestCase):
+    def test_launcher_is_a_direct_unprivileged_terminal_command(self):
+        path = ROOT / "packaging/desktop" / DESKTOP
+        self.assertTrue(path.is_file(), "missing application-menu launcher")
+        config = configparser.ConfigParser(interpolation=None)
+        config.optionxform = str
+        config.read(path)
+        self.assertEqual(config.sections(), ["Desktop Entry"])
+        entry = config["Desktop Entry"]
+        self.assertEqual(entry["Type"], "Application")
+        self.assertEqual(entry["Exec"], "irlume tui")
+        self.assertEqual(entry["TryExec"], "irlume")
+        self.assertEqual(entry["Terminal"], "true")
+        self.assertEqual(entry["Icon"], APP_ID)
+        self.assertEqual(entry["Categories"], "Settings;")
+        self.assertNotIn("DBusActivatable", entry)
+        self.assertNotIn("Actions", entry)
+        self.assertNotIn("OnlyShowIn", entry)
+        self.assertNotIn("NoDisplay", entry)
+        self.assertNotIn("Hidden", entry)
+        subprocess.run(["desktop-file-validate", str(path)], check=True)
+
+    def test_icon_is_self_contained_svg(self):
+        path = ROOT / "packaging/desktop" / ICON
+        self.assertTrue(path.is_file(), "missing application icon")
+        tree = ET.parse(path)
+        self.assertEqual(tree.getroot().tag, "{http://www.w3.org/2000/svg}svg")
+        for node in tree.iter():
+            self.assertNotIn(node.tag.rsplit("}", 1)[-1], ["script", "image", "foreignObject"])
+            self.assertFalse(any(key.endswith("href") for key in node.attrib))
+
+    def test_all_supported_install_recipes_stage_the_shared_payload(self):
+        lanes = {
+            "packaging/fedora/irlume.spec": "%{buildroot}%{_datadir}",
+            "packaging/arch/PKGBUILD": "$pkgdir/usr/share",
+            "packaging/ppa/debian/rules": "debian/irlume/usr/share",
+            "nix/package.nix": "$out/share",
+            "scripts/install-host.sh": "/usr/local/share",
+        }
+        with tempfile.TemporaryDirectory(prefix="irlume-desktop-") as td:
+            for lane, prefix in lanes.items():
+                for name, relative in ASSETS.items():
+                    with self.subTest(lane=lane, asset=name):
+                        rows = [shlex.split(line) for line in commands(lane)
+                                if line.startswith("install ")
+                                and (line.endswith(name + '"') or line.endswith(name))]
+                        rows = [row for row in rows if row[-1] == f"{prefix}/{relative}"]
+                        self.assertEqual(len(rows), 1, f"missing/duplicate installed {relative}")
+                        args = rows[0]
+                        source = args[-2].replace("$REPO/", "")
+                        self.assertEqual(source, f"packaging/desktop/{name}")
+                        dest = Path(td) / lane.replace("/", "_") / relative
+                        subprocess.run([*args[:-2], str(ROOT / source), str(dest)], check=True)
+                        self.assertEqual(dest.read_bytes(), (ROOT / source).read_bytes())
+                        self.assertEqual(stat.S_IMODE(dest.stat().st_mode), 0o644)
+
+    def test_debian_manifest_and_rpm_ownership_include_both_assets(self):
+        manifest = (ROOT / "packaging/debian/nfpm.yaml").read_text()
+        spec = (ROOT / "packaging/fedora/irlume.spec").read_text()
+        self.assertRegex(spec, r"(?m)^Requires:\s+hicolor-icon-theme$")
+        files = spec.split("\n%files\n", 1)[1].split("\n%files selinux", 1)[0]
+        for name, relative in ASSETS.items():
+            with self.subTest(asset=name):
+                self.assertRegex(manifest, re.escape(f"- src: ../desktop/{name}")
+                                 + r"\s+" + re.escape(f"dst: /usr/share/{relative}"))
+                self.assertIn(f"%{{_datadir}}/{relative}", files.splitlines())
+
+    def test_prefix_specific_launchers_bind_the_installed_binary(self):
+        nix = (ROOT / "nix/package.nix").read_text()
+        self.assertIn("--replace-fail 'Exec=irlume tui' \"Exec=$out/bin/irlume tui\"", nix)
+        self.assertIn("--replace-fail 'TryExec=irlume' \"TryExec=$out/bin/irlume\"", nix)
+        source = (ROOT / "scripts/install-host.sh").read_text()
+        self.assertIn("s|^Exec=irlume tui$|Exec=/usr/local/bin/irlume tui|", source)
+        self.assertIn("s|^TryExec=irlume$|TryExec=/usr/local/bin/irlume|", source)
+
+        # Execute the installer's actual rewrite against a disposable file.
+        with tempfile.TemporaryDirectory(prefix="irlume-local-launcher-") as td:
+            path = Path(td) / DESKTOP
+            path.write_bytes((ROOT / "packaging/desktop" / DESKTOP).read_bytes())
+            rewrite = [shlex.split(line) for line in commands("scripts/install-host.sh")
+                       if line.startswith("sed -i ") and line.endswith(DESKTOP)]
+            self.assertEqual(len(rewrite), 1)
+            subprocess.run([*rewrite[0][:-1], str(path)], check=True)
+            config = configparser.ConfigParser(interpolation=None)
+            config.read(path)
+            self.assertEqual(config["Desktop Entry"]["Exec"], "/usr/local/bin/irlume tui")
+            self.assertEqual(config["Desktop Entry"]["TryExec"], "/usr/local/bin/irlume")
+            subprocess.run(["desktop-file-validate", str(path)], check=True)
+
+    def test_source_removal_matches_only_the_source_installer_assets(self):
+        source = (ROOT / "crates/irlume-cli/src/uninstall.rs").read_text()
+        self.assertIn('remove_source_desktop_files(Path::new("/usr/local/share"))', source)
+        body = source.split("fn remove_source_desktop_files(", 1)[1].split("\n}", 1)[0]
+        paths = re.findall(r'"((?:applications|icons)/[^"]+)"', body)
+        self.assertEqual(sorted(paths), sorted(ASSETS.values()))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What & why

Make Irlume's TUI a discoverable, live setup and configuration interface. Add an application-menu launcher that opens `irlume tui` as the normal user in the desktop-selected terminal, with assets installed through Fedora, Arch, Debian, PPA, Nix and source paths.

- Give settings consistent ON/OFF/UNKNOWN badges, clear spacing, keyboard action focus, mouse controls and scrollable dialogs. Add an **80 columns × 24 rows** minimum: smaller windows show only a resize notice, preserve the page/dialog, and reject hidden controls until the matching window has been drawn.
- Expand Activity into bounded, timestamped session history. **F4 Current observations** shows current daemon work, queued requests, automatic background qualification and each source's age. Failed or expired observations become unavailable instead of remaining apparently current.
- Refresh connected UVC camera choices automatically. Separate passive inventory, role inspection and explicit capture qualification. Preserve selection by device identity; refuse a switch if the observed connection changed during confirmation or administrator approval.
- Add bounded, memory-only daemon live status that answers before engine readiness without entering the biometric worker, capturing frames, reading the TPM or adding observer history. Preserve existing authentication policy and authorization boundaries.

Live observations reflect the last successful check; they are not instantaneous physical-state guarantees. Session history covers this TUI, while live operation metadata also includes other Irlume clients. Past recognition/qualification results remain labeled as historical.

## Testing

- [x] `cargo test --workspace` — **2,435 passed**, zero failed; 107 existing environment/hardware-dependent tests ignored by default. Required-test count/name guards passed.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` and explicit formatting checks for included test files clean.
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` clean.
- [x] Docs/CHANGELOG updated.
- [ ] Attended camera hardware validation — not performed for this UI work; no capture test was started.

Also passed: release workspace build; **280 TUI tests with NO_COLOR**; six desktop-integration tests with real desktop-file validation; packaging parity, ShellCheck, per-file shell syntax, Nix syntax and Python/YAML checks. Final synthetic Ratatui galleries contain **128 frames per color mode**, covering all screens, dialogs, live/failure states and minimum-size boundaries. Reviewed both light/dark terminal defaults; all five compiled source bindings match the final files. Eight offline gallery-renderer tests passed.

A harmless desktop launcher probe verified normal-user execution and a real TTY. This does not establish terminal selection/menu refresh on every distribution. Independent source reviews covered daemon tracking, camera inventory, TUI freshness, resize/input safety and visual spacing.

Subsequent device smoke check: installed the matching unreleased files directly on Fedora 44 KDE, including the daemon/helpers, schema, desktop entry and icon. All nine installed hashes matched; daemon models and live status reached ready; existing configuration/state and service enablement were preserved. The actual desktop entry opened the new TUI as a normal user in Konsole. An installed-TUI check passed the small-window notice, resize recovery, F4 observations and clean exit. This was an interface/install check, not an attended authentication comparison.
