### PR TITLE
fix(packit): build the branched Fedora release in the Copr job

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -30,6 +30,13 @@ jobs:
     enable_net: true
     targets:
       - fedora-stable
+      # The branched pre-release (fedora-45 until it goes stable) is in the
+      # gap between fedora-stable and fedora-rawhide; without this target its
+      # Copr chroot keeps serving the last old result. 0.12.0 needed a manual
+      # fedora-45 SRPM rebuild (Copr build 10977555) because of that gap.
+      # The alias also carries rawhide; the explicit entry below is kept as a
+      # guard and the duplicate is deduplicated by Packit.
+      - fedora-development
       - fedora-rawhide
     # onnxruntime is bundled in the RPM (Source1); no external Copr needed.
 


### PR DESCRIPTION
## Problem

The release `copr_build` job targets `fedora-stable` plus `fedora-rawhide`. The branched pre-release (fedora-45 until it goes stable) is in the gap between the two aliases, so Packit never built it for 0.12.0 and the `fedora-45-x86_64` Copr chroot kept serving the last forked 0.10.0-1 result. It took a manual SRPM rebuild (Copr build 10977555) to serve 0.12.0-1 there.

## Change

Add `fedora-development` to the release job targets. Packit resolves aliases through fedora-distro-aliases from live Bodhi state: `fedora-development` covers every Fedora release in pending or frozen state, which today is fedora-45 (branched) plus fedora-rawhide (F46). `fedora-stable` covers the current releases (F43, F44). The explicit `fedora-rawhide` target stays as a deduplicated guard.

When fedora-45 goes stable, it moves to `fedora-stable` and the new branched release (F47) enters `fedora-development` automatically, so the gap cannot recur.

The PR job targets are unchanged.

## Validation

- YAML parses; release job targets read back as `fedora-stable`, `fedora-development`, `fedora-rawhide`; PR job unchanged.
- Alias semantics verified against the fedora-distro-aliases source and live Bodhi state on 2026-09-12: current F43, F44; pending F45, F46.
- Configuration-only change: no code paths affected.