### PR TITLE
chore(release): prepare v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to irlume are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-09-11
+
 ### Added
 
 - Application-menu launcher for the TUI, using the desktop's terminal as the
@@ -35,6 +37,17 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Changed
 
+- Bound routine status observations with a shared deadline, move TUI probes off
+  the input thread, and use wallet metadata for routine status. Reuse verified
+  model buffers and release serialized recognizer weights before auxiliary
+  sessions are loaded.
+- Use adaptive startup for validated, configured IR-only targets while
+  preserving the full rate window, rate floor, continuity and exact metadata
+  selection. Generic fixed and paired sessions retain their existing behavior.
+- Collect complete PAD evidence in one serviced RGB/IR session for eligible
+  concurrent login/lock requests, then prepare identity for the final admissible
+  sample. Ordinary RGB+IR preparation remains eager; capture ownership,
+  cancellation, deadlines and admission checks remain enforced.
 - Read KDE wallet salts through the packaged helper after it permanently enters
   the target account, then pass the fixed-size value to the daemon's unchanged KDF.
   The daemon no longer opens that user path as root or falls back to doing so;
@@ -50,6 +63,15 @@ All notable changes to irlume are documented here. This project adheres to
 
 ### Fixed
 
+- Preserve administrator-selected daemon/socket activity and enablement during
+  package upgrades, including stopped services in the PPA hooks.
+- Require recorded IR template provenance before using IR identity evidence.
+  Faces and the CLI explain compatible, missing and unknown IR coverage without
+  guessing provenance for old scans or removing existing RGB data.
+- Avoid duplicate login scans except after an explicit pre-authentication
+  unseal refusal, and report camera contention with actionable feedback.
+- Correct package descriptions for removed head gestures and persistent face
+  retry limits; password login remains available.
 - Refresh TUI camera choices on device changes, reject a switch whose device
   changed during confirmation, and show failed or expired observations as
   unavailable. Live daemon worker status remains observable during TUI dialogs.
@@ -3241,7 +3263,8 @@ is always the fallback: no lockout, ever.
   credentials).
 - Not lab-certified: self-tested against ISO/IEC 30107-3, no paid iBeta pass.
 
-[Unreleased]: https://github.com/archledger/irlume/compare/v0.11.3...HEAD
+[Unreleased]: https://github.com/archledger/irlume/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/archledger/irlume/compare/v0.11.3...v0.12.0
 [0.11.3]: https://github.com/archledger/irlume/compare/v0.11.2...v0.11.3
 [0.11.2]: https://github.com/archledger/irlume/compare/v0.11.1...v0.11.2
 [0.11.1]: https://github.com/archledger/irlume/compare/v0.11.0...v0.11.1

--- a/crates/irlume-camera/src/lib.rs
+++ b/crates/irlume-camera/src/lib.rs
@@ -2597,7 +2597,11 @@ fn map_io(device: &str, e: std::io::Error) -> Error {
 /// needs root to see other users' processes (the daemon runs as root). Returns
 /// e.g. "kamoso (pid 2567)", or `None` if it can't tell.
 fn camera_holder(device: &str) -> Option<String> {
-    match camera_holders(device) {
+    describe_camera_holder(camera_holders(device))
+}
+
+fn describe_camera_holder(holders: Holders) -> Option<String> {
+    match holders {
         Holders::Other(who) => Some(who),
         // Only our own handle, and the scan saw everything: nothing the user
         // can close, so say what it is.
@@ -2701,11 +2705,10 @@ fn camera_holders(device: &str) -> Holders {
 
 /// What a scan that found no OTHER holder concluded, as a value.
 ///
-/// Separated out because the interesting branch is unreachable in a test: only
-/// a process that can read every `/proc` entry, in practice root, can say the
-/// holder is nobody but itself. The decision is still a function of two
-/// booleans, so it is the decision that gets tested (see #187, where a wrong
-/// answer here cost the reporter days of restarting the daemon).
+/// Test the decision independently of `/proc` permissions and PID namespaces:
+/// even an unprivileged process can inspect every visible entry in a restricted
+/// namespace. See #187, where a wrong answer cost the reporter days of
+/// restarting the daemon.
 fn holder_verdict(saw_self: bool, blind: bool) -> Holders {
     match (saw_self, blind) {
         // A blind spot outranks everything: the holder may be a process this
@@ -15234,27 +15237,22 @@ mod tests {
     /// ever presented as something to close.
     #[test]
     fn only_another_process_is_presented_as_closeable() {
-        let dir = std::env::temp_dir().join(format!("irlume-cam-holder-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("held");
-        std::fs::write(&path, b"x").unwrap();
-        let _held = std::fs::File::open(&path).unwrap();
-
-        // This test runs unprivileged, so the scan cannot read every process
-        // and must decline to name anyone rather than blame irlume.
-        let who = camera_holder(path.to_str().unwrap());
-        if let Some(who) = &who {
-            assert!(
-                !who.contains("bug in irlume"),
-                "a scan with blind spots must not accuse irlume: {who}"
-            );
-        }
+        assert_eq!(
+            describe_camera_holder(Holders::Other("kamoso (pid 2567)".into())),
+            Some("kamoso (pid 2567)".into())
+        );
+        let own = describe_camera_holder(Holders::SelfOnly).unwrap();
+        assert!(
+            own.contains("bug in irlume rather than another app"),
+            "{own}"
+        );
+        // A blind scan cannot name a holder, regardless of the test runner's
+        // privileges or which processes its PID namespace makes visible.
+        assert_eq!(describe_camera_holder(Holders::UnknownBlind), None);
+        assert_eq!(describe_camera_holder(Holders::None), None);
 
         // Nothing holds a nonexistent path.
         assert_eq!(camera_holder("/dev/irlume-test-missing"), None);
-        drop(_held);
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// Another process holding the node wins over our own handle, because that

--- a/docs/HEAD-GESTURE-REMOVAL.md
+++ b/docs/HEAD-GESTURE-REMOVAL.md
@@ -1,6 +1,6 @@
 # Head-gesture removal
 
-Head gestures are removed in the unreleased source build after 0.11.3. Face
+Head gestures are removed in 0.12.0. Face
 authentication no longer watches for nods or shakes before or after matching.
 The change removes an optional intent step; it does not change recognition
 thresholds, passive PAD, IR provenance, camera binding, retry accounting, or the

--- a/docs/adr/0020-managed-concurrent-pad-collection.md
+++ b/docs/adr/0020-managed-concurrent-pad-collection.md
@@ -1,6 +1,7 @@
 # ADR-0020: Service concurrent camera queues while collecting PAD evidence
 
-**Status:** Proposed; implementation and hardware validation in progress
+**Status:** Accepted and implemented in 0.12.0; bounded ASUS validation complete,
+without a general latency or hardware-qualification claim
 **Date:** 2026-09-11
 **Related:** [ADR-0013](0013-ship-pad-models-default-on.md),
 [ADR-0014](0014-schedule-aware-pairing-budget.md),

--- a/packaging/debian/nfpm.yaml
+++ b/packaging/debian/nfpm.yaml
@@ -15,7 +15,8 @@ description: |
   IR (Windows Hello) cameras get the secure tier: login, sudo, and TPM-sealed
   keyring unlock with algorithmic IR liveness. Regular RGB webcams get screen
   unlock; a fingerprint reader can join as a companion factor. Thin PAM module
-  + privileged daemon; YuNet + AuraFace. Password is always the fallback.
+  + privileged daemon with face detection, recognition and liveness models.
+  Face authentication has a persistent retry limit; password login remains available.
 vendor: irlume
 homepage: https://github.com/archledger/irlume
 license: GPL-3.0-or-later

--- a/packaging/debian/postinstall.sh
+++ b/packaging/debian/postinstall.sh
@@ -79,5 +79,5 @@ irlume installed. Next steps:
   sudo irlume login enable --apply   # opt-in: wire greeter/lock screen
 (most Hello cameras need no emitter step; if IR frames stay dark,
  sudo irlume ir-setup writes to the camera and tells you so first)
-Password is always the fallback; no lockout.
+Password login remains available when face authentication is retry-limited.
 EOF

--- a/packaging/fedora/irlume.spec
+++ b/packaging/fedora/irlume.spec
@@ -72,9 +72,10 @@ machine has: an infrared (Windows Hello) camera enables the secure tier
 while a regular RGB webcam enables convenient screen unlock, and a
 fingerprint reader can join as a companion factor. A thin PAM module talks
 to a privileged daemon that owns the camera and runs a clean-license model
-stack. Gesture-gated requests use head nodding to approve and a head shake to
-decline; passive PAD remains separate. Password is always the fallback; no
-lockout.
+stack. Privileged face authentication requests require typed confirmation by
+default; the machine owner can explicitly waive it. Face authentication has a persistent retry
+limit, while password login remains available. The TUI provides setup,
+configuration, recovery controls, and current daemon observations.
 
 %package selinux
 Summary:        SELinux policy module for irlume

--- a/packaging/ppa/debian/control
+++ b/packaging/ppa/debian/control
@@ -27,8 +27,9 @@ Description: Windows Hello-style face login for Linux
  IR (Windows Hello) cameras get the secure tier: login, sudo, and TPM-sealed
  keyring unlock with algorithmic IR liveness. Regular RGB webcams get screen
  unlock; a fingerprint reader can join as a companion factor. Thin PAM module
- plus privileged daemon; YuNet detection + AuraFace recognition. Password is
- always the fallback - no lockout.
+ plus privileged daemon with face detection, recognition and liveness models.
+ Password login remains available when face authentication is unavailable
+ or retry-limited.
  .
  Bundles onnxruntime (>= 1.24) under /opt/irlume because irlume needs a newer
  runtime than the Ubuntu archive ships. Model weights install to

--- a/packaging/ppa/debian/postinst
+++ b/packaging/ppa/debian/postinst
@@ -22,7 +22,7 @@ irlume installed. Next steps:
   sudo irlume login enable --apply   # opt-in: wire greeter/lock screen
 (most Hello cameras need no emitter step; if IR frames stay dark,
  sudo irlume ir-setup writes to the camera and tells you so first)
-Password is always the fallback - no lockout.
+Password login remains available when face authentication is retry-limited.
 MSG
         ;;
 esac


### PR DESCRIPTION
Prepare v0.12.0 by promoting the accumulated changelog, documenting the merged status/loading, IR startup and managed concurrent PAD work, and correcting upgrade descriptions for gesture removal, privileged face confirmation and the persistent retry limit. Existing version fields already agree on 0.12.0.

The release check exposed a camera diagnostic test that assumed every unprivileged process must encounter unreadable `/proc` entries. That fails in a restricted PID namespace where all visible entries are readable. Extract the existing holder-description match into a private function and test all four verdicts explicitly; retain blind-scan classification, missing-path and real competing-process coverage. Detection and diagnostic behavior are unchanged.

Validation: 2,435 workspace tests passed (107 existing hardware/environment-dependent ignores); formatting passed. Clippy passed with warnings denied. Packaging parity, package hooks, ShellCheck, 23 release-signature tests and 15 real Ubuntu 26.04/debhelper PPA hook tests passed. The holder correction and full camera suite pass, with independent source review complete. Initial sandbox Unix-socket/GPG startup failures and the missing local debhelper result are retained as environment failures.

Release publication remains a separate step after final candidate CI, the full install matrix, native install/upgrade/rollback qualification, and the attended nightly hardware checks. This PR does not publish a release or change installed authentication policy.
