### PR TITLE
feat(auth): typed liveness refusal causes and timing boundaries

### DIFF
--- a/crates/irlume-auth/src/engine_tests/pair_identity_tests.rs
+++ b/crates/irlume-auth/src/engine_tests/pair_identity_tests.rs
@@ -658,11 +658,27 @@ fn managed_preparation_non_live_precedence_matches_eager_admission() {
     let engine = &mut state.engine;
     let previous_ir = engine.ir_available;
     engine.ir_available = true;
-    for (verdict, reason) in [
-        (Verdict::Uncertain, "framing fixture"),
-        (Verdict::Uncertain, "IR exposure unmeasurable fixture"),
-        (Verdict::Spoof, "no face in IR fixture"),
-        (Verdict::Spoof, "spoof fixture"),
+    for (verdict, cause, reason) in [
+        (
+            Verdict::Uncertain,
+            irlume_liveness::DenyCause::Other,
+            "framing fixture",
+        ),
+        (
+            Verdict::Uncertain,
+            irlume_liveness::DenyCause::ExposureUnmeasurable,
+            "IR exposure unmeasurable fixture",
+        ),
+        (
+            Verdict::Spoof,
+            irlume_liveness::DenyCause::NoIrFace,
+            "no face in IR fixture",
+        ),
+        (
+            Verdict::Spoof,
+            irlume_liveness::DenyCause::Other,
+            "spoof fixture",
+        ),
     ] {
         for (rgb, ir) in [(true, true), (true, false), (false, true), (false, false)] {
             let make = |engine: &mut Engine| {
@@ -670,6 +686,7 @@ fn managed_preparation_non_live_precedence_matches_eager_admission() {
                 let mut sample = visible_pair_sample(engine, 0, 0.2, false);
                 sample.assessment.verdict = verdict;
                 sample.assessment.reason = reason.into();
+                sample.assessment.deny_cause = cause;
                 sample.assessment.ir_pad = PadEvidence::InferenceFailed;
                 if !rgb {
                     sample.identity.0 = None;

--- a/crates/irlume-auth/src/grouped_auth.rs
+++ b/crates/irlume-auth/src/grouped_auth.rs
@@ -112,7 +112,7 @@ impl Engine {
         }
         if uncertain_short_circuits(a.verdict, rgb, ir) || (rgb && a.verdict != Verdict::Live) {
             return Some(Outcome::deny(
-                liveness_deny_kind(a.verdict, &a.reason),
+                liveness_deny_kind(a.verdict, a.deny_cause),
                 format!("liveness {:?}: {}", a.verdict, a.reason),
             ));
         }
@@ -130,10 +130,10 @@ impl Engine {
                 "the room is lit but no face is visible to the RGB camera; dark (IR-only) authentication requires a dark room — add light so the RGB camera can see you, or use your password",
             ));
         }
-        let (verdict, _, reason) = self.gate.evaluate_ir_only(&a.signals);
+        let (verdict, cues, reason) = self.gate.evaluate_ir_only(&a.signals);
         if verdict != Verdict::Live {
             return Some(Outcome::deny(
-                liveness_deny_kind(verdict, &reason),
+                liveness_deny_kind(verdict, cues.deny_cause),
                 format!("dark liveness {verdict:?}: {reason}"),
             ));
         }

--- a/crates/irlume-auth/src/ir_assessment.rs
+++ b/crates/irlume-auth/src/ir_assessment.rs
@@ -960,13 +960,20 @@ impl Engine {
 
     // Retain the existing helper lifetime rule: a cancelled/expired caller
     // drains the loader before returning. No camera or lease is held here.
-    fn load_ir_enrollment(
+    pub(super) fn load_ir_enrollment(
         &self,
         user: &str,
         window: AuthenticationWindow,
         read_only: bool,
+        diagnostics: Option<&dyn irlume_common::diagnostics::DiagnosticSink>,
     ) -> irlume_common::Result<Option<irlume_core::storage::Enrollment>> {
         self.check_authentication_completion(window)?;
+        // This route dispatches before the dual-sensor loader's timing site.
+        // Include resolution and any cancellation drain, but not a request
+        // rejected before loading. Read-only readiness probes pass no sink.
+        let _timer = diagnostics.map(|sink| {
+            TraceStageTimer::new(sink, irlume_common::diagnostics::TraceStage::EnrollmentLoad)
+        });
         let (sender, receiver) = std::sync::mpsc::channel();
         let user = user.to_string();
         std::thread::Builder::new()
@@ -1021,7 +1028,7 @@ impl Engine {
         if let Some(refusal) = self.ir_model_readiness(&target) {
             return refusal;
         }
-        let enrollment = match self.load_ir_enrollment(user, window, true) {
+        let enrollment = match self.load_ir_enrollment(user, window, true, None) {
             Ok(Some(enrollment)) => enrollment,
             _ => return Ready::EnrollmentUnavailable,
         };
@@ -1046,7 +1053,7 @@ impl Engine {
         if let Some(refusal) = self.ir_model_readiness(&target) {
             return Ok(readiness_refusal(refusal));
         }
-        let enrollment = match self.load_ir_enrollment(user, window, false)? {
+        let enrollment = match self.load_ir_enrollment(user, window, false, Some(diagnostics))? {
             Some(enrollment) => enrollment,
             None => return Ok(readiness_refusal(Ready::EnrollmentUnavailable)),
         };

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -150,6 +150,12 @@ pub use irlume_vision::Detector;
 pub struct Assessment {
     pub verdict: Verdict,
     pub reason: String,
+    /// Typed origin of the liveness refusal, from the gate that produced it.
+    /// Overrides that replace `verdict`/`reason` after the gate (stale-pair
+    /// refusal, PAD downgrades) reset this to
+    /// [`irlume_liveness::DenyCause::Other`], so classification can never see
+    /// a cause the recorded verdict did not produce.
+    pub deny_cause: irlume_liveness::DenyCause,
     /// RGB-face embedding (visible light), the primary identity.
     pub embedding: Option<[f32; EMBED_DIM]>,
     /// IR-face embedding (for dark operation), if a face was found in IR:
@@ -1082,33 +1088,47 @@ pub fn presence_retryable(o: &Outcome) -> bool {
     )
 }
 
-/// Start of the reason irlume-liveness produces when the IR format defines no
-/// sensor ceiling. Pinned against that text by
-/// `an_unmeasurable_exposure_is_not_retryable`, the same way the `no face in IR`
-/// prefix below is pinned.
-const EXPOSURE_UNMEASURABLE_PREFIX: &str = "IR exposure unmeasurable";
-
 /// Kind of a non-Live cross-spectrum gate verdict on the RGB primary path.
-/// The `no face in IR` reason is singled out because it is the retryable
-/// RGB-yes/IR-no transient; the prefix is pinned against the string
-/// irlume-liveness produces by `grace_retries_only_presence_failures`.
-fn liveness_deny_kind(verdict: Verdict, reason: &str) -> OutcomeKind {
-    match verdict {
+/// The retryable RGB-yes/IR-no transient and the unmeasurable-exposure
+/// refusal arrive as typed causes from irlume-liveness (see
+/// [`irlume_liveness::DenyCause`]), produced where the gate produces its
+/// refusal; the reason strings stay human-facing only. Parity with the
+/// prefix matching this replaced is pinned by
+/// `typed_cause_classification_matches_the_prefix_contract`.
+fn liveness_deny_kind(verdict: Verdict, cause: irlume_liveness::DenyCause) -> OutcomeKind {
+    use irlume_liveness::DenyCause;
+    match (verdict, cause) {
         // Uncertain normally means framing or quality, which the grace window
         // retries. An unmeasurable IR format is neither: it is a property of
         // the camera that will hold for every frame, so retrying spends the
         // whole window to reach the same answer while telling the user to
         // adjust something that cannot help (#358). Report unavailable,
         // preserving terminal fallback and the existing account strike.
-        Verdict::Uncertain if reason.starts_with(EXPOSURE_UNMEASURABLE_PREFIX) => {
-            OutcomeKind::RuntimeUnavailable
-        }
-        Verdict::Uncertain => OutcomeKind::Uncertain,
-        Verdict::Spoof if reason.starts_with("no face in IR") => OutcomeKind::SpoofNoIrFace,
-        Verdict::Spoof => OutcomeKind::Spoof,
+        (Verdict::Uncertain, DenyCause::ExposureUnmeasurable) => OutcomeKind::RuntimeUnavailable,
+        (Verdict::Uncertain, _) => OutcomeKind::Uncertain,
+        // `no face in IR` is the retryable RGB-yes/IR-no transient; the typed
+        // cause carries it, so the reason prose below stays free to evolve.
+        (Verdict::Spoof, DenyCause::NoIrFace) => OutcomeKind::SpoofNoIrFace,
+        (Verdict::Spoof, _) => OutcomeKind::Spoof,
         // Callers only classify rejections; a Live verdict never reaches here.
-        Verdict::Live => OutcomeKind::OtherDeny,
+        (Verdict::Live, _) => OutcomeKind::OtherDeny,
     }
+}
+
+/// Report the enrollment-load boundary for a completed load. On the
+/// synchronous path this is the store load itself; on the deferred path it
+/// is the spawn-to-join resolution interval, which deliberately overlaps the
+/// camera preflight the unseal was deferred behind (stages may nest; never
+/// sum them). Not emitted when no load was ever attempted (the pre-check
+/// instant deny for a user with no store).
+fn emit_enrollment_load_timing(
+    diagnostics: &dyn irlume_common::diagnostics::DiagnosticSink,
+    started: std::time::Instant,
+) {
+    diagnostics.emit_trace(irlume_common::diagnostics::TraceEventKind::StageTiming {
+        stage: irlume_common::diagnostics::TraceStage::EnrollmentLoad,
+        elapsed_us: u64::try_from(started.elapsed().as_micros()).unwrap_or(u64::MAX),
+    });
 }
 
 fn emit_trace_stage_ms(
@@ -4073,7 +4093,8 @@ impl Engine {
             rgb_moire_score: rgb_moire,
         };
         let liveness_started = std::time::Instant::now();
-        let (verdict, _cues, reason) = self.gate.evaluate_rgb_only(&signals);
+        let (verdict, cues, reason) = self.gate.evaluate_rgb_only(&signals);
+        let deny_cause = cues.deny_cause;
         diagnostics.emit_trace(irlume_common::diagnostics::TraceEventKind::StageTiming {
             stage: irlume_common::diagnostics::TraceStage::Liveness,
             elapsed_us: u64::try_from(liveness_started.elapsed().as_micros()).unwrap_or(u64::MAX),
@@ -4106,7 +4127,7 @@ impl Engine {
             _ => PadEvidence::NotApplicable,
         };
         self.check_request_active()?;
-        let (verdict, reason) = match rgb_pad {
+        let (verdict, reason, deny_cause) = match rgb_pad {
             PadEvidence::Score(p) => {
                 irlume_common::dlog!("pad-vit(rgb-only): p_spoof {p:.3}");
                 if self.vit_pad_votes_deny(p) {
@@ -4116,12 +4137,13 @@ impl Engine {
                     (
                         Verdict::Spoof,
                         "RGB PAD cue flags a spoof; use your password".into(),
+                        irlume_liveness::DenyCause::Other,
                     )
                 } else {
-                    (verdict, reason)
+                    (verdict, reason, deny_cause)
                 }
             }
-            _ => (verdict, reason),
+            _ => (verdict, reason, deny_cause),
         };
         self.check_request_active()?;
         let embedding = match &rgb_top {
@@ -4135,6 +4157,7 @@ impl Engine {
         Ok(Assessment {
             verdict,
             reason,
+            deny_cause,
             embedding,
             rgb_frame_mean: irlume_camera::frame_mean(&rgb.data),
             ir_embedding: None,
@@ -4944,6 +4967,9 @@ impl Engine {
                 });
                 return Ok(DeferredAssessment { assessment: Assessment {
                     verdict: Verdict::Uncertain,
+                    // Never reached the gate; the default cause classifies the
+                    // custom reason exactly as the prefix rule did.
+                    deny_cause: irlume_liveness::DenyCause::Other,
                     rgb_frame_mean: irlume_camera::frame_mean(&rgb.data),
                     reason: format!(
                         "RGB and IR frames are {}ms apart (limit {}ms); they may not show the same moment",
@@ -5048,10 +5074,13 @@ impl Engine {
             rgb_specular_frac: 0.0,
         };
         let liveness_started = std::time::Instant::now();
-        let (verdict, _cues, reason) = match stale_pair_reason {
+        let (verdict, cues, reason) = match stale_pair_reason {
+            // A stale pair never reached the gate; the default cues carry no
+            // typed cause, which is the correct classification for it.
             Some(reason) => (Verdict::Uncertain, Default::default(), reason),
             None => self.gate.evaluate(&signals),
         };
+        let deny_cause = cues.deny_cause;
         // Log the cue values on PASS too; a near-miss on a genuine user is
         // invisible in the outcome line but obvious here.
         irlume_common::dlog!(
@@ -5092,18 +5121,20 @@ impl Engine {
             PadEvidence::Score(p) => Some(p),
             _ => None,
         };
-        let (verdict, reason) = if pad_downgrades(verdict, shipped_ir_fake, IR_PAD_THRESHOLD) {
-            let pf = shipped_ir_fake.unwrap_or(1.0);
-            irlume_common::dlog!(
-                "pad-ir: p_fake {pf:.3} >= {IR_PAD_THRESHOLD:.2}; downgrading Live to Spoof"
-            );
-            (
-                Verdict::Spoof,
-                "IR PAD cue flags a spoof; use your password".into(),
-            )
-        } else {
-            (verdict, reason)
-        };
+        let (verdict, reason, deny_cause) =
+            if pad_downgrades(verdict, shipped_ir_fake, IR_PAD_THRESHOLD) {
+                let pf = shipped_ir_fake.unwrap_or(1.0);
+                irlume_common::dlog!(
+                    "pad-ir: p_fake {pf:.3} >= {IR_PAD_THRESHOLD:.2}; downgrading Live to Spoof"
+                );
+                (
+                    Verdict::Spoof,
+                    "IR PAD cue flags a spoof; use your password".into(),
+                    irlume_liveness::DenyCause::Other,
+                )
+            } else {
+                (verdict, reason, deny_cause)
+            };
         // Shipped ViT RGB PAD cue (ADR-0013, default-on): score the RGB face
         // only on frames the (already post-IR-PAD) verdict still calls Live —
         // deny-only cues never need to run on frames that already deny, and
@@ -5133,7 +5164,7 @@ impl Engine {
             _ => PadEvidence::NotApplicable,
         };
         self.check_request_active()?;
-        let (verdict, reason) = match rgb_pad {
+        let (verdict, reason, deny_cause) = match rgb_pad {
             PadEvidence::Score(p) => {
                 irlume_common::dlog!("pad-vit: p_spoof {p:.3}");
                 if self.vit_pad_votes_deny(p) {
@@ -5143,12 +5174,13 @@ impl Engine {
                     (
                         Verdict::Spoof,
                         "RGB PAD cue flags a spoof; use your password".into(),
+                        irlume_liveness::DenyCause::Other,
                     )
                 } else {
-                    (verdict, reason)
+                    (verdict, reason, deny_cause)
                 }
             }
-            _ => (verdict, reason),
+            _ => (verdict, reason, deny_cause),
         };
         diagnostics.emit_trace(irlume_common::diagnostics::TraceEventKind::StageTiming {
             stage: irlume_common::diagnostics::TraceStage::Liveness,
@@ -5161,6 +5193,7 @@ impl Engine {
         let assessment = Assessment {
             verdict,
             reason,
+            deny_cause,
             embedding: None,
             rgb_frame_mean: irlume_camera::frame_mean(&rgb.data),
             ir_embedding: None,
@@ -5479,7 +5512,11 @@ impl Engine {
         // path resolves `enr` at the join below, after camera setup.
         let loader_was_async = loader.receiver.is_some();
         let sync_enr = if loader.receiver.is_none() {
-            match irlume_core::storage::load(user)? {
+            let loaded = irlume_core::storage::load(user)?;
+            // Completed work boundary: the plaintext store load itself,
+            // before any policy decision on its content.
+            emit_enrollment_load_timing(diagnostics, load_started);
+            match loaded {
                 Some(enr) => match self.enrollment_policy_refusal(user, &enr) {
                     Some(outcome) => return Ok(outcome),
                     None => Some(enr),
@@ -5575,7 +5612,12 @@ impl Engine {
         let enr = match loader.receiver.take() {
             Some(rx) => {
                 let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-                match resolve_loader(rx.recv_timeout(remaining)) {
+                let resolved = resolve_loader(rx.recv_timeout(remaining));
+                // The deferred store load just finished (or failed bounded):
+                // report the resolution interval, which by design overlaps
+                // the camera preflight it was deferred behind.
+                emit_enrollment_load_timing(diagnostics, load_started);
+                match resolved {
                     Ok(enr) => enr,
                     Err(LoaderExit::NotEnrolled) => {
                         return Ok(Outcome::deny(
@@ -6064,7 +6106,7 @@ impl Engine {
         // dark path's own retryability kinds.
         if uncertain_short_circuits(a.verdict, a.embedding.is_some(), a.ir_embedding.is_some()) {
             return Ok(Outcome::deny(
-                liveness_deny_kind(a.verdict, &a.reason),
+                liveness_deny_kind(a.verdict, a.deny_cause),
                 format!("liveness {:?}: {}", a.verdict, a.reason),
             ));
         }
@@ -6088,7 +6130,7 @@ impl Engine {
         if let Some(probe) = a.embedding {
             if a.verdict != Verdict::Live {
                 return Ok(Outcome::deny(
-                    liveness_deny_kind(a.verdict, &a.reason),
+                    liveness_deny_kind(a.verdict, a.deny_cause),
                     format!("liveness {:?}: {}", a.verdict, a.reason),
                 ));
             }
@@ -6302,7 +6344,7 @@ impl Engine {
                 };
                 return Ok(Outcome::deny(OutcomeKind::OtherDeny, reason));
             }
-            let (verdict, _cues, reason) = self.gate.evaluate_ir_only(&a.signals);
+            let (verdict, cues, reason) = self.gate.evaluate_ir_only(&a.signals);
             diagnostics.emit_trace(irlume_liveness::diagnostic_trace_decision(
                 verdict, &a.signals,
             ));
@@ -6326,13 +6368,14 @@ impl Engine {
                 // as Uncertain too, and an inline map would leave it in the
                 // retryable class on exactly the camera this gate exists for:
                 // six full captures reaching the identical answer, every dark
-                // login, forever. The classifier holds the one prefix rule
+                // login, forever. The classifier holds the typed-cause rule
                 // (#358 review).
                 //
                 // `reason` here is the raw liveness string; the "dark liveness"
-                // prefix is applied in the `format!` below, after this call, so
-                // the prefix match still sees what irlume-liveness produced.
-                let kind = liveness_deny_kind(verdict, &reason);
+                // prefix is applied in the `format!` below, after this call.
+                // Classification reads the typed cause the same evaluator
+                // produced, not the decorated reason.
+                let kind = liveness_deny_kind(verdict, cues.deny_cause);
                 return Ok(Outcome::deny(
                     kind,
                     format!("dark liveness {verdict:?}: {reason}"),
@@ -8858,14 +8901,21 @@ mod tests {
             ..Default::default()
         };
         sig.ir_ceiling_known = false;
-        let (verdict, _, reason) = irlume_liveness::LivenessGate::new().evaluate(&sig);
+        let (verdict, cues, reason) = irlume_liveness::LivenessGate::new().evaluate(&sig);
         assert_eq!(verdict, Verdict::Uncertain, "precondition for this test");
+        // The wording stays pinned even though routing no longer reads it: it
+        // must keep refusing to advise something that cannot help (#358).
         assert!(
             reason.starts_with(EXPOSURE_UNMEASURABLE_PREFIX),
-            "the prefix this routing keys on moved: {reason}"
+            "the pinned producer wording moved: {reason}"
+        );
+        assert_eq!(
+            cues.deny_cause,
+            irlume_liveness::DenyCause::ExposureUnmeasurable,
+            "the producer must type this refusal at its origin"
         );
 
-        let kind = liveness_deny_kind(verdict, &reason);
+        let kind = liveness_deny_kind(verdict, cues.deny_cause);
         assert_eq!(
             kind,
             OutcomeKind::RuntimeUnavailable,
@@ -8881,8 +8931,8 @@ mod tests {
         let mut blown = sig.clone();
         blown.ir_ceiling_known = true;
         blown.ir_saturated_frac = Some(0.9);
-        let (bv, _, br) = irlume_liveness::LivenessGate::new().evaluate(&blown);
-        let bk = liveness_deny_kind(bv, &br);
+        let (bv, bc, br) = irlume_liveness::LivenessGate::new().evaluate(&blown);
+        let bk = liveness_deny_kind(bv, bc.deny_cause);
         assert_eq!(bk, OutcomeKind::Uncertain, "{br}");
         assert!(presence_retryable(&denied(bk, &br, false)), "{br}");
 
@@ -8892,13 +8942,17 @@ mod tests {
         // site mapping inline, so on the one camera class this gate exists for
         // a dark login burned the whole grace window reaching this answer
         // repeatedly (#358 review).
-        let (dv, _, dr) = irlume_liveness::LivenessGate::new().evaluate_ir_only(&sig);
+        let (dv, dc, dr) = irlume_liveness::LivenessGate::new().evaluate_ir_only(&sig);
         assert_eq!(dv, Verdict::Uncertain, "precondition: {dr}");
         assert!(
             dr.starts_with(EXPOSURE_UNMEASURABLE_PREFIX),
-            "the dark evaluator stopped producing the pinned prefix: {dr}"
+            "the dark evaluator stopped producing the pinned wording: {dr}"
         );
-        let dk = liveness_deny_kind(dv, &dr);
+        assert_eq!(
+            dc.deny_cause,
+            irlume_liveness::DenyCause::ExposureUnmeasurable
+        );
+        let dk = liveness_deny_kind(dv, dc.deny_cause);
         assert_eq!(dk, OutcomeKind::RuntimeUnavailable, "{dr}");
         assert!(!presence_retryable(&denied(dk, &dr, false)), "{dr}");
 
@@ -8908,9 +8962,13 @@ mod tests {
         dark_flat.ir_ceiling_known = true;
         dark_flat.ir_saturated_frac = Some(0.0);
         dark_flat.ir_center_edge_ratio = 0.1;
-        let (fv, _, fr) = irlume_liveness::LivenessGate::new().evaluate_ir_only(&dark_flat);
+        let (fv, fc, fr) = irlume_liveness::LivenessGate::new().evaluate_ir_only(&dark_flat);
         assert_eq!(fv, Verdict::Spoof, "precondition: {fr}");
-        assert_eq!(liveness_deny_kind(fv, &fr), OutcomeKind::Spoof, "{fr}");
+        assert_eq!(
+            liveness_deny_kind(fv, fc.deny_cause),
+            OutcomeKind::Spoof,
+            "{fr}"
+        );
     }
 
     /// Every liveness verdict becomes an `OutcomeKind` through
@@ -8945,22 +9003,99 @@ mod tests {
             "these sites classify a liveness verdict by hand instead of calling \
              liveness_deny_kind, so they do not inherit its retryability rules: {offenders:?}"
         );
-        // Not vacuous: the call site must actually be there, or this test
-        // would pass by having nothing to look at. The needle is assembled
-        // from pieces so it does not appear verbatim in the file it scans;
-        // spelled inline, the assertion matched its own source and stayed
+        // Not vacuous: the call sites must actually be there, or this test
+        // would pass by having nothing to look at. The needles are assembled
+        // from pieces so they do not appear verbatim in the file they scan;
+        // spelled inline, an assertion matched its own source and stayed
         // green with the real call site deleted.
-        let needle = concat!("liveness_deny_kind", "(verdict, &reason)");
+        let stored = concat!("liveness_deny_kind", "(a.verdict, a.deny_cause)");
+        let fresh = concat!("liveness_deny_kind", "(verdict, cues.deny_cause)");
         assert!(
-            src.matches(needle).count() >= 2,
+            src.matches(stored).count() + src.matches(fresh).count() >= 5,
             "the deny sites that route through liveness_deny_kind are gone; \
              the rule this test pins has nothing left to hold"
         );
     }
 
+    /// Start of the reason irlume-liveness produces when the IR format
+    /// defines no sensor ceiling. Routing no longer keys on this prefix (the
+    /// typed [`irlume_liveness::DenyCause`] carries it); this literal keeps
+    /// pinning the producer's wording so the user-facing explanation cannot
+    /// silently drift into advice that cannot help (#358).
+    const EXPOSURE_UNMEASURABLE_PREFIX: &str = "IR exposure unmeasurable";
+
+    /// The prefix rules the typed classifier replaced, kept here as the
+    /// parity oracle: for every (verdict, cause, reason) triple the producers
+    /// emit, the typed classifier must agree with the prefix classifier it
+    /// replaced.
+    fn legacy_prefix_kind(verdict: Verdict, reason: &str) -> OutcomeKind {
+        match verdict {
+            Verdict::Uncertain if reason.starts_with(EXPOSURE_UNMEASURABLE_PREFIX) => {
+                OutcomeKind::RuntimeUnavailable
+            }
+            Verdict::Uncertain => OutcomeKind::Uncertain,
+            Verdict::Spoof if reason.starts_with("no face in IR") => OutcomeKind::SpoofNoIrFace,
+            Verdict::Spoof => OutcomeKind::Spoof,
+            Verdict::Live => OutcomeKind::OtherDeny,
+        }
+    }
+
+    #[test]
+    fn typed_cause_classification_matches_the_prefix_contract() {
+        use irlume_liveness::DenyCause;
+        let cases = [
+            (
+                Verdict::Uncertain,
+                DenyCause::ExposureUnmeasurable,
+                "IR exposure unmeasurable: this camera's IR format defines no sensor \
+                 ceiling, so clipping cannot be checked and the liveness cues cannot \
+                 be trusted. Report the camera so its format can be supported.",
+            ),
+            (
+                Verdict::Uncertain,
+                DenyCause::Other,
+                "IR frame blown out (90% of the face at the sensor ceiling); move \
+                 back or dim the light",
+            ),
+            (
+                Verdict::Uncertain,
+                DenyCause::Other,
+                "not facing the camera (yaw 0.50, pitch 0.10); look directly at it",
+            ),
+            (Verdict::Uncertain, DenyCause::NoIrFace, "no face in IR"),
+            (
+                Verdict::Spoof,
+                DenyCause::NoIrFace,
+                "no face in IR: a real face reflects 850nm; a screen/print does not",
+            ),
+            (
+                Verdict::Spoof,
+                DenyCause::Other,
+                "IR too flat (center/edge 0.90); looks 2D, not a 3D face",
+            ),
+            (
+                Verdict::Spoof,
+                DenyCause::Other,
+                "IR PAD cue flags a spoof; use your password",
+            ),
+            (
+                Verdict::Live,
+                DenyCause::Other,
+                "live: face in RGB+IR, co-located, frontal, IR-reflective, 3D",
+            ),
+        ];
+        for (verdict, cause, reason) in cases {
+            assert_eq!(
+                liveness_deny_kind(verdict, cause),
+                legacy_prefix_kind(verdict, reason),
+                "typed drift: {verdict:?} + {cause:?} ({reason})"
+            );
+        }
+    }
+
     #[test]
     fn grace_retries_only_presence_failures() {
-        use irlume_liveness::Verdict;
+        use irlume_liveness::{DenyCause, Verdict};
         // Retryable: the user simply was not usably in frame yet. Strings are
         // built exactly as the authenticate path builds them, and kinds come
         // from the same classifier the construction sites use, so this test
@@ -8972,7 +9107,7 @@ mod tests {
         );
         assert_retryable(
             &denied(
-                liveness_deny_kind(Verdict::Uncertain, "not facing the camera"),
+                liveness_deny_kind(Verdict::Uncertain, DenyCause::Other),
                 &format!("liveness {:?}: not facing the camera", Verdict::Uncertain),
                 false,
             ),
@@ -8990,7 +9125,7 @@ mod tests {
         // settling into frame (safe: a real screen never grows an IR face).
         assert_retryable(
             &denied(
-                liveness_deny_kind(Verdict::Spoof, "no face in IR: a real face reflects 850nm"),
+                liveness_deny_kind(Verdict::Spoof, DenyCause::NoIrFace),
                 &format!(
                     "liveness {:?}: no face in IR: a real face reflects 850nm",
                     Verdict::Spoof
@@ -9002,7 +9137,7 @@ mod tests {
         // NEVER retryable: a real spoof verdict (flat/2D, free attack retries)...
         assert_retryable(
             &denied(
-                liveness_deny_kind(Verdict::Spoof, "flat 2D surface"),
+                liveness_deny_kind(Verdict::Spoof, DenyCause::Other),
                 &format!("liveness {:?}: flat 2D surface", Verdict::Spoof),
                 false,
             ),
@@ -10766,7 +10901,7 @@ mod pad_cue_tests {
         }
         kinds.push(super::liveness_deny_kind(
             Verdict::Uncertain,
-            super::EXPOSURE_UNMEASURABLE_PREFIX,
+            irlume_liveness::DenyCause::ExposureUnmeasurable,
         ));
         for kind in kinds {
             for f in &facts {
@@ -11262,6 +11397,8 @@ mod engine_tests {
         });
         let a = Assessment {
             verdict: if deny { Verdict::Spoof } else { Verdict::Live },
+            // PAD-downgrade origin: never one of the specially routed causes.
+            deny_cause: irlume_liveness::DenyCause::Other,
             reason: if deny {
                 "RGB PAD cue flags a spoof"
             } else {
@@ -12540,7 +12677,6 @@ mod engine_tests {
         assert!(!o.granted);
         assert_eq!(o.reason, "'irlume-test-empty' has no face scans enrolled");
         assert_eq!(o.kind, OutcomeKind::SetupUnavailable);
-
         // Camera binding mismatch: anti-swap refusal before any capture.
         let mut e = Enrollment::new("irlume-test-bound");
         e.profiles.push(FaceProfile {
@@ -12604,6 +12740,94 @@ mod engine_tests {
         write_enrollment(&dir, &e);
         let err = s.engine.authenticate("irlume-test-cam", None).unwrap_err();
         assert!(err.to_string().contains("no camera found"), "{err}");
+
+        teardown_sandbox(&dir);
+    }
+
+    /// The enrollment-load boundary is a completed-work interval: it is
+    /// emitted exactly when a load (or deferred unseal join) finishes, never
+    /// for the pre-check instant deny of a user with no store at all.
+    #[test]
+    fn enrollment_load_boundary_is_traced_where_the_load_completes() {
+        use irlume_common::diagnostics::{DiagnosticSink, TraceEventKind, TraceStage};
+        use std::sync::Mutex;
+
+        #[derive(Default)]
+        struct StageSink(Mutex<Vec<TraceEventKind>>);
+
+        impl DiagnosticSink for StageSink {
+            fn emit_trace(&self, kind: TraceEventKind) {
+                self.0.lock().unwrap().push(kind);
+            }
+        }
+
+        let _g = env_guard();
+        let mut s = shared();
+        let dir = state_sandbox("auth-load-trace");
+
+        // A user with no store at all denies before any load starts, so no
+        // enrollment-load interval may appear.
+        let ghost = StageSink::default();
+        let o = s
+            .engine
+            .authenticate_for_with_diagnostics(
+                "irlume-test-ghost",
+                None,
+                AuthenticationPurpose::Verify,
+                &ghost,
+            )
+            .unwrap();
+        assert_eq!(o.kind, OutcomeKind::SetupUnavailable);
+        assert!(!ghost.0.lock().unwrap().iter().any(|event| matches!(
+            event,
+            TraceEventKind::StageTiming {
+                stage: TraceStage::EnrollmentLoad,
+                ..
+            }
+        )));
+
+        // An enrolled store that loads and then denies on policy still
+        // reports the completed load interval exactly once.
+        let mut e = Enrollment::new("irlume-test-empty");
+        e.profiles.push(FaceProfile {
+            name: "P1".into(),
+            scans: vec![],
+            ir_calib: None,
+            ir_calibs: Default::default(),
+        });
+        write_enrollment(&dir, &e);
+        let loaded = StageSink::default();
+        let o = s
+            .engine
+            .authenticate_for_with_diagnostics(
+                "irlume-test-empty",
+                None,
+                AuthenticationPurpose::Verify,
+                &loaded,
+            )
+            .unwrap();
+        assert_eq!(o.kind, OutcomeKind::SetupUnavailable);
+        let timings: Vec<_> = loaded
+            .0
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|event| {
+                matches!(
+                    event,
+                    TraceEventKind::StageTiming {
+                        stage: TraceStage::EnrollmentLoad,
+                        ..
+                    }
+                )
+            })
+            .cloned()
+            .collect();
+        assert_eq!(timings.len(), 1, "{:?}", loaded.0.lock().unwrap());
+        assert!(
+            matches!(&timings[0], TraceEventKind::StageTiming { elapsed_us, .. } if *elapsed_us > 0),
+            "the boundary must carry a real duration"
+        );
 
         teardown_sandbox(&dir);
     }
@@ -13161,6 +13385,7 @@ mod engine_tests {
         use irlume_liveness::{FaceBox, Signals, Verdict};
         let a = super::Assessment {
             verdict: Verdict::Uncertain,
+            deny_cause: irlume_liveness::DenyCause::Other,
             reason: "test".into(),
             embedding: None,
             ir_embedding: None,
@@ -13240,6 +13465,7 @@ mod engine_tests {
             let ir_brightness = signals.ir_face_brightness;
             let assessment = Assessment {
                 verdict: Verdict::Spoof,
+                deny_cause: irlume_liveness::DenyCause::Other,
                 reason: "failed liveness assessment".into(),
                 embedding: None,
                 ir_embedding: None,
@@ -13267,9 +13493,9 @@ mod engine_tests {
                 "flat" => thinkpad.ir_center_edge_ratio = 1.0,
                 _ => unreachable!(),
             }
-            let (verdict, _, reason) = LivenessGate::new().evaluate(&thinkpad);
+            let (verdict, cues, reason) = LivenessGate::new().evaluate(&thinkpad);
             assert_eq!(verdict, Verdict::Spoof, "{cue}: {reason}");
-            let kind = liveness_deny_kind(verdict, &reason);
+            let kind = liveness_deny_kind(verdict, cues.deny_cause);
             assert_eq!(kind, OutcomeKind::Spoof, "{cue}: {reason}");
             assert_eq!(
                 situation(thinkpad.clone(), kind),
@@ -13290,9 +13516,9 @@ mod engine_tests {
             let mut dark = base.clone();
             dark.ir_face_brightness = 20.0;
             dark.ir_persistent_saturated_frac = fraction;
-            let (verdict, _, reason) = LivenessGate::new().evaluate(&dark);
+            let (verdict, cues, reason) = LivenessGate::new().evaluate(&dark);
             assert_eq!(verdict, Verdict::Spoof, "fraction {fraction:?}: {reason}");
-            let kind = liveness_deny_kind(verdict, &reason);
+            let kind = liveness_deny_kind(verdict, cues.deny_cause);
             assert_eq!(
                 situation(dark, kind),
                 AttemptSituation::Spoof,
@@ -13342,18 +13568,18 @@ mod engine_tests {
         reworded.ir_persistent_saturated_frac = Some(0.1702);
 
         let gate = LivenessGate::new();
-        let (old_verdict, _, old_reason) = gate.evaluate(&old);
-        let (new_verdict, _, new_reason) = gate.evaluate(&reworded);
+        let (old_verdict, old_cues, old_reason) = gate.evaluate(&old);
+        let (new_verdict, new_cues, new_reason) = gate.evaluate(&reworded);
         assert_eq!(old_verdict, Verdict::Spoof, "{old_reason}");
         assert_eq!(new_verdict, Verdict::Spoof, "{new_reason}");
         assert!(!old_reason.contains("IR-bright source"), "{old_reason}");
         assert!(new_reason.contains("IR-bright source"), "{new_reason}");
         assert_eq!(
-            super::liveness_deny_kind(old_verdict, &old_reason),
-            super::liveness_deny_kind(new_verdict, &new_reason)
+            super::liveness_deny_kind(old_verdict, old_cues.deny_cause),
+            super::liveness_deny_kind(new_verdict, new_cues.deny_cause)
         );
         assert_eq!(
-            super::liveness_deny_kind(new_verdict, &new_reason),
+            super::liveness_deny_kind(new_verdict, new_cues.deny_cause),
             super::OutcomeKind::Spoof
         );
     }

--- a/crates/irlume-auth/src/lib.rs
+++ b/crates/irlume-auth/src/lib.rs
@@ -12833,6 +12833,72 @@ mod engine_tests {
     }
 
     #[test]
+    fn ir_enrollment_load_traces_success_absence_and_error_without_opening_cameras() {
+        use irlume_common::diagnostics::{DiagnosticSink, TraceEventKind, TraceStage};
+
+        #[derive(Default)]
+        struct Stages(Mutex<Vec<TraceEventKind>>);
+        impl DiagnosticSink for Stages {
+            fn emit_trace(&self, event: TraceEventKind) {
+                self.0.lock().unwrap().push(event);
+            }
+        }
+        let _g = env_guard();
+        let s = shared();
+        let dir = state_sandbox("ir-load-trace");
+        let sink = Stages::default();
+        let user = "irlume-test-ir-load";
+        write_enrollment(&dir, &Enrollment::new(user));
+        let loaded = s
+            .engine
+            .load_ir_enrollment(user, AuthenticationWindow::new(10_000), false, Some(&sink))
+            .unwrap()
+            .unwrap();
+        assert_eq!(loaded.user, user);
+        // Missing and corrupt stores retain their different return semantics,
+        // and each attempted load emits one completed boundary, no capture.
+        assert!(s
+            .engine
+            .load_ir_enrollment(
+                "irlume-test-missing",
+                AuthenticationWindow::new(10_000),
+                false,
+                Some(&sink),
+            )
+            .unwrap()
+            .is_none());
+        std::fs::write(dir.join(format!("{user}.json")), b"not json").unwrap();
+        assert!(s
+            .engine
+            .load_ir_enrollment(user, AuthenticationWindow::new(10_000), false, Some(&sink),)
+            .is_err());
+        let events = sink.0.lock().unwrap();
+        assert_eq!(events.len(), 3);
+        assert!(events.iter().all(|event| matches!(
+            event,
+            TraceEventKind::StageTiming {
+                stage: TraceStage::EnrollmentLoad,
+                ..
+            }
+        )));
+        drop(events);
+
+        // A request already outside its window must never start the loader or
+        // invent a completed-load timing. Zero means legacy one-shot, not expiry.
+        let expired = AuthenticationWindow {
+            deadline: std::time::Instant::now() - std::time::Duration::from_secs(1),
+            milliseconds: 1,
+        };
+        assert!(matches!(
+            s.engine
+                .load_ir_enrollment(user, expired, false, Some(&sink)),
+            Err(irlume_common::Error::DeadlineExpired)
+        ));
+        assert_eq!(sink.0.lock().unwrap().len(), 3);
+        teardown_sandbox(&dir);
+    }
+
+    #[test]
     fn identify_respects_fingerprint_mode_and_needs_a_camera() {
         let _g = env_guard();
         let mut s = shared();

--- a/crates/irlume-cli/src/trace.rs
+++ b/crates/irlume-cli/src/trace.rs
@@ -427,8 +427,9 @@ mod tests {
         ));
         let requested: serde_json::Value = serde_json::from_str(&request_line).unwrap();
         assert_eq!(
-            requested["TraceSubscribe"]["trace_schema"], 2,
-            "current CLI must negotiate the richer trace vocabulary"
+            requested["TraceSubscribe"]["trace_schema"],
+            serde_json::json!(CURRENT_TRACE_SCHEMA_VERSION),
+            "current CLI must negotiate the current trace vocabulary"
         );
         serde_json::to_writer(&mut stream, &Response::TraceAccepted { limits }).unwrap();
         stream.write_all(b"\n").unwrap();
@@ -581,7 +582,7 @@ mod tests {
         let _guard = crate::testenv::ENV_LOCK
             .lock()
             .unwrap_or_else(|p| p.into_inner());
-        for schema in [1, 2] {
+        for schema in [1, CURRENT_TRACE_SCHEMA_VERSION] {
             let dir = sandbox("negotiated");
             let socket = dir.join("daemon.sock");
             let target = dir.join("capture.jsonl");
@@ -665,7 +666,11 @@ mod tests {
                 },
                 !mislabeled_event,
             );
-            invalid.trace_schema = if mislabeled_event { 1 } else { 2 };
+            invalid.trace_schema = if mislabeled_event {
+                1
+            } else {
+                CURRENT_TRACE_SCHEMA_VERSION
+            };
             let listener = UnixListener::bind(&socket).unwrap();
             let server =
                 std::thread::spawn(move || serve_fixture(listener, limits, vec![started, invalid]));
@@ -695,7 +700,7 @@ mod tests {
     }
 
     #[test]
-    fn explanation_renders_v2_refusal_and_stage_labels_without_raw_reason_text() {
+    fn explanation_renders_refusal_and_stage_labels_without_raw_reason_text() {
         use irlume_common::diagnostics::{TraceRefusalReason, TraceStage};
         let records = vec![
             fixture_record(
@@ -723,7 +728,9 @@ mod tests {
             ),
         ];
         let rendered = render_timeline(&records);
-        assert!(rendered.starts_with("Irlume diagnostic trace schema 2\n"));
+        assert!(rendered.starts_with(&format!(
+            "Irlume diagnostic trace schema {TRACE_SCHEMA_VERSION}\n"
+        )));
         assert!(rendered.contains("AuthenticationRefusal { reason: RgbPadPending }"));
         assert!(rendered.contains("IdentityInference"));
         assert!(rendered.contains("StreamOwnerRelease"));

--- a/crates/irlume-common/src/diagnostics.rs
+++ b/crates/irlume-common/src/diagnostics.rs
@@ -14,8 +14,13 @@ pub const MAX_UNAVAILABLE_SECTIONS: usize = 16;
 pub const MAX_HISTORY_MS: u64 = 30 * 60 * 1_000;
 /// The schema selected when a subscriber does not request a version.
 pub const LEGACY_TRACE_SCHEMA_VERSION: u32 = 1;
+/// The schema tier between the legacy vocabulary and the current one: it
+/// added the typed authentication refusals and the identity/release timing
+/// stages, but not the end-to-end timing stages of the current tier. Kept
+/// addressable so an older client that negotiated it keeps working.
+pub const V2_TRACE_SCHEMA_VERSION: u32 = 2;
 /// Latest trace vocabulary, requested explicitly by current clients.
-pub const CURRENT_TRACE_SCHEMA_VERSION: u32 = 2;
+pub const CURRENT_TRACE_SCHEMA_VERSION: u32 = 3;
 /// Current schema for callers constructing new records, not a subscription default.
 pub const TRACE_SCHEMA_VERSION: u32 = CURRENT_TRACE_SCHEMA_VERSION;
 pub const DEFAULT_TRACE_DURATION_MS: u64 = 60_000;
@@ -703,6 +708,11 @@ diagnostic_enum!(TraceStage {
     StreamOwnerRelease,
     Matching,
     EmitterRestore,
+    EnrollmentLoad,
+    IngressParse,
+    QueueWait,
+    EngineAuthenticate,
+    CredentialUnseal,
 });
 diagnostic_enum!(TraceRefusalReason {
     RgbPadPending,
@@ -848,17 +858,37 @@ pub enum TraceEventKind {
 
 impl TraceEventKind {
     /// Whether this closed event vocabulary is available in the selected
-    /// schema. Legacy subscribers omit newer events before queue accounting.
+    /// schema. Legacy subscribers omit newer events before queue accounting:
+    /// an older parser rejects an unknown enum variant at deserialization,
+    /// so a stage or event a tier did not define must never reach it.
     #[must_use]
     pub const fn supports_schema(&self, schema: u32) -> bool {
+        macro_rules! end_to_end_timing_stage {
+            () => {
+                TraceStage::EnrollmentLoad
+                    | TraceStage::IngressParse
+                    | TraceStage::QueueWait
+                    | TraceStage::EngineAuthenticate
+                    | TraceStage::CredentialUnseal
+            };
+        }
         match schema {
             LEGACY_TRACE_SCHEMA_VERSION => !matches!(
                 self,
                 Self::AuthenticationRefusal { .. }
                     | Self::StageTiming {
-                        stage: TraceStage::IdentityInference | TraceStage::StreamOwnerRelease,
+                        stage: TraceStage::IdentityInference
+                            | TraceStage::StreamOwnerRelease
+                            | end_to_end_timing_stage!(),
                         ..
                     }
+            ),
+            V2_TRACE_SCHEMA_VERSION => !matches!(
+                self,
+                Self::StageTiming {
+                    stage: end_to_end_timing_stage!(),
+                    ..
+                }
             ),
             CURRENT_TRACE_SCHEMA_VERSION => true,
             _ => false,
@@ -1496,7 +1526,7 @@ mod tests {
                 true,
             ),
         ];
-        for schema in [1, 2] {
+        for schema in [1, 2, 3] {
             for record in &mut records {
                 record.trace_schema = schema;
             }
@@ -1510,7 +1540,7 @@ mod tests {
                 Err(TraceParseError::Schema)
             ));
         }
-        for schema in [0, 3, u32::MAX] {
+        for schema in [0, 4, u32::MAX] {
             records[0].trace_schema = schema;
             assert!(matches!(
                 parse_trace(std::io::Cursor::new(trace_jsonl(&records)), limits),
@@ -1564,6 +1594,50 @@ mod tests {
                 "event":"authentication_refusal", "reason":reason,
             }))
             .is_err());
+        }
+    }
+
+    /// The schema-3 end-to-end timing stages are a closed vocabulary tier of
+    /// their own: an older parser (schema 1 or 2 subscriber) fails
+    /// deserialization on an unknown enum variant, so the daemon must never
+    /// send one down those subscriptions, which is what `supports_schema`
+    /// encodes and this test pins.
+    #[test]
+    fn trace_v3_timing_stages_are_not_valid_v1_or_v2_records() {
+        let limits = TraceLimits::bounded(1000);
+        for stage in [
+            "enrollment_load",
+            "ingress_parse",
+            "queue_wait",
+            "engine_authenticate",
+            "credential_unseal",
+        ] {
+            let event = serde_json::json!({
+                "event":"stage_timing", "stage":stage, "elapsed_us":12
+            });
+            let typed = serde_json::from_value::<TraceEventKind>(event.clone())
+                .expect("schema 3 closed event vocabulary must deserialize");
+            assert_eq!(serde_json::to_value(&typed).unwrap(), event);
+            // Every pre-existing stage stays valid at every tier it already
+            // was, and the new tier accepts all of them.
+            assert!(typed.supports_schema(CURRENT_TRACE_SCHEMA_VERSION));
+            assert!(!typed.supports_schema(V2_TRACE_SCHEMA_VERSION), "{event}");
+            assert!(
+                !typed.supports_schema(LEGACY_TRACE_SCHEMA_VERSION),
+                "{event}"
+            );
+            for schema in [1, 2] {
+                let mut record = trace_record(0, typed.clone(), false);
+                record.trace_schema = schema;
+                let mut validator = TraceValidator::new(limits).unwrap();
+                assert!(
+                    matches!(
+                        validator.push_line(&serde_json::to_vec(&record).unwrap()),
+                        Err(TraceParseError::Schema)
+                    ),
+                    "{event} under schema {schema}"
+                );
+            }
         }
     }
 

--- a/crates/irlume-daemon/examples/daemon_timing.rs
+++ b/crates/irlume-daemon/examples/daemon_timing.rs
@@ -11,10 +11,11 @@
 
 use irlume_common::diagnostics::{
     TraceEventKind, TraceRecord, TraceStage, TraceValidator, CURRENT_TRACE_SCHEMA_VERSION,
-    MAX_TRACE_LINE_BYTES,
+    MAX_TRACE_DURATION_MS, MAX_TRACE_LINE_BYTES,
 };
 use irlume_common::{Request, Response};
-use std::io::{BufReader, Read, Write as _};
+use std::io::{BufRead as _, BufReader, Write as _};
+use std::os::unix::net::UnixStream;
 use std::time::{Duration, Instant};
 
 const HELP: &str = "Usage: daemon_timing <user> [--service NAME|none] [--trials N] [--cancel-after MS] [--no-trace]
@@ -23,7 +24,12 @@ With a trace subscription (root; default on unless --no-trace) it also prints th
 daemon-side stage boundaries (schema 3). Refused and cancelled trials are labeled,
 never pooled with grants. Stage intervals may overlap or nest and are never summed.
 Unmeasured boundaries (worker reply to socket write, PAM stack, desktop unlock) are
-printed explicitly. Attended, authorized use only: cameras may open.";
+printed explicitly. Replies have a 30s deadline; cancellation must be 0..=30000ms.
+Trace collection reserves a bounded window for the whole trial plan (at most 5min)
+and waits for its terminal record. Use --no-trace for longer trial plans or old daemons.
+Attended, authorized use only: cameras may open.";
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
+const REPLY_TIMEOUT: Duration = Duration::from_secs(30);
 const TRACE_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 
 struct Options {
@@ -73,22 +79,48 @@ impl Options {
         if positional.len() != 1 {
             return Err(HELP.into());
         }
-        Ok(Self {
+        if cancel_after_ms.is_some_and(|ms| ms > 30_000) {
+            return Err("cancel-after must be 0..=30000 ms".into());
+        }
+        let options = Self {
             user: positional.remove(0),
             service,
             trials,
             cancel_after_ms,
             trace,
-        })
+        };
+        if options.trace {
+            options.trace_duration_ms()?;
+        }
+        Ok(options)
+    }
+
+    fn trace_duration_ms(&self) -> Result<u64, String> {
+        let reply = self
+            .cancel_after_ms
+            .map(Duration::from_millis)
+            .unwrap_or(REPLY_TIMEOUT);
+        // Include each connection budget and leave cancellation cleanup time.
+        // Reject rather than silently letting the server clamp away coverage.
+        let duration = (CONNECT_TIMEOUT + reply + TRACE_DRAIN_TIMEOUT) * self.trials;
+        let ms = u64::try_from(duration.as_millis()).map_err(|_| "trace plan overflow")?;
+        if ms > MAX_TRACE_DURATION_MS {
+            return Err(
+                "trial plan exceeds the 5min trace limit; use fewer trials or --no-trace".into(),
+            );
+        }
+        Ok(ms)
     }
 }
 
 /// One client-measured trial. `wall_us` is the harness's own clock around
 /// request-to-reply; it shares no origin with daemon monotonic timestamps.
+#[derive(Debug)]
 struct TrialTiming {
     wall_us: Option<u64>,
     cancelled: bool,
     outcome: String,
+    reason: Option<String>,
 }
 
 fn outcome_label(response: &Response) -> &'static str {
@@ -139,6 +171,10 @@ fn render_report(trials: &[TrialTiming], stages: &[(TraceStage, u64)]) -> String
                 }
             )),
         }
+        if let Some(reason) = &trial.reason {
+            // Debug formatting escapes terminal controls and line breaks.
+            out.push_str(&format!("  reason: {reason:?}\n"));
+        }
     }
     let granted: Vec<u64> = trials
         .iter()
@@ -184,58 +220,83 @@ fn render_report(trials: &[TrialTiming], stages: &[(TraceStage, u64)]) -> String
     out
 }
 
-fn read_bounded_line<R: Read>(reader: &mut R, limit: usize) -> std::io::Result<Option<Vec<u8>>> {
+fn read_bounded_line(
+    reader: &mut BufReader<UnixStream>,
+    limit: usize,
+    deadline: Instant,
+) -> std::io::Result<Option<Vec<u8>>> {
     let mut line = Vec::new();
-    let mut byte = [0_u8; 1];
     loop {
-        match reader.read(&mut byte) {
-            Ok(0) => {
-                return if line.is_empty() {
-                    Ok(None)
-                } else {
-                    Err(std::io::Error::other("truncated line"))
-                };
-            }
-            Ok(_) if byte[0] == b'\n' => {
-                if line.len() > limit {
-                    return Err(std::io::Error::other("line too long"));
-                }
-                return Ok(Some(line));
-            }
-            Ok(_) => {
-                line.push(byte[0]);
-                if line.len() > limit {
-                    return Err(std::io::Error::other("line too long"));
-                }
-            }
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "line deadline",
+            ));
+        }
+        reader.get_ref().set_read_timeout(Some(remaining))?;
+        let available = match reader.fill_buf() {
+            Ok(bytes) => bytes,
             Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
             Err(e) => return Err(e),
+        };
+        if available.is_empty() {
+            return if line.is_empty() {
+                Ok(None)
+            } else {
+                Err(std::io::Error::other("truncated line"))
+            };
+        }
+        let newline = available.iter().position(|byte| *byte == b'\n');
+        let count = newline.unwrap_or(available.len());
+        if count > limit.saturating_sub(line.len()) {
+            return Err(std::io::Error::other("line too long"));
+        }
+        line.extend_from_slice(&available[..count]);
+        reader.consume(count + usize::from(newline.is_some()));
+        if newline.is_some() {
+            return Ok(Some(line));
         }
     }
+}
+
+fn encode_request(request: &Request) -> Result<Vec<u8>, String> {
+    let mut bytes =
+        serde_json::to_vec(request).map_err(|error| format!("encode request: {error}"))?;
+    bytes.push(b'\n');
+    Ok(bytes)
 }
 
 struct TraceConnection {
     reader: BufReader<std::os::unix::net::UnixStream>,
     validator: TraceValidator,
+    deadline: Instant,
+    coverage_deadline: Instant,
 }
 
 impl TraceConnection {
     fn subscribe(duration_ms: u64) -> Result<Self, String> {
-        let timeout = Duration::from_secs(15);
-        let mut stream = irlume_common::client::connect_stream(timeout)
+        let stream = irlume_common::client::connect_stream(CONNECT_TIMEOUT)
             .map_err(|error| format!("connect: {error}"))?;
-        let mut request = serde_json::to_vec(&Request::TraceSubscribe {
+        Self::on_stream(stream, duration_ms)
+    }
+
+    fn on_stream(mut stream: UnixStream, duration_ms: u64) -> Result<Self, String> {
+        let request = encode_request(&Request::TraceSubscribe {
             duration_ms,
             trace_schema: Some(CURRENT_TRACE_SCHEMA_VERSION),
-        })
-        .map_err(|error| format!("encode request: {error}"))?;
-        request.push(b'\n');
+        })?;
+        stream
+            .set_write_timeout(Some(CONNECT_TIMEOUT))
+            .map_err(|e| e.to_string())?;
+        let subscription_sent = Instant::now();
         stream
             .write_all(&request)
             .and_then(|()| stream.flush())
             .map_err(|error| format!("send request: {error}"))?;
         let mut reader = BufReader::new(stream);
-        let header = read_bounded_line(&mut reader, MAX_TRACE_LINE_BYTES)
+        let header_deadline = Instant::now() + CONNECT_TIMEOUT;
+        let header = read_bounded_line(&mut reader, MAX_TRACE_LINE_BYTES, header_deadline)
             .map_err(|error| format!("read header: {error}"))?
             .ok_or_else(|| "daemon closed before accepting the trace".to_owned())?;
         let limits = match serde_json::from_slice::<Response>(&header)
@@ -245,18 +306,43 @@ impl TraceConnection {
             Response::Error(message) => return Err(format!("trace refused: {message}")),
             other => return Err(format!("unexpected daemon response: {other:?}")),
         };
-        let validator = TraceValidator::new(limits)
+        let mut validator = TraceValidator::new(limits)
             .map_err(|error| format!("invalid daemon limits: {error}"))?;
-        Ok(Self { reader, validator })
+        if limits.duration_ms < duration_ms {
+            return Err("accepted trace window is shorter than the trial plan".into());
+        }
+        // Subscription processing can only start after this instant. Using it
+        // is conservative even when delivery of the start record is delayed.
+        let coverage_deadline = subscription_sent + Duration::from_millis(limits.duration_ms);
+        let deadline = coverage_deadline + TRACE_DRAIN_TIMEOUT;
+        // Older daemons may ignore the requested schema. Verify it before any
+        // authentication request, rather than losing timing attribution later.
+        let first = read_bounded_line(&mut reader, MAX_TRACE_LINE_BYTES, header_deadline)
+            .map_err(|error| format!("read trace start: {error}"))?
+            .ok_or("trace closed before its start record")?;
+        let first = validator
+            .push_line(&first)
+            .map_err(|e| format!("invalid trace start: {e}"))?;
+        if first.trace_schema != CURRENT_TRACE_SCHEMA_VERSION
+            || !matches!(first.event, TraceEventKind::TraceStarted { .. })
+            || first.terminal
+        {
+            return Err("daemon did not start the requested schema 3 trace; use --no-trace for an older daemon".into());
+        }
+        Ok(Self {
+            reader,
+            validator,
+            deadline,
+            coverage_deadline,
+        })
     }
 
     /// Drain until the terminal record (or a timeout), returning the stage
     /// boundaries of every operation observed.
     fn drain(mut self) -> Result<Vec<(TraceStage, u64)>, String> {
         let mut stages = Vec::new();
-        let deadline = Instant::now() + TRACE_DRAIN_TIMEOUT;
         loop {
-            let remaining = deadline.saturating_duration_since(Instant::now());
+            let remaining = self.deadline.saturating_duration_since(Instant::now());
             if remaining.is_zero() {
                 return Err("trace did not finish within the drain timeout".into());
             }
@@ -264,29 +350,36 @@ impl TraceConnection {
                 .get_ref()
                 .set_read_timeout(Some(remaining))
                 .map_err(|error| format!("set timeout: {error}"))?;
-            let line = match read_bounded_line(&mut self.reader, MAX_TRACE_LINE_BYTES) {
-                Ok(Some(line)) => line,
-                Ok(None) => {
-                    return Err("trace ended without a terminal record".into());
-                }
-                Err(e)
-                    if matches!(
-                        e.kind(),
-                        std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
-                    ) =>
-                {
-                    return Err("trace did not finish within the drain timeout".into());
-                }
-                Err(e) => return Err(format!("read trace: {e}")),
-            };
+            let line =
+                match read_bounded_line(&mut self.reader, MAX_TRACE_LINE_BYTES, self.deadline) {
+                    Ok(Some(line)) => line,
+                    Ok(None) => {
+                        return Err("trace ended without a terminal record".into());
+                    }
+                    Err(e)
+                        if matches!(
+                            e.kind(),
+                            std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                        ) =>
+                    {
+                        return Err("trace did not finish within the drain timeout".into());
+                    }
+                    Err(e) => return Err(format!("read trace: {e}")),
+                };
             let record: TraceRecord = self
                 .validator
                 .push_line(&line)
                 .map_err(|error| format!("invalid trace record: {error}"))?;
+            if matches!(record.event, TraceEventKind::EventsDropped { count } if count != 0) {
+                return Err("trace dropped events; timing attribution is incomplete".into());
+            }
             if let TraceEventKind::StageTiming { stage, elapsed_us } = record.event {
                 stages.push((stage, elapsed_us));
             }
             if record.terminal {
+                self.validator
+                    .finish()
+                    .map_err(|e| format!("invalid trace end: {e}"))?;
                 return Ok(stages);
             }
         }
@@ -294,30 +387,36 @@ impl TraceConnection {
 }
 
 fn one_trial(options: &Options) -> Result<TrialTiming, String> {
-    let mut stream = irlume_common::client::connect_stream(Duration::from_secs(15))
+    let stream = irlume_common::client::connect_stream(CONNECT_TIMEOUT)
         .map_err(|error| format!("connect: {error}"))?;
-    let request = serde_json::to_vec(&Request::Authenticate {
+    trial_on_stream(stream, options, REPLY_TIMEOUT)
+}
+
+fn trial_on_stream(
+    mut stream: UnixStream,
+    options: &Options,
+    reply_timeout: Duration,
+) -> Result<TrialTiming, String> {
+    let request = encode_request(&Request::Authenticate {
         user: options.user.clone(),
         service: options.service.clone(),
         structured_errors: true,
         intent_confirmation: None,
-    })
-    .map_err(|error| format!("encode request: {error}"))?;
+    })?;
     let cancel = options.cancel_after_ms.map(Duration::from_millis);
     let started = Instant::now();
+    stream
+        .set_write_timeout(Some(reply_timeout))
+        .map_err(|e| e.to_string())?;
     stream
         .write_all(&request)
         .and_then(|()| stream.flush())
         .map_err(|error| format!("send request: {error}"))?;
-    // A cancelled trial closes its own socket mid-request: the daemon learns
-    // the client left and stops the capture (ClientLink), which is the
-    // production cancellation path this harness observes.
-    if let Some(delay) = cancel {
-        std::thread::sleep(delay);
-        let _ = stream.shutdown(std::net::Shutdown::Both);
-    }
+    // Read immediately so a reply that beats cancellation keeps its actual
+    // reply interval. A deadline-triggered disconnect has no reply interval.
     let mut reader = BufReader::new(stream);
-    let line = read_bounded_line(&mut reader, MAX_TRACE_LINE_BYTES);
+    let deadline = started + cancel.unwrap_or(reply_timeout).min(reply_timeout);
+    let line = read_bounded_line(&mut reader, MAX_TRACE_LINE_BYTES, deadline);
     let elapsed = started.elapsed();
     match line {
         Ok(Some(line)) => {
@@ -327,18 +426,41 @@ fn one_trial(options: &Options) -> Result<TrialTiming, String> {
                 wall_us: Some(u64::try_from(elapsed.as_micros()).unwrap_or(u64::MAX)),
                 cancelled: false,
                 outcome: outcome_label(&response).to_owned(),
+                reason: match response {
+                    Response::AuthResult {
+                        granted: false,
+                        reason,
+                        ..
+                    } => Some(reason),
+                    Response::Error(reason) => Some(reason),
+                    _ => None,
+                },
+            })
+        }
+        Err(e)
+            if cancel.is_some()
+                && matches!(
+                    e.kind(),
+                    std::io::ErrorKind::TimedOut | std::io::ErrorKind::WouldBlock
+                ) =>
+        {
+            reader
+                .get_ref()
+                .shutdown(std::net::Shutdown::Both)
+                .map_err(|e| format!("cancel request: {e}"))?;
+            Ok(TrialTiming {
+                wall_us: None,
+                cancelled: true,
+                outcome: "cancelled".into(),
+                reason: None,
             })
         }
         Err(e) => Err(format!("read reply: {e}")),
         Ok(None) => Ok(TrialTiming {
             wall_us: None,
-            cancelled: cancel.is_some(),
-            outcome: if cancel.is_some() {
-                "cancelled"
-            } else {
-                "no-reply"
-            }
-            .to_owned(),
+            cancelled: false,
+            outcome: "no-reply".into(),
+            reason: None,
         }),
     }
 }
@@ -357,26 +479,31 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     eprintln!(
         "attended, authorized measurement only; cameras may open; refused outcomes are labeled"
     );
-    let trace = match if options.trace {
-        Some(TraceConnection::subscribe(60_000))
+    let (trace, coverage_deadline) = if options.trace {
+        let connection = TraceConnection::subscribe(options.trace_duration_ms()?)?;
+        let coverage_deadline = connection.coverage_deadline;
+        // Drain while trials run: an undrained subscriber can overflow its
+        // bounded queue and lose exactly the events this tool is measuring.
+        (
+            Some(std::thread::spawn(move || connection.drain())),
+            Some(coverage_deadline),
+        )
     } else {
-        None
-    } {
-        Some(Ok(connection)) => Some(connection),
-        Some(Err(message)) => {
-            eprintln!("daemon_timing: continuing without a trace ({message})");
-            None
-        }
-        None => None,
+        (None, None)
     };
-    let mut trials = Vec::new();
-    for _ in 0..options.trials {
-        trials.push(one_trial(&options)?);
-    }
+    let trials: Result<Vec<_>, _> = (0..options.trials).map(|_| one_trial(&options)).collect();
+    let coverage_overrun = coverage_deadline.is_some_and(|deadline| Instant::now() > deadline);
     let stages = match trace {
-        Some(connection) => connection.drain()?,
-        None => Vec::new(),
+        Some(worker) => worker.join().map_err(|_| "trace reader panicked")?,
+        None => Ok(Vec::new()),
     };
+    let trials = trials?;
+    let stages = stages?;
+    if coverage_overrun {
+        return Err(
+            "trials outlasted the reserved trace window; timing attribution is incomplete".into(),
+        );
+    }
     print!("{}", render_report(&trials, &stages));
     Ok(())
 }
@@ -384,12 +511,280 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use irlume_common::diagnostics::{
+        CategoricalOutcome, OperationClass, OperationId, TraceLimits, TraceWarning,
+    };
+
+    const REFUSAL: &[u8] = b"{\"AuthResult\":{\"granted\":false,\"score\":0.0,\"live\":false,\"reason\":\"no face in IR\"}}\n";
+
+    fn options(cancel: Option<u64>) -> Options {
+        Options {
+            user: "synthetic-user".into(),
+            service: Some("kde-fingerprint".into()),
+            trials: 1,
+            cancel_after_ms: cancel,
+            trace: false,
+        }
+    }
+
+    fn fake_auth(reply: Option<&'static [u8]>) -> (UnixStream, std::thread::JoinHandle<()>) {
+        let (client, server) = UnixStream::pair().unwrap();
+        let worker = std::thread::spawn(move || {
+            let mut reader = BufReader::new(server);
+            let request = read_bounded_line(
+                &mut reader,
+                MAX_TRACE_LINE_BYTES,
+                Instant::now() + Duration::from_secs(2),
+            )
+            .unwrap()
+            .unwrap();
+            assert!(matches!(
+                serde_json::from_slice::<Request>(&request).unwrap(),
+                Request::Authenticate { .. }
+            ));
+            if let Some(reply) = reply {
+                reader.get_mut().write_all(reply).unwrap();
+            }
+        });
+        (client, worker)
+    }
+
+    #[test]
+    fn socket_trial_sends_a_complete_request_and_preserves_refusal_reason() {
+        let (client, worker) = fake_auth(Some(REFUSAL));
+        let result = trial_on_stream(client, &options(None), REPLY_TIMEOUT).unwrap();
+        worker.join().unwrap();
+        assert_eq!(result.outcome, "refused");
+        assert_eq!(result.reason.as_deref(), Some("no face in IR"));
+        assert!(result.wall_us.is_some());
+    }
+
+    #[test]
+    fn reply_winning_cancellation_keeps_its_reply_time() {
+        let (client, worker) = fake_auth(Some(REFUSAL));
+        let result = trial_on_stream(client, &options(Some(2_000)), REPLY_TIMEOUT).unwrap();
+        worker.join().unwrap();
+        assert_eq!(result.outcome, "refused");
+        assert!(!result.cancelled);
+        assert!(
+            result.wall_us.unwrap() < 1_500_000,
+            "must not sleep to the cancellation instant after a reply"
+        );
+    }
+
+    #[test]
+    fn cancellation_disconnects_without_inventing_a_reply_interval() {
+        let (client, server) = UnixStream::pair().unwrap();
+        let result = trial_on_stream(client, &options(Some(30)), REPLY_TIMEOUT).unwrap();
+        assert!(result.cancelled);
+        assert_eq!(result.wall_us, None);
+        let mut reader = BufReader::new(server);
+        let deadline = Instant::now() + Duration::from_secs(1);
+        assert!(
+            read_bounded_line(&mut reader, MAX_TRACE_LINE_BYTES, deadline)
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            read_bounded_line(&mut reader, MAX_TRACE_LINE_BYTES, deadline)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn peer_eof_before_cancel_is_not_a_harness_cancellation() {
+        let (client, worker) = fake_auth(None);
+        let result = trial_on_stream(client, &options(Some(2_000)), REPLY_TIMEOUT).unwrap();
+        worker.join().unwrap();
+        assert_eq!(result.outcome, "no-reply");
+        assert!(!result.cancelled);
+    }
+
+    #[test]
+    fn reply_wait_uses_its_own_budget_and_a_partial_line_cannot_extend_it() {
+        let (client, mut server) = UnixStream::pair().unwrap();
+        // An inherited connect timeout must not become the reply timeout.
+        client
+            .set_read_timeout(Some(Duration::from_millis(1)))
+            .unwrap();
+        let worker = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(30));
+            server.write_all(REFUSAL).unwrap();
+        });
+        let result = trial_on_stream(client, &options(None), Duration::from_secs(1)).unwrap();
+        worker.join().unwrap();
+        assert_eq!(result.outcome, "refused");
+
+        let (client, mut server) = UnixStream::pair().unwrap();
+        server.write_all(b"{\"AuthResult\":").unwrap();
+        let result = trial_on_stream(client, &options(None), Duration::from_millis(30));
+        assert!(result.unwrap_err().contains("read reply"));
+    }
+
+    #[test]
+    fn socket_lines_reject_oversize_and_truncation() {
+        for (bytes, limit, expected) in [
+            (b"abc\n".as_slice(), 3, true),
+            (b"abcd\n", 3, false),
+            (b"abc", 3, false),
+        ] {
+            let (client, mut server) = UnixStream::pair().unwrap();
+            server.write_all(bytes).unwrap();
+            server.shutdown(std::net::Shutdown::Write).unwrap();
+            let result = read_bounded_line(
+                &mut BufReader::new(client),
+                limit,
+                Instant::now() + Duration::from_secs(1),
+            );
+            assert_eq!(result.is_ok(), expected);
+        }
+    }
+
+    fn trace_record(
+        schema: u32,
+        sequence: u64,
+        event: TraceEventKind,
+        terminal: bool,
+    ) -> TraceRecord {
+        TraceRecord {
+            trace_schema: schema,
+            sequence,
+            monotonic_us: sequence,
+            utc_unix_ms: 0,
+            operation_id: OperationId::from_bytes([0; 16]),
+            operation: OperationClass::Authentication,
+            event,
+            terminal,
+        }
+    }
+
+    fn send_record(stream: &mut UnixStream, record: &TraceRecord) {
+        let mut bytes = serde_json::to_vec(record).unwrap();
+        bytes.push(b'\n');
+        stream.write_all(&bytes).unwrap();
+    }
+
+    fn trace_pair(schema: u32, duration: u64) -> (UnixStream, UnixStream) {
+        let (client, mut server) = UnixStream::pair().unwrap();
+        let limits = TraceLimits::bounded(duration);
+        let mut header = serde_json::to_vec(&Response::TraceAccepted { limits }).unwrap();
+        header.push(b'\n');
+        server.write_all(&header).unwrap();
+        send_record(
+            &mut server,
+            &trace_record(
+                schema,
+                0,
+                TraceEventKind::TraceStarted {
+                    limits,
+                    warning: TraceWarning::PrivilegedDiagnosticOracle,
+                },
+                false,
+            ),
+        );
+        (client, server)
+    }
+
+    #[test]
+    fn trace_rejects_ignored_schema_and_clipped_coverage_before_trials() {
+        let (client, _server) = trace_pair(1, 100);
+        assert!(TraceConnection::on_stream(client, 100)
+            .err()
+            .unwrap()
+            .contains("schema 3"));
+        let (client, _server) = trace_pair(3, 50);
+        assert!(TraceConnection::on_stream(client, 100)
+            .err()
+            .unwrap()
+            .contains("shorter"));
+    }
+
+    #[test]
+    fn trace_requires_a_terminal_record_and_rejects_dropped_events() {
+        let (client, server) = trace_pair(3, 100);
+        let connection = TraceConnection::on_stream(client, 100).unwrap();
+        server.shutdown(std::net::Shutdown::Write).unwrap();
+        assert!(connection.drain().unwrap_err().contains("terminal"));
+        let (client, mut server) = trace_pair(3, 100);
+        let connection = TraceConnection::on_stream(client, 100).unwrap();
+        send_record(
+            &mut server,
+            &trace_record(3, 1, TraceEventKind::EventsDropped { count: 1 }, false),
+        );
+        assert!(connection.drain().unwrap_err().contains("dropped"));
+    }
+
+    #[test]
+    fn trace_waits_for_the_promised_window_instead_of_a_fixed_five_second_drain() {
+        let (client, mut server) = trace_pair(3, 6_000);
+        let connection = TraceConnection::on_stream(client, 6_000).unwrap();
+        let worker = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_secs(6));
+            send_record(
+                &mut server,
+                &trace_record(
+                    3,
+                    1,
+                    TraceEventKind::StageTiming {
+                        stage: TraceStage::QueueWait,
+                        elapsed_us: 12,
+                    },
+                    false,
+                ),
+            );
+            send_record(
+                &mut server,
+                &trace_record(
+                    3,
+                    2,
+                    TraceEventKind::Finished {
+                        outcome: CategoricalOutcome::Completed,
+                    },
+                    true,
+                ),
+            );
+        });
+        let stages = connection.drain().unwrap();
+        worker.join().unwrap();
+        assert_eq!(stages, vec![(TraceStage::QueueWait, 12)]);
+    }
+
+    #[test]
+    fn trace_plan_and_cancellation_are_bounded_before_connecting() {
+        let parse =
+            |args: &[&str]| Options::parse(&args.iter().map(|s| s.to_string()).collect::<Vec<_>>());
+        assert_eq!(
+            parse(&["user"]).unwrap().trace_duration_ms().unwrap(),
+            50_000
+        );
+        assert_eq!(
+            parse(&["user", "--trials", "6"])
+                .unwrap()
+                .trace_duration_ms()
+                .unwrap(),
+            300_000
+        );
+        assert!(parse(&["user", "--trials", "7"]).is_err());
+        assert!(parse(&["user", "--trials", "100", "--no-trace"]).is_ok());
+        assert!(parse(&["user", "--cancel-after", "30001"]).is_err());
+    }
+
+    #[test]
+    fn refusal_reason_is_visible_but_terminal_controls_are_escaped() {
+        let mut refused = trial(Some(1_000), "refused");
+        refused.reason = Some("no face\n\x1b[2J".into());
+        let report = render_report(&[refused], &[]);
+        assert!(report.contains("no face\\n\\u{1b}[2J"));
+        assert!(!report.contains('\x1b'));
+    }
 
     fn trial(wall_us: Option<u64>, outcome: &str) -> TrialTiming {
         TrialTiming {
             wall_us,
             cancelled: outcome == "cancelled",
             outcome: outcome.to_owned(),
+            reason: None,
         }
     }
 

--- a/crates/irlume-daemon/examples/daemon_timing.rs
+++ b/crates/irlume-daemon/examples/daemon_timing.rs
@@ -1,0 +1,454 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright the irlume contributors.
+
+//! One live daemon authentication trial set, with boundary attribution.
+//!
+//! This connects to the RUNNING daemon over its socket and sends real
+//! `Authenticate` requests; with a diagnostic trace subscription it also
+//! prints the daemon-side stage boundaries for those requests. It performs
+//! no inference itself. See --help and docs/research/benchmark-harness.md.
+//! Engine stages can overlap or nest; this tool never sums them.
+
+use irlume_common::diagnostics::{
+    TraceEventKind, TraceRecord, TraceStage, TraceValidator, CURRENT_TRACE_SCHEMA_VERSION,
+    MAX_TRACE_LINE_BYTES,
+};
+use irlume_common::{Request, Response};
+use std::io::{BufReader, Read, Write as _};
+use std::time::{Duration, Instant};
+
+const HELP: &str = "Usage: daemon_timing <user> [--service NAME|none] [--trials N] [--cancel-after MS] [--no-trace]
+Sends real Authenticate requests to the running daemon and measures request-to-reply.
+With a trace subscription (root; default on unless --no-trace) it also prints the
+daemon-side stage boundaries (schema 3). Refused and cancelled trials are labeled,
+never pooled with grants. Stage intervals may overlap or nest and are never summed.
+Unmeasured boundaries (worker reply to socket write, PAM stack, desktop unlock) are
+printed explicitly. Attended, authorized use only: cameras may open.";
+const TRACE_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
+
+struct Options {
+    user: String,
+    service: Option<String>,
+    trials: u32,
+    cancel_after_ms: Option<u64>,
+    trace: bool,
+}
+
+impl Options {
+    fn parse(args: &[String]) -> Result<Self, String> {
+        let mut positional = Vec::new();
+        let mut service = Some("kde-fingerprint".to_owned());
+        let mut trials = 1_u32;
+        let mut cancel_after_ms = None;
+        let mut trace = true;
+        let mut args = args.iter();
+        while let Some(arg) = args.next() {
+            match arg.as_str() {
+                "--service" => {
+                    let value = args.next().ok_or("--service requires a value")?;
+                    service = (value != "none").then(|| value.clone());
+                }
+                "--trials" => {
+                    let value = args.next().ok_or("--trials requires a value")?;
+                    trials = value
+                        .parse()
+                        .map_err(|_| format!("invalid trials: {value}"))?;
+                    if trials == 0 || trials > 100 {
+                        return Err("trials must be 1..=100".into());
+                    }
+                }
+                "--cancel-after" => {
+                    let value = args.next().ok_or("--cancel-after requires a value")?;
+                    cancel_after_ms = Some(
+                        value
+                            .parse()
+                            .map_err(|_| format!("invalid cancel-after: {value}"))?,
+                    );
+                }
+                "--no-trace" => trace = false,
+                value if value.starts_with('-') => return Err(format!("unknown option: {value}")),
+                _ => positional.push(arg.clone()),
+            }
+        }
+        if positional.len() != 1 {
+            return Err(HELP.into());
+        }
+        Ok(Self {
+            user: positional.remove(0),
+            service,
+            trials,
+            cancel_after_ms,
+            trace,
+        })
+    }
+}
+
+/// One client-measured trial. `wall_us` is the harness's own clock around
+/// request-to-reply; it shares no origin with daemon monotonic timestamps.
+struct TrialTiming {
+    wall_us: Option<u64>,
+    cancelled: bool,
+    outcome: String,
+}
+
+fn outcome_label(response: &Response) -> &'static str {
+    match response {
+        Response::AuthResult { granted: true, .. } => "granted",
+        Response::AuthResult { granted: false, .. } => "refused",
+        Response::Error(_) => "error",
+        _ => "unexpected",
+    }
+}
+
+/// Nearest-rank median (ceil(n/2), ranks from one), the same convention the
+/// benchmark examples use, so an even sample count reports an observed value
+/// rather than an average of two.
+fn median(values: &[u64]) -> Option<u64> {
+    if values.is_empty() {
+        return None;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_unstable();
+    let rank = sorted.len().div_ceil(2);
+    Some(sorted[rank - 1])
+}
+
+/// The report separates the two clock domains and always names the
+/// unmeasured boundaries. Stage intervals are listed, never summed.
+fn render_report(trials: &[TrialTiming], stages: &[(TraceStage, u64)]) -> String {
+    let mut out = String::new();
+    out.push_str(
+        "== request-to-reply (client clock; includes daemon ingress, queue, engine, reply) ==\n",
+    );
+    for (index, trial) in trials.iter().enumerate() {
+        match trial.wall_us {
+            Some(wall) => out.push_str(&format!(
+                "trial {}: {} {:.3} ms\n",
+                index + 1,
+                trial.outcome,
+                wall as f64 / 1000.0
+            )),
+            None => out.push_str(&format!(
+                "trial {}: {} (no reply interval: {})\n",
+                index + 1,
+                trial.outcome,
+                if trial.cancelled {
+                    "cancelled by this harness"
+                } else {
+                    "connection ended without a reply"
+                }
+            )),
+        }
+    }
+    let granted: Vec<u64> = trials
+        .iter()
+        .filter(|t| t.outcome == "granted")
+        .filter_map(|t| t.wall_us)
+        .collect();
+    let refused: Vec<u64> = trials
+        .iter()
+        .filter(|t| t.outcome == "refused")
+        .filter_map(|t| t.wall_us)
+        .collect();
+    if let Some(m) = median(&granted) {
+        out.push_str(&format!(
+            "granted median: {:.3} ms ({} samples)\n",
+            m as f64 / 1000.0,
+            granted.len()
+        ));
+    }
+    if let Some(m) = median(&refused) {
+        out.push_str(&format!(
+            "refused median: {:.3} ms ({} samples; never pooled with grants)\n",
+            m as f64 / 1000.0,
+            refused.len()
+        ));
+    }
+    out.push_str("== daemon stage boundaries (daemon monotonic clock; may overlap or nest) ==\n");
+    if stages.is_empty() {
+        out.push_str("  (no stage records; subscribe without --no-trace and run as root)\n");
+    }
+    for (stage, elapsed_us) in stages {
+        out.push_str(&format!(
+            "  {stage:?}: {:.3} ms\n",
+            *elapsed_us as f64 / 1000.0
+        ));
+    }
+    out.push_str("stages are attribution labels, not addends; do not sum them\n");
+    out.push_str("== unmeasured boundaries ==\n");
+    out.push_str("  worker reply to socket write: unmeasured\n");
+    out.push_str("  PAM stack around the daemon calls: unmeasured\n");
+    out.push_str(
+        "  desktop/greeter unlock completion: unmeasured (no trustworthy signal established)\n",
+    );
+    out
+}
+
+fn read_bounded_line<R: Read>(reader: &mut R, limit: usize) -> std::io::Result<Option<Vec<u8>>> {
+    let mut line = Vec::new();
+    let mut byte = [0_u8; 1];
+    loop {
+        match reader.read(&mut byte) {
+            Ok(0) => {
+                return if line.is_empty() {
+                    Ok(None)
+                } else {
+                    Err(std::io::Error::other("truncated line"))
+                };
+            }
+            Ok(_) if byte[0] == b'\n' => {
+                if line.len() > limit {
+                    return Err(std::io::Error::other("line too long"));
+                }
+                return Ok(Some(line));
+            }
+            Ok(_) => {
+                line.push(byte[0]);
+                if line.len() > limit {
+                    return Err(std::io::Error::other("line too long"));
+                }
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+struct TraceConnection {
+    reader: BufReader<std::os::unix::net::UnixStream>,
+    validator: TraceValidator,
+}
+
+impl TraceConnection {
+    fn subscribe(duration_ms: u64) -> Result<Self, String> {
+        let timeout = Duration::from_secs(15);
+        let mut stream = irlume_common::client::connect_stream(timeout)
+            .map_err(|error| format!("connect: {error}"))?;
+        let mut request = serde_json::to_vec(&Request::TraceSubscribe {
+            duration_ms,
+            trace_schema: Some(CURRENT_TRACE_SCHEMA_VERSION),
+        })
+        .map_err(|error| format!("encode request: {error}"))?;
+        request.push(b'\n');
+        stream
+            .write_all(&request)
+            .and_then(|()| stream.flush())
+            .map_err(|error| format!("send request: {error}"))?;
+        let mut reader = BufReader::new(stream);
+        let header = read_bounded_line(&mut reader, MAX_TRACE_LINE_BYTES)
+            .map_err(|error| format!("read header: {error}"))?
+            .ok_or_else(|| "daemon closed before accepting the trace".to_owned())?;
+        let limits = match serde_json::from_slice::<Response>(&header)
+            .map_err(|error| format!("invalid daemon response: {error}"))?
+        {
+            Response::TraceAccepted { limits } => limits,
+            Response::Error(message) => return Err(format!("trace refused: {message}")),
+            other => return Err(format!("unexpected daemon response: {other:?}")),
+        };
+        let validator = TraceValidator::new(limits)
+            .map_err(|error| format!("invalid daemon limits: {error}"))?;
+        Ok(Self { reader, validator })
+    }
+
+    /// Drain until the terminal record (or a timeout), returning the stage
+    /// boundaries of every operation observed.
+    fn drain(mut self) -> Result<Vec<(TraceStage, u64)>, String> {
+        let mut stages = Vec::new();
+        let deadline = Instant::now() + TRACE_DRAIN_TIMEOUT;
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return Err("trace did not finish within the drain timeout".into());
+            }
+            self.reader
+                .get_ref()
+                .set_read_timeout(Some(remaining))
+                .map_err(|error| format!("set timeout: {error}"))?;
+            let line = match read_bounded_line(&mut self.reader, MAX_TRACE_LINE_BYTES) {
+                Ok(Some(line)) => line,
+                Ok(None) => {
+                    return Err("trace ended without a terminal record".into());
+                }
+                Err(e)
+                    if matches!(
+                        e.kind(),
+                        std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                    ) =>
+                {
+                    return Err("trace did not finish within the drain timeout".into());
+                }
+                Err(e) => return Err(format!("read trace: {e}")),
+            };
+            let record: TraceRecord = self
+                .validator
+                .push_line(&line)
+                .map_err(|error| format!("invalid trace record: {error}"))?;
+            if let TraceEventKind::StageTiming { stage, elapsed_us } = record.event {
+                stages.push((stage, elapsed_us));
+            }
+            if record.terminal {
+                return Ok(stages);
+            }
+        }
+    }
+}
+
+fn one_trial(options: &Options) -> Result<TrialTiming, String> {
+    let mut stream = irlume_common::client::connect_stream(Duration::from_secs(15))
+        .map_err(|error| format!("connect: {error}"))?;
+    let request = serde_json::to_vec(&Request::Authenticate {
+        user: options.user.clone(),
+        service: options.service.clone(),
+        structured_errors: true,
+        intent_confirmation: None,
+    })
+    .map_err(|error| format!("encode request: {error}"))?;
+    let cancel = options.cancel_after_ms.map(Duration::from_millis);
+    let started = Instant::now();
+    stream
+        .write_all(&request)
+        .and_then(|()| stream.flush())
+        .map_err(|error| format!("send request: {error}"))?;
+    // A cancelled trial closes its own socket mid-request: the daemon learns
+    // the client left and stops the capture (ClientLink), which is the
+    // production cancellation path this harness observes.
+    if let Some(delay) = cancel {
+        std::thread::sleep(delay);
+        let _ = stream.shutdown(std::net::Shutdown::Both);
+    }
+    let mut reader = BufReader::new(stream);
+    let line = read_bounded_line(&mut reader, MAX_TRACE_LINE_BYTES);
+    let elapsed = started.elapsed();
+    match line {
+        Ok(Some(line)) => {
+            let response = serde_json::from_slice::<Response>(&line)
+                .map_err(|error| format!("invalid response: {error}"))?;
+            Ok(TrialTiming {
+                wall_us: Some(u64::try_from(elapsed.as_micros()).unwrap_or(u64::MAX)),
+                cancelled: false,
+                outcome: outcome_label(&response).to_owned(),
+            })
+        }
+        Err(e) => Err(format!("read reply: {e}")),
+        Ok(None) => Ok(TrialTiming {
+            wall_us: None,
+            cancelled: cancel.is_some(),
+            outcome: if cancel.is_some() {
+                "cancelled"
+            } else {
+                "no-reply"
+            }
+            .to_owned(),
+        }),
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<_> = std::env::args().skip(1).collect();
+    if args.iter().any(|arg| arg == "--help" || arg == "-h") {
+        println!("{HELP}");
+        return Ok(());
+    }
+    let options = Options::parse(&args)?;
+    eprintln!(
+        "daemon_timing: user={} service={:?} trials={} cancel_after={:?} trace={}",
+        options.user, options.service, options.trials, options.cancel_after_ms, options.trace
+    );
+    eprintln!(
+        "attended, authorized measurement only; cameras may open; refused outcomes are labeled"
+    );
+    let trace = match if options.trace {
+        Some(TraceConnection::subscribe(60_000))
+    } else {
+        None
+    } {
+        Some(Ok(connection)) => Some(connection),
+        Some(Err(message)) => {
+            eprintln!("daemon_timing: continuing without a trace ({message})");
+            None
+        }
+        None => None,
+    };
+    let mut trials = Vec::new();
+    for _ in 0..options.trials {
+        trials.push(one_trial(&options)?);
+    }
+    let stages = match trace {
+        Some(connection) => connection.drain()?,
+        None => Vec::new(),
+    };
+    print!("{}", render_report(&trials, &stages));
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn trial(wall_us: Option<u64>, outcome: &str) -> TrialTiming {
+        TrialTiming {
+            wall_us,
+            cancelled: outcome == "cancelled",
+            outcome: outcome.to_owned(),
+        }
+    }
+
+    #[test]
+    fn options_reject_unknown_flags_and_bad_counts() {
+        assert!(Options::parse(&["user".into()]).is_ok());
+        assert!(Options::parse(&["--surprise".into(), "user".into()]).is_err());
+        assert!(Options::parse(&[]).is_err());
+        assert!(Options::parse(&["user".into(), "--trials".into(), "0".into()]).is_err());
+        assert!(Options::parse(&["user".into(), "--trials".into(), "101".into()]).is_err());
+        assert!(Options::parse(&["user".into(), "--cancel-after".into(), "x".into()]).is_err());
+        let options = Options::parse(&["u".into(), "--service".into(), "none".into()]).unwrap();
+        assert_eq!(options.service, None);
+        assert_eq!(options.trials, 1);
+    }
+
+    #[test]
+    fn the_report_always_names_the_unmeasured_boundaries() {
+        let report = render_report(&[trial(Some(1_000), "granted")], &[]);
+        assert!(report.contains("worker reply to socket write: unmeasured"));
+        assert!(report.contains("PAM stack around the daemon calls: unmeasured"));
+        assert!(report.contains("desktop/greeter unlock completion: unmeasured"));
+    }
+
+    #[test]
+    fn stages_are_listed_but_never_summed() {
+        let stages = vec![
+            (TraceStage::QueueWait, 1_500),
+            (TraceStage::EngineAuthenticate, 3_000_000),
+        ];
+        let report = render_report(&[trial(Some(3_100_000), "granted")], &stages);
+        assert!(report.contains("QueueWait: 1.500 ms"));
+        assert!(report.contains("EngineAuthenticate: 3000.000 ms"));
+        assert!(report.contains("do not sum them"));
+        assert!(!report.contains("total"));
+    }
+
+    #[test]
+    fn cancelled_and_refused_trials_are_labeled_not_pooled() {
+        let trials = vec![
+            trial(Some(2_000_000), "granted"),
+            trial(Some(4_000_000), "granted"),
+            trial(Some(9_000_000), "refused"),
+            trial(None, "cancelled"),
+        ];
+        let report = render_report(&trials, &[]);
+        assert!(report.contains("trial 4: cancelled (no reply interval"));
+        assert!(
+            report.contains("refused median: 9000.000 ms (1 samples; never pooled with grants)")
+        );
+        assert!(report.contains("granted median: 2000.000 ms (2 samples)"));
+    }
+
+    #[test]
+    fn median_handles_odd_even_and_empty_inputs() {
+        assert_eq!(median(&[]), None);
+        assert_eq!(median(&[7]), Some(7));
+        assert_eq!(median(&[3, 1, 2]), Some(2));
+        // Nearest rank: an observed value, never an average of two.
+        assert_eq!(median(&[4, 1, 3, 2]), Some(2));
+    }
+}

--- a/crates/irlume-daemon/src/diagnostics.rs
+++ b/crates/irlume-daemon/src/diagnostics.rs
@@ -8,6 +8,7 @@ use irlume_common::diagnostics::{
     SanitizedCameraContext, ShareSafeEvent, ShareSafeEventKind, SupportSnapshot, TraceEventKind,
     TraceLimits, TraceRecord, TraceWarning, CURRENT_TRACE_SCHEMA_VERSION,
     LEGACY_TRACE_SCHEMA_VERSION, MAX_HISTORY_MS, MAX_SHARE_SAFE_EVENTS, MAX_TRACE_LINE_BYTES,
+    V2_TRACE_SCHEMA_VERSION,
 };
 use sha2::{Digest as _, Sha256};
 use std::collections::VecDeque;
@@ -220,7 +221,7 @@ impl DiagnosticState {
         let trace_schema = trace_schema.unwrap_or(LEGACY_TRACE_SCHEMA_VERSION);
         if !matches!(
             trace_schema,
-            LEGACY_TRACE_SCHEMA_VERSION | CURRENT_TRACE_SCHEMA_VERSION
+            LEGACY_TRACE_SCHEMA_VERSION | V2_TRACE_SCHEMA_VERSION | CURRENT_TRACE_SCHEMA_VERSION
         ) {
             return Err(TraceSubscribeError::UnsupportedSchema);
         }
@@ -787,13 +788,13 @@ mod tests {
     #[test]
     fn trace_negotiation_defaults_to_legacy_and_rejects_unknown_versions_without_ownership() {
         let state = DiagnosticState::default();
-        for unsupported in [0, 3, u32::MAX] {
+        for unsupported in [0, 4, u32::MAX] {
             assert!(matches!(
                 state.subscribe_trace(0, 60_000, Some(unsupported)),
                 Err(TraceSubscribeError::UnsupportedSchema)
             ));
         }
-        for (requested, expected) in [(None, 1), (Some(1), 1), (Some(2), 2)] {
+        for (requested, expected) in [(None, 1), (Some(1), 1), (Some(2), 2), (Some(3), 3)] {
             let subscription = state.subscribe_trace(0, 60_000, requested).unwrap();
             let mut records: Vec<_> = subscription.receiver.try_iter().collect();
             records.extend(subscription.finish(CategoricalOutcome::Completed));

--- a/crates/irlume-daemon/src/main.rs
+++ b/crates/irlume-daemon/src/main.rs
@@ -951,7 +951,10 @@ fn main() {
                                 reply,
                                 link,
                                 scope,
+                                enqueued_at,
                             } = job.payload;
+                            // Queue-wait boundary: submission to this take.
+                            note_queue_wait(&scope, enqueued_at);
                             // The client left while this sat in the queue: never open
                             // the camera for an answer nobody is waiting for. Release
                             // the slot first, exactly as the normal path does, so the
@@ -1514,6 +1517,55 @@ struct WorkerReply {
     completion: Option<FaceCompletion>,
 }
 
+/// Report one daemon-side timing boundary as a closed-vocabulary trace
+/// event on the request's operation scope. Bound durations saturate rather
+/// than wrap.
+fn emit_stage_timing(
+    diagnostics: &dyn irlume_common::diagnostics::DiagnosticSink,
+    stage: irlume_common::diagnostics::TraceStage,
+    started: std::time::Instant,
+) {
+    diagnostics.emit_trace(irlume_common::diagnostics::TraceEventKind::StageTiming {
+        stage,
+        elapsed_us: u64::try_from(started.elapsed().as_micros()).unwrap_or(u64::MAX),
+    });
+}
+
+/// The queue-wait boundary: from the connection thread's submission to the
+/// worker taking the job. Emitted by the worker loop from the submission
+/// instant carried on the queued job.
+fn note_queue_wait(scope: &diagnostics::OperationScope, enqueued_at: std::time::Instant) {
+    use irlume_common::diagnostics::TraceStage;
+    emit_stage_timing(scope, TraceStage::QueueWait, enqueued_at);
+}
+
+/// Emits a stage boundary when the guarded scope exits, so every return
+/// path (including early refusals) reports the same completed interval.
+struct StageExitTimer<'a> {
+    diagnostics: &'a dyn irlume_common::diagnostics::DiagnosticSink,
+    stage: irlume_common::diagnostics::TraceStage,
+    started: std::time::Instant,
+}
+
+impl<'a> StageExitTimer<'a> {
+    fn new(
+        diagnostics: &'a dyn irlume_common::diagnostics::DiagnosticSink,
+        stage: irlume_common::diagnostics::TraceStage,
+    ) -> Self {
+        Self {
+            diagnostics,
+            stage,
+            started: std::time::Instant::now(),
+        }
+    }
+}
+
+impl Drop for StageExitTimer<'_> {
+    fn drop(&mut self) {
+        emit_stage_timing(self.diagnostics, self.stage, self.started);
+    }
+}
+
 impl std::fmt::Debug for WorkerReply {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("WorkerReply")
@@ -1583,6 +1635,9 @@ struct Queued {
     /// Lets the worker learn that this request's client has gone away.
     link: std::sync::Arc<ClientLink>,
     scope: diagnostics::OperationScope,
+    /// Submission instant, from which the worker measures the queue-wait
+    /// boundary. Set immediately before `arbiter.submit`.
+    enqueued_at: std::time::Instant,
 }
 
 /// The handshake between one connection thread and the camera worker, so work a
@@ -2828,6 +2883,9 @@ fn serve_peer(
 ) -> std::io::Result<()> {
     stream.set_read_timeout(Some(std::time::Duration::from_secs(15)))?;
     stream.set_write_timeout(Some(std::time::Duration::from_secs(15)))?;
+    // Ingress boundary origin: the connection thread's work from here to the
+    // queued scope (read wait, parse, posture, authorization).
+    let ingress_started = std::time::Instant::now();
     match read_request(&stream)? {
         ReadOutcome::Closed => Ok(()),
         ReadOutcome::Bad => respond(stream, &Response::Error("bad request".into())),
@@ -2930,6 +2988,15 @@ fn serve_peer(
                     (None, None)
                 };
             let scope = diagnostic_state.begin(diagnostic_operation_class(&req));
+            // The ingress boundary covers the connection thread's work up to
+            // this scope: the read deadline wait, request parse, posture gate
+            // and authorization. Measured from before the read (the scope
+            // does not exist yet then) and reported inside the operation.
+            emit_stage_timing(
+                &scope,
+                irlume_common::diagnostics::TraceStage::IngressParse,
+                ingress_started,
+            );
             let (reply, answer) = std::sync::mpsc::channel();
             let activity = live::request_kind(&req).map(|(kind, changes_state)| {
                 diagnostic_state
@@ -2949,6 +3016,7 @@ fn serve_peer(
                 reply,
                 link: std::sync::Arc::clone(&link),
                 scope: scope.clone(),
+                enqueued_at: std::time::Instant::now(),
             };
             if let Err(refusal) = arbiter.submit(class, peer.uid, queued) {
                 // Refused, not queued: answer now so the client can retry rather
@@ -4951,14 +5019,22 @@ fn dispatch_scoped_session_inner(
             };
             let convenience = tier == irlume_core::biopolicy::Tier::Convenience;
             let t = std::time::Instant::now();
-            match engine.authenticate_for_in_window_with_policy(
+            let auth_result = engine.authenticate_for_in_window_with_policy(
                 &user,
                 service.as_deref(),
                 irlume_auth::AuthenticationPurpose::for_service(service.as_deref()),
                 window,
                 sensor_policy,
                 scope,
-            ) {
+            );
+            // Engine-call boundary: the daemon's wall time around the whole
+            // engine authentication (policy refusals above never reach it).
+            emit_stage_timing(
+                scope,
+                irlume_common::diagnostics::TraceStage::EngineAuthenticate,
+                t,
+            );
+            match auth_result {
                 Ok(o) => bounded_face_response(
                     o.granted,
                     || engine.check_authentication_completion(window),
@@ -5363,6 +5439,14 @@ fn dispatch_scoped_session_inner(
             }
         }
         Request::UnsealPassword { user, service } => {
+            // Credential-release boundary: the arm's whole daemon-side
+            // interval (policy gates, face authentication, release), on every
+            // exit including the refusals below. Nests the engine-call
+            // boundary when the request reaches the engine.
+            let _credential = StageExitTimer::new(
+                scope,
+                irlume_common::diagnostics::TraceStage::CredentialUnseal,
+            );
             // The sealed LOGIN password is released ONLY to a root peer (the
             // table's RootOnly), and the refusal explains itself in the journal
             // through `note_unseal_password_refusal`, which is where the
@@ -5448,7 +5532,15 @@ fn dispatch_scoped_session_inner(
             user,
             service,
             have_password,
-        } => unseal_keyring(&user, service.as_deref(), have_password, peer),
+        } => {
+            // Credential-release boundary, same vocabulary as the password
+            // unseal: the request's whole daemon-side interval, every exit.
+            let _credential = StageExitTimer::new(
+                scope,
+                irlume_common::diagnostics::TraceStage::CredentialUnseal,
+            );
+            unseal_keyring(&user, service.as_deref(), have_password, peer)
+        }
         Request::ForgetPassword { user } => match irlume_core::keyring::forget_password(&user) {
             Ok(()) => Response::PasswordForgotten,
             Err(e) => Response::Error(e.to_string()),
@@ -6030,14 +6122,21 @@ fn do_unseal_password_scoped(
         Ok(attempt) => attempt,
         Err(reason) => return retry_unseal_refusal(reason),
     };
-    let outcome = match engine.authenticate_for_in_window_with_policy(
+    let engine_result = engine.authenticate_for_in_window_with_policy(
         user,
         service,
         credential_release_purpose(),
         window,
         sensor_policy,
         diagnostics,
-    ) {
+    );
+    // Engine-call boundary, same closed vocabulary as the Authenticate arm.
+    emit_stage_timing(
+        diagnostics,
+        irlume_common::diagnostics::TraceStage::EngineAuthenticate,
+        t,
+    );
+    let outcome = match engine_result {
         Ok(o) => o,
         Err(e) => {
             // A PCR-drift here is the ENROLLED-TEMPLATE key failing to unseal (it
@@ -8538,6 +8637,7 @@ mod tests {
                     link: std::sync::Arc::new(ClientLink::default()),
                     scope: diagnostic_state
                         .begin(irlume_common::diagnostics::OperationClass::Authentication),
+                    enqueued_at: std::time::Instant::now(),
                 },
             )
             .unwrap();
@@ -8957,6 +9057,7 @@ mod tests {
                         reply,
                         link,
                         scope,
+                        enqueued_at: _,
                     } = job.payload;
                     assert!(link.claim());
                     let response = dispatch_scoped(req, &peer, &mut engine, &scope, authorization);
@@ -9860,6 +9961,7 @@ mod tests {
                     link: std::sync::Arc::new(ClientLink::default()),
                     scope: diagnostic_state
                         .begin(irlume_common::diagnostics::OperationClass::Authentication),
+                    enqueued_at: std::time::Instant::now(),
                 },
             )
             .unwrap();
@@ -10952,6 +11054,213 @@ mod tests {
         ) {
             Response::Error(msg) => assert_eq!(msg, "not authorized to authenticate 'carol'"),
             other => panic!("foreign peer must be refused, got {other:?}"),
+        }
+    }
+
+    /// The daemon-side timing boundaries are closed-vocabulary trace events
+    /// on the request's own operation scope, so an end-to-end attribution can
+    /// label ingress, queue, engine and credential intervals without reading
+    /// the journal.
+    mod daemon_stage_boundaries {
+        use super::*;
+        use irlume_common::diagnostics::{
+            TraceEventKind, TraceStage, CURRENT_TRACE_SCHEMA_VERSION,
+        };
+
+        fn stage_records(subscription: &diagnostics::TraceSubscription) -> Vec<(TraceStage, u64)> {
+            let mut records = Vec::new();
+            while let Ok(record) = subscription.recv_timeout(std::time::Duration::from_millis(200))
+            {
+                records.push(record);
+            }
+            records
+                .into_iter()
+                .filter_map(|record| match record.event {
+                    TraceEventKind::StageTiming { stage, elapsed_us } => Some((stage, elapsed_us)),
+                    _ => None,
+                })
+                .collect()
+        }
+
+        #[test]
+        fn authenticate_arm_reports_the_engine_call_boundary() {
+            let _g = env_lock();
+            let mut e = engine();
+            let sb = sandbox("auth-stage-trace");
+            let _ = &sb;
+            let state = diagnostics::DiagnosticState::default();
+            let subscription = state
+                .subscribe_trace(0, 60_000, Some(CURRENT_TRACE_SCHEMA_VERSION))
+                .unwrap();
+            let scope = state.begin(irlume_common::diagnostics::OperationClass::Authentication);
+            // A real local account, so the retry-throttle state is
+            // readable; it is not enrolled in the sandbox, so the engine
+            // call itself denies and still exercises the boundary.
+            // SAFETY: getuid reads only this process's own real uid and
+            // is specified as always succeeding.
+            let local_user =
+                users::name_for_uid(unsafe { libc::getuid() }).unwrap_or_else(|| "root".into());
+            let reply = dispatch_scoped_session(
+                Request::Authenticate {
+                    structured_errors: false,
+                    user: local_user,
+                    // A screen-unlock service so the convenience-tier engine
+                    // still reaches the engine call. This service class takes
+                    // no intent attestation; sending one would be refused by
+                    // the confirmation gate.
+                    service: Some("kde-fingerprint".into()),
+                    intent_confirmation: None,
+                },
+                &peer(0),
+                &mut e,
+                &scope,
+                None,
+                None,
+                None,
+            );
+            assert!(
+                matches!(reply.response, Response::AuthResult { granted: false, .. }),
+                "{:?}",
+                reply.response
+            );
+            let stages = stage_records(&subscription);
+            assert!(
+                stages.iter().any(
+                    |(stage, elapsed)| *stage == TraceStage::EngineAuthenticate && *elapsed > 0
+                ),
+                "engine call boundary missing: {stages:?}"
+            );
+        }
+
+        #[test]
+        fn unseal_password_reports_the_credential_unseal_boundary() {
+            let _g = env_lock();
+            let mut e = engine();
+            let sb = sandbox("unseal-stage-trace");
+            let _ = &sb;
+            let state = diagnostics::DiagnosticState::default();
+            let subscription = state
+                .subscribe_trace(0, 60_000, Some(CURRENT_TRACE_SCHEMA_VERSION))
+                .unwrap();
+            let scope = state.begin(irlume_common::diagnostics::OperationClass::Authentication);
+            let reply = dispatch_scoped_session(
+                Request::UnsealPassword {
+                    user: "carol".into(),
+                    service: None,
+                },
+                &peer(0),
+                &mut e,
+                &scope,
+                None,
+                None,
+                None,
+            );
+            // carol has no sealed password: the request exits early, and the
+            // boundary must still report the completed (refused) interval.
+            assert!(
+                matches!(reply.response, Response::UnsealUnavailable { .. }),
+                "{:?}",
+                reply.response
+            );
+            let stages = stage_records(&subscription);
+            assert!(
+                stages
+                    .iter()
+                    .any(|(stage, elapsed)| *stage == TraceStage::CredentialUnseal && *elapsed > 0),
+                "credential boundary missing: {stages:?}"
+            );
+        }
+
+        #[test]
+        fn queued_request_reports_the_ingress_parse_boundary() {
+            use std::io::{BufRead as _, BufReader, Write as _};
+            let arbiter = arbiter::Arbiter::<Queued>::new();
+            let ready = std::sync::atomic::AtomicBool::new(true);
+            let state = diagnostics::DiagnosticState::default();
+            let subscription = state
+                .subscribe_trace(0, 60_000, Some(CURRENT_TRACE_SCHEMA_VERSION))
+                .unwrap();
+            // A stand-in worker that answers from the queue: this test pins
+            // the CONNECTION-side ingress boundary, which is emitted before
+            // submission, so the answer content is irrelevant.
+            let resp = std::thread::scope(|scope| {
+                let arb = &arbiter;
+                let worker = scope.spawn(move || {
+                    while let Some(job) = arb.take() {
+                        let job_class = job.class;
+                        let job_uid = job.uid;
+                        let Queued {
+                            reply,
+                            scope: job_scope,
+                            ..
+                        } = job.payload;
+                        let resp = WorkerReply {
+                            response: Response::Error("stand-in worker".into()),
+                            completion: None,
+                        };
+                        job_scope.finish(irlume_common::diagnostics::CategoricalOutcome::Failed);
+                        arb.finish(job_class, job_uid);
+                        let _ = reply.send(resp);
+                    }
+                });
+                let resp = with_serve_as_peer_and_diagnostics(
+                    &arbiter,
+                    &ready,
+                    &state,
+                    Peer {
+                        uid: 0,
+                        gid: 0,
+                        pid: 0,
+                    },
+                    |client: &UnixStream| {
+                        let mut client = client;
+                        client
+                            .write_all(
+                                b"{\"Authenticate\":{\"user\":\"carol\",\"service\":null,\"structured_errors\":false}}\n",
+                            )
+                            .unwrap();
+                        let mut line = String::new();
+                        client
+                            .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+                            .unwrap();
+                        BufReader::new(client)
+                            .read_line(&mut line)
+                            .expect("stand-in worker answers immediately");
+                        serde_json::from_str::<Response>(line.trim()).unwrap()
+                    },
+                );
+                arbiter.close();
+                worker.join().unwrap();
+                resp
+            });
+            assert!(matches!(resp, Response::Error(_)), "{resp:?}");
+            let stages = stage_records(&subscription);
+            assert!(
+                stages
+                    .iter()
+                    .any(|(stage, elapsed)| *stage == TraceStage::IngressParse && *elapsed > 0),
+                "ingress boundary missing: {stages:?}"
+            );
+        }
+
+        /// The real worker loop must measure queue wait from the submission
+        /// instant carried on the queued job. The loop itself needs a full
+        /// engine, so the wiring is pinned on source like other structural
+        /// guarantees, while the emission behavior is covered above.
+        #[test]
+        fn worker_loop_measures_queue_wait_from_submission() {
+            let src = include_str!("main.rs");
+            let call = concat!("note_queue_wait", "(&scope, enqueued_at)");
+            assert_eq!(
+                src.matches(call).count(),
+                1,
+                "exactly the worker loop reports the queue-wait boundary from \
+                 the job's submission instant; that call moved or vanished"
+            );
+            assert!(
+                src.contains(concat!("enqueued_at: std::time::Instant", "::now()")),
+                "the queued job must carry its submission instant"
+            );
         }
     }
 

--- a/crates/irlume-liveness/src/lib.rs
+++ b/crates/irlume-liveness/src/lib.rs
@@ -338,6 +338,24 @@ pub fn rgb_moire_max() -> f32 {
     env_override("IRLUME_RGB_MOIRE_MAX", RGB_MOIRE_MAX, |v| v > 0.0)
 }
 
+/// Typed origin of a non-Live gate decision, produced where the refusal is
+/// produced, so downstream routing (retry eligibility, runtime availability)
+/// branches on a value instead of pinning reason prefixes. `Other` covers
+/// every refusal without special routing and every Live result, where the
+/// field carries no information.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum DenyCause {
+    #[default]
+    Other,
+    /// RGB saw a face the IR stream did not: at once the retryable settling
+    /// transient of a genuine user and the persistent signature of a
+    /// screen/print, which never grows an IR face.
+    NoIrFace,
+    /// The negotiated IR format defines no sensor ceiling, so exposure
+    /// cannot be checked (#358). A property of the camera, not the frame.
+    ExposureUnmeasurable,
+}
+
 /// Per-cue evidence, surfaced for logging/self-test (never raw image data).
 #[derive(Debug, Default, Clone)]
 pub struct Cues {
@@ -384,6 +402,9 @@ pub struct Cues {
     /// negotiated IR format defines no sensor ceiling, so nothing was read and
     /// `ir_exposure_ok` carries no information.
     pub ir_exposure_measured: bool,
+    /// Typed origin of this decision; see [`DenyCause`]. `Other` unless the
+    /// evaluator named a cause where it produced its refusal.
+    pub deny_cause: DenyCause,
 }
 
 /// IR face region must be at least this bright (0..255). A lit live face ran ~83
@@ -565,6 +586,7 @@ impl LivenessGate {
         // Core anti-screen cue: a real face reflects the IR emitter and is
         // detectable in IR; a phone/print does not.
         let Some(ir) = s.ir_face.filter(|f| f.score >= MIN_FACE_SCORE) else {
+            cues.deny_cause = DenyCause::NoIrFace;
             return (
                 Verdict::Spoof,
                 cues,
@@ -717,6 +739,7 @@ impl LivenessGate {
     pub fn evaluate_ir_only(&self, s: &Signals) -> (Verdict, Cues, String) {
         let mut cues = Cues::default();
         if s.ir_face.filter(|f| f.score >= MIN_FACE_SCORE).is_none() {
+            cues.deny_cause = DenyCause::NoIrFace;
             return (Verdict::Uncertain, cues, "no face in IR".into());
         }
         cues.face_in_ir = true;
@@ -867,6 +890,7 @@ fn exposure_refusal(s: &Signals, cues: &mut Cues) -> Option<(Verdict, String)> {
     cues.ir_exposure_measured = s.ir_ceiling_known;
     if !s.ir_ceiling_known {
         cues.ir_exposure_ok = false;
+        cues.deny_cause = DenyCause::ExposureUnmeasurable;
         return Some((
             Verdict::Uncertain,
             "IR exposure unmeasurable: this camera's IR format defines no sensor \
@@ -1212,6 +1236,44 @@ mod tests {
             ir_persistent_saturated_frac: None,
             ..Default::default() // frontal pose
         }
+    }
+
+    /// The typed cause is produced at the refusal origin, not re-derived from
+    /// wording downstream: each arm below pins the cause for one producer, so
+    /// irlume-auth can branch on a value instead of a reason prefix.
+    #[test]
+    fn deny_causes_are_typed_at_their_origin() {
+        let gate = LivenessGate::new();
+        // RGB present, IR absent: the retryable cross-spectrum transient and
+        // the persistent screen/print signature at once.
+        let mut s = live_signals();
+        s.ir_face = None;
+        let (verdict, cues, reason) = gate.evaluate(&s);
+        assert_eq!(verdict, Verdict::Spoof, "{reason}");
+        assert_eq!(cues.deny_cause, DenyCause::NoIrFace);
+        // The dark evaluator's own no-face arm carries the same cause; its
+        // verdict stays Uncertain and classification stays with the verdict.
+        let (verdict, cues, reason) = gate.evaluate_ir_only(&s);
+        assert_eq!(verdict, Verdict::Uncertain, "{reason}");
+        assert_eq!(cues.deny_cause, DenyCause::NoIrFace);
+        // Unmeasurable exposure, on both evaluators (shared exposure_refusal).
+        let mut un = live_signals();
+        un.ir_ceiling_known = false;
+        let (verdict, cues, reason) = gate.evaluate(&un);
+        assert_eq!(verdict, Verdict::Uncertain, "{reason}");
+        assert_eq!(cues.deny_cause, DenyCause::ExposureUnmeasurable);
+        let (verdict, cues, reason) = gate.evaluate_ir_only(&un);
+        assert_eq!(verdict, Verdict::Uncertain, "{reason}");
+        assert_eq!(cues.deny_cause, DenyCause::ExposureUnmeasurable);
+        // Every other refusal, and every Live result, stays Other.
+        let mut flat = live_signals();
+        flat.ir_center_edge_ratio = 0.1;
+        let (verdict, cues, reason) = gate.evaluate(&flat);
+        assert_eq!(verdict, Verdict::Spoof, "{reason}");
+        assert_eq!(cues.deny_cause, DenyCause::Other);
+        let (verdict, cues, reason) = gate.evaluate(&live_signals());
+        assert_eq!(verdict, Verdict::Live, "{reason}");
+        assert_eq!(cues.deny_cause, DenyCause::Other);
     }
 
     #[test]

--- a/docs/research/benchmark-harness.md
+++ b/docs/research/benchmark-harness.md
@@ -137,6 +137,31 @@ may open and the emitter can fire. `--cancel-after MS` closes the harness's
 own socket mid-request, which exercises the production client-disconnect
 cancellation path; such trials are labeled `cancelled`, never pooled.
 
+Requests are newline-framed. The connection budget is 15 seconds; a separate
+30-second deadline covers request write and reply, including a partial reply.
+`--cancel-after` accepts 0 through 30000 milliseconds. The harness reads replies
+while waiting to cancel: a complete reply that arrives first keeps its actual
+request-to-reply interval. A peer that closes first is `no-reply`, not a successful
+harness cancellation. Refusal/error reasons are printed with escaped control
+characters; grant reasons and similarity scores are omitted.
+
+Trace collection runs concurrently with the trials to avoid filling an unread
+subscriber queue. Its reserved duration is the number of trials times the sum of
+the connection budget, reply/cancellation budget, and five seconds for cleanup.
+The plan must fit the daemon's five-minute trace maximum: six ordinary trials
+fit, while longer plans require fewer trials or explicit `--no-trace`. Invalid
+plans fail before connecting. Trace-enabled runs verify the schema-3 start
+record before sending authentication requests and reject a shortened accepted
+window, dropped events, malformed/truncated streams, a missing terminal record,
+or trials outlasting the reserved window. They do not silently fall back to
+untraced measurements. The run waits
+for the reserved trace window to finish, with five seconds of terminal-delivery
+grace; this reporting wait is outside each trial's reply interval.
+
+The subscription observes all daemon operations during its window. Run on an
+otherwise quiet daemon; the stage list alone does not establish a per-trial
+association when unrelated clients also use it.
+
 The boundary vocabulary and what each interval covers:
 
 * `IngressParse`: the connection thread from the start of its read through
@@ -150,6 +175,11 @@ The boundary vocabulary and what each interval covers:
   deliberately overlaps the camera preflight, so this interval is a
   spawn-to-join resolution interval, not isolated loader CPU time. A user
   with no store at all denies before any load and emits nothing here.
+  The experimental IR-only route has a separate loader: its interval includes
+  helper resolution and any cancellation drain, before camera acquisition.
+  Missing/corrupt stores still emit a boundary when that loader was attempted;
+  a request already expired before loading emits none. Read-only IR readiness
+  probes do not emit authentication load timings.
 * `EngineAuthenticate`: the daemon's wall time around the whole engine
   authentication call, including its nested engine stages (`CameraOpen`,
   `RateEstablishment`, captures, `Detection`, `Liveness`,

--- a/docs/research/benchmark-harness.md
+++ b/docs/research/benchmark-harness.md
@@ -121,6 +121,77 @@ credential-release request. Stage diagnostics can overlap or nest, and
 `Liveness` covers different work in paired versus RGB-only paths. Never add the
 stage lines together or compare those labels as equivalent work across modes.
 
+## Daemon request boundaries
+
+```sh
+cargo run --release --locked -p irlume-daemon --example daemon_timing -- \
+  <user> [--service NAME|none] [--trials N] [--cancel-after MS] [--no-trace]
+```
+
+This example talks to the RUNNING daemon over its socket; it performs no
+inference itself. Each trial is one real `Authenticate` request measured
+request-to-reply on the harness's own clock. With a diagnostic trace
+subscription (root; schema 3) it also prints the daemon-side stage boundaries
+the daemon emitted for those requests. Attended, authorized use only: cameras
+may open and the emitter can fire. `--cancel-after MS` closes the harness's
+own socket mid-request, which exercises the production client-disconnect
+cancellation path; such trials are labeled `cancelled`, never pooled.
+
+The boundary vocabulary and what each interval covers:
+
+* `IngressParse`: the connection thread from the start of its read through
+  request parse, posture gate and authorization, up to the creation of the
+  operation scope. Measured from before the read (the scope does not exist
+  yet) and reported inside the operation.
+* `QueueWait`: from the connection thread's submission instant to the worker
+  taking the job.
+* `EnrollmentLoad`: engine-side, emitted exactly where a store load (or the
+  deferred TPM unseal join) completes. On encrypted stores the deferred load
+  deliberately overlaps the camera preflight, so this interval is a
+  spawn-to-join resolution interval, not isolated loader CPU time. A user
+  with no store at all denies before any load and emits nothing here.
+* `EngineAuthenticate`: the daemon's wall time around the whole engine
+  authentication call, including its nested engine stages (`CameraOpen`,
+  `RateEstablishment`, captures, `Detection`, `Liveness`,
+  `IdentityInference`, `Matching`, `StreamOwnerRelease`, `EmitterRestore`).
+* `CredentialUnseal`: an unseal request's whole daemon-side handling
+  (policy gates, face authentication when reached, release), on every exit
+  including policy refusals; nests `EngineAuthenticate` when the engine is
+  reached.
+
+Stage intervals may overlap or nest by design; the report lists them and
+never sums them. Trials are separated by categorical outcome (granted,
+refused, cancelled) and medians use the nearest-rank convention over observed
+values only; refused trials are never pooled with grants.
+
+### Explicitly unmeasured boundaries
+
+The harness prints these gaps in every report because they are real parts of
+perceived login latency that no current Irlume diagnostic observes:
+
+* worker reply to socket write (the reply channel and the connection
+  thread's write are outside the operation scope);
+* the PAM stack around the daemon calls;
+* desktop/greeter unlock completion.
+
+No trustworthy desktop-unlock completion signal is established: a brief
+review (September 2026) of KScreenLocker documentation and community logs
+found failure-side journal lines (for example `pam_unix` authentication
+failures from `kscreenlocker_greet`) but no documented, stable positive
+completion event for a PAM-driven unlock. Candidate mechanisms such as
+logind session `Unlock` signals were not verified to fire on normal
+PAM-authenticated unlocks, so the boundary stays explicitly unmeasured
+rather than approximated. Establishing such a signal would be its own
+verified investigation before any report claims desktop-unlock latency.
+
+Cold/warm operation and route labeling: a cold trial requires a freshly
+started daemon and is a session-level protocol decision, not a harness flag.
+The active capture schedule comes from the trace's stream-contract and
+capture-schedule events, never from the service name alone; do not describe
+a trial by an assumed schedule. Loaded-system behavior is observed by
+running concurrent camera-class requests during a trial, and belongs in the
+session notes rather than the tool.
+
 ## Deterministic checks
 
 ```sh
@@ -128,10 +199,15 @@ cargo test --locked -p irlume-auth \
   --example stage_bench --example letterbox_bench --example auth_timing
 cargo clippy --locked -p irlume-auth \
   --example stage_bench --example letterbox_bench --example auth_timing -- -D warnings
+cargo test --locked -p irlume-daemon --example daemon_timing
+cargo clippy --locked -p irlume-daemon --example daemon_timing -- -D warnings
 ```
 
 The shared sampler tests reject zero samples before any work, stop on warmup
 and measured failures, verify valid counts/output observation, and check known
 nearest-rank percentiles including empty and singleton inputs. Auth option
 tests exercise service-based default purpose, explicit credential purpose and
-malformed input without loading models or authenticating.
+malformed input without loading models or authenticating. The daemon_timing
+tests cover option validation, report labeling (cancelled/refused trials,
+unmeasured gaps always present, stages never summed) and nearest-rank medians
+without contacting a daemon.

--- a/docs/superpowers/plans/2026-09-12-auth-timing-typed-refusal.md
+++ b/docs/superpowers/plans/2026-09-12-auth-timing-typed-refusal.md
@@ -1,0 +1,246 @@
+# Typed liveness refusals + complete authentication timing boundaries — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use inline `executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Do not commit or push without explicit user authorization; leave reviewable changes in the worktree.
+
+**Goal:** Replace the two text-prefix liveness refusal classifications with typed causes produced at their origin, and add the missing end-to-end authentication timing boundaries (daemon ingress/queue, enrollment load, engine call, credential unseal) with a repeatable daemon-level harness, preserving all outward behavior.
+
+**Architecture:** Part A adds a `DenyCause` value to `irlume_liveness::Cues`, set exactly where the gate produces each refusal, and rewrites `irlume_auth::liveness_deny_kind` to branch on `(Verdict, DenyCause)`; `Assessment` carries the cause alongside `verdict`/`reason`. Part B extends the existing privileged `TraceStage`/`StageTiming` diagnostics with the missing boundaries behind trace schema v3 and adds one `daemon_timing` example that merges the trace into a labeled boundary table with explicit gaps.
+
+**Tech Stack:** Rust 2021 edition, MSRV 1.88, cargo workspace (`irlume-liveness`, `irlume-auth`, `irlume-common`, `irlume-daemon`), serde, existing `DiagnosticSink` plumbing.
+
+**Spec:** `artifacts/irlume/2026-09-11-tui-desktop-experience/NEXT-RECOMMENDATION.md` (shared ledger, not in-repo) and `docs/research/benchmark-harness.md` (in-repo contract for benchmark examples).
+
+## Global Constraints
+
+- rust-version 1.88, edition 2021; every task ends green under `cargo fmt --check`, `cargo clippy --locked --workspace --all-targets -- -D warnings`, `cargo test --locked --workspace`, and `cargo doc --locked --workspace --no-deps --document-private-items` warnings denied (repo standard gates; IR-featured variants where the touched code is feature-gated).
+- Outward reason strings, `presence_retryable` outcomes, retry/account-strike semantics, deadlines, and wire `TraceRefusalReason` values must not change. The `legacy_prefix_retryable` oracle test (`crates/irlume-auth/src/lib.rs:8757`) must keep passing unchanged.
+- Diagnostic-trace compatibility: legacy schema-1 subscribers must never receive new `TraceStage` variants (unknown enum variants fail serde deserialization in old parsers). New variants ship behind a schema bump to 3 with `supports_schema` exclusions for schemas 1 and 2.
+- Domain language per `CONTEXT.md`: "capture schedule" (never "camera mode"), "capture qualification", "runtime degradation", "support report", "diagnostic trace".
+- No test opens cameras, TPM, or enrollment state. Attended hardware measurement is a separate user-authorized session, not part of this plan's verification.
+- No em dashes in source comments or commit messages (repo convention).
+- Sign commits with the repo release key only after explicit user authorization.
+
+---
+
+### Task A1: `DenyCause` typed at the origin in irlume-liveness
+
+**Files:**
+- Modify: `crates/irlume-liveness/src/lib.rs:343` (`Cues` struct), `:567-573` (`evaluate` no-IR Spoof arm), `:719-721` (`evaluate_ir_only` no-face arm), `:853-897` (`exposure_refusal`)
+- Test: `crates/irlume-liveness/src/lib.rs` test module
+
+**Interfaces:**
+- Produces: `pub enum DenyCause { Other, NoIrFace, ExposureUnmeasurable }` (exported from `irlume_liveness`), `pub deny_cause: DenyCause` field on `Cues`, defaulting to `DenyCause::Other`.
+
+- [ ] **Step 1: Write the failing tests** (compile-fail is the red state) in the liveness test module:
+
+```rust
+/// The typed cause is produced at the refusal origin, not re-derived from
+/// wording downstream: each arm below pins the cause for one producer.
+#[test]
+fn deny_causes_are_typed_at_their_origin() {
+    let gate = LivenessGate::new();
+    let mut s = live_signals();
+    // RGB present, IR absent: the retryable cross-spectrum transient.
+    s.ir_face = None;
+    let (_, cues, _) = gate.evaluate(&s);
+    assert_eq!(cues.deny_cause, DenyCause::NoIrFace);
+    // Dark evaluator's own no-face arm carries the same cause; its verdict
+    // stays Uncertain and classification stays with the verdict there.
+    let (_, cues, _) = gate.evaluate_ir_only(&s);
+    assert_eq!(cues.deny_cause, DenyCause::NoIrFace);
+    // Unmeasurable exposure, both evaluators (shared exposure_refusal).
+    let mut un = live_signals();
+    un.ir_ceiling_known = false;
+    let (_, cues, _) = gate.evaluate(&un);
+    assert_eq!(cues.deny_cause, DenyCause::ExposureUnmeasurable);
+    let (_, cues, _) = gate.evaluate_ir_only(&un);
+    assert_eq!(cues.deny_cause, DenyCause::ExposureUnmeasurable);
+    // Every other refusal, and every Live result, stays Other.
+    let mut flat = live_signals();
+    flat.ir_center_edge_ratio = 0.1;
+    let (verdict, cues, _) = gate.evaluate(&flat);
+    assert_eq!(verdict, Verdict::Spoof);
+    assert_eq!(cues.deny_cause, DenyCause::Other);
+    let (_, cues, _) = gate.evaluate(&live_signals());
+    assert_eq!(cues.deny_cause, DenyCause::Other);
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test --locked -p irlume-liveness deny_causes_are_typed_at_their_origin`
+Expected: compile error (`no field deny_cause`, `DenyCause` not found).
+
+- [ ] **Step 3: Implement** — add above `Cues`:
+
+```rust
+/// Typed origin of a non-Live gate decision, produced where the refusal is
+/// produced, so downstream routing (retry eligibility, runtime availability)
+/// branches on a value instead of pinning reason prefixes. `Other` covers
+/// every refusal without special routing and every Live result, where the
+/// field carries no information.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum DenyCause {
+    #[default]
+    Other,
+    /// RGB saw a face the IR stream did not: the retryable settling
+    /// transient and the persistent screen/print signature at once.
+    NoIrFace,
+    /// The negotiated IR format defines no sensor ceiling, so exposure
+    /// cannot be checked (#358); a property of the camera, not the frame.
+    ExposureUnmeasurable,
+}
+```
+
+Add to `Cues` (after `ir_exposure_measured`):
+
+```rust
+    /// Typed origin of this decision; see [`DenyCause`]. `Other` unless the
+    /// evaluator named a cause where it produced its refusal.
+    pub deny_cause: DenyCause,
+```
+
+Set it at the three origins: in `evaluate`'s no-IR Spoof arm (`cues.deny_cause = DenyCause::NoIrFace;` before the return), in `evaluate_ir_only`'s no-face arm (same), and in `exposure_refusal`'s unmeasurable arm (`cues.deny_cause = DenyCause::ExposureUnmeasurable;`). The blown-frame arm and every other refusal keep the `Other` default deliberately (they are retryable Uncertainties or ordinary Spoofs).
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo test --locked -p irlume-liveness`
+Expected: all pass. Then `cargo clippy --locked -p irlume-liveness --all-targets -- -D warnings` and `cargo fmt --check -p irlume-liveness`.
+
+### Task A2: irlume-auth classifies on the typed cause
+
+**Files:**
+- Modify: `crates/irlume-auth/src/lib.rs:150-192` (`Assessment`), `:1085-1112` (`liveness_deny_kind`), `:5051-5106` (gate result + overrides), `:5161` (Assessment construction), `:6065-6069`, `:6089-6093`, `:6318-6339` (classification sites), `:8962` test, `:8837` test, `:8990-8996` test
+- Modify: `crates/irlume-auth/src/grouped_auth.rs:113-118`, `:133-138`
+- Modify: `crates/irlume-auth/src/engine_tests/pair_identity_tests.rs:663-664`
+
+**Interfaces:**
+- Consumes: `irlume_liveness::DenyCause`, `Cues::deny_cause` (Task A1).
+- Produces: `Assessment { pub deny_cause: DenyCause, .. }`; `fn liveness_deny_kind(verdict: Verdict, cause: DenyCause) -> OutcomeKind` (private, unchanged visibility).
+
+- [ ] **Step 1: Write the failing parity test** in the auth test module. The old prefix classifier is kept in the test as the oracle:
+
+```rust
+/// The prefix rules this refactor removes, kept here as the parity oracle:
+/// for every (verdict, cause, reason) triple the producers can emit, the
+/// typed classifier must agree with the prefix classifier it replaced.
+    fn legacy_prefix_kind(verdict: Verdict, reason: &str) -> OutcomeKind {
+        match verdict {
+            Verdict::Uncertain if reason.starts_with(EXPOSURE_UNMEASURABLE_PREFIX) => {
+                OutcomeKind::RuntimeUnavailable
+            }
+            Verdict::Uncertain => OutcomeKind::Uncertain,
+            Verdict::Spoof if reason.starts_with("no face in IR") => OutcomeKind::SpoofNoIrFace,
+            Verdict::Spoof => OutcomeKind::Spoof,
+            Verdict::Live => OutcomeKind::OtherDeny,
+        }
+    }
+
+    #[test]
+    fn typed_cause_classification_matches_the_prefix_contract() {
+        use irlume_liveness::DenyCause;
+        let cases = [
+            (Verdict::Uncertain, DenyCause::ExposureUnmeasurable, "IR exposure unmeasurable: this camera's IR format defines no sensor ceiling"),
+            (Verdict::Uncertain, DenyCause::Other, "IR frame blown out (90% of the face at the sensor ceiling); move back or dim the light"),
+            (Verdict::Uncertain, DenyCause::Other, "not facing the camera (yaw 0.50, pitch 0.10); look directly at it"),
+            (Verdict::Uncertain, DenyCause::NoIrFace, "no face in IR"),
+            (Verdict::Spoof, DenyCause::NoIrFace, "no face in IR: a real face reflects 850nm; a screen/print does not"),
+            (Verdict::Spoof, DenyCause::Other, "IR too flat (center/edge 0.90); looks 2D, not a 3D face"),
+            (Verdict::Spoof, DenyCause::Other, "IR PAD cue flags a spoof; use your password"),
+            (Verdict::Live, DenyCause::Other, "live: face in RGB+IR, co-located, frontal, IR-reflective, 3D"),
+        ];
+        for (verdict, cause, reason) in cases {
+            assert_eq!(
+                liveness_deny_kind(verdict, cause),
+                legacy_prefix_kind(verdict, reason),
+                "typed drift: {verdict:?} + {cause:?} ({reason})"
+            );
+        }
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test --locked -p irlume-auth typed_cause_classification`
+Expected: compile error (field/signature mismatch).
+
+- [ ] **Step 3: Implement.** Change `liveness_deny_kind` to match on `(verdict, cause)` exactly as the parity test's expectations, updating its doc comment (the pin is now the typed cause; wording pins remain in tests). Add `pub deny_cause: irlume_liveness::DenyCause` to `Assessment`. At the `assess_full` gate-result site, capture `cues.deny_cause` from `self.gate.evaluate(&signals)`; the `stale_pair_reason` override forces `DenyCause::Other`, and the PAD-downgrade override in the same function resets the captured cause to `DenyCause::Other` when it replaces the verdict/reason. Store the final value in the `Assessment` built at `:5161`. Update the five classification sites (`6067`, `6091`, `6335`, `grouped_auth.rs:115`, `:136`) to pass the cause (`a.deny_cause` for stored assessments, `cues.deny_cause` for fresh evaluations). Update the direct-call tests (`grace_retries_only_presence_failures`, `an_unmeasurable_exposure_is_not_retryable`, the `liveness Spoof: no face in IR` case near `:8993`, and the `pair_identity_tests.rs` fixture) to pass typed causes while keeping their reason-string assertions as wording pins. `EXPOSURE_UNMEASURABLE_PREFIX` moves into the test module (routing no longer reads it).
+
+- [ ] **Step 4: Full gate**
+
+Run: `cargo test --locked -p irlume-auth && cargo test --locked -p irlume-liveness && cargo clippy --locked -p irlume-auth -p irlume-liveness --all-targets -- -D warnings && cargo fmt --check`
+Expected: all pass, including the untouched `legacy_prefix_retryable` oracle and `no_deny_site_classifies_a_liveness_verdict_by_hand` source scan.
+
+- [ ] **Step 5: Workspace gate**
+
+Run: `cargo test --locked --workspace && cargo clippy --locked --workspace --all-targets -- -D warnings && cargo doc --locked --workspace --no-deps --document-private-items 2>&1 | tail -1`
+Expected: all pass, zero doc warnings.
+
+---
+
+### Task B1: Trace schema v3 with the new stage vocabulary
+
+**Files:**
+- Modify: `crates/irlume-common/src/diagnostics.rs:16-20` (version constants), `:694-706` (`TraceStage`), `:853-866` (`supports_schema`)
+
+**Interfaces:**
+- Produces: `TraceStage::{EnrollmentLoad, IngressParse, QueueWait, EngineAuthenticate, CredentialUnseal}`; `CURRENT_TRACE_SCHEMA_VERSION = 3`; `V2_TRACE_SCHEMA_VERSION = 2` named tier.
+
+- [ ] **Step 1: Write the failing test** (in diagnostics.rs tests or a new adjacent test): for each new stage, `supports_schema(1, stage)` and `supports_schema(2, stage)` are false while `supports_schema(3, stage)` is true; every pre-existing stage stays true at 2 and false-or-true at 1 exactly as today (IdentityInference/StreamOwnerRelease false at 1, others true).
+- [ ] **Step 2: Run to verify it fails.**
+- [ ] **Step 3: Implement** the variants, bump `CURRENT_TRACE_SCHEMA_VERSION` to 3, add the named v2 tier, and extend `supports_schema` so schemas 1 and 2 exclude the five new stages (schema 1 keeps its existing exclusions). `TRACE_SCHEMA_VERSION` follows `CURRENT`.
+- [ ] **Step 4:** `cargo test --locked -p irlume-common && cargo clippy --locked -p irlume-common --all-targets -- -D warnings`.
+
+### Task B2: Engine enrollment-load boundary
+
+**Files:**
+- Modify: `crates/irlume-auth/src/lib.rs:5448-5610` (loader span)
+
+- [ ] **Step 1: Write the failing test:** a `DiagnosticSink` collector around an authenticate call that ends in a setup refusal (not-enrolled path) still observes `StageTiming { stage: EnrollmentLoad }` exactly once, with nonzero elapsed. Use an existing test harness that exercises `authenticate_for_with_diagnostics` against missing enrollment.
+- [ ] **Step 2: Verify it fails** (no such event today).
+- [ ] **Step 3: Implement:** wrap the loader span (`load_started` at `:5448` through resolution including the NotEnrolled/Fallback early returns) in `TraceStageTimer::new(diagnostics, TraceStage::EnrollmentLoad)` so unwinding and early returns are measured; remove the now-duplicated `dlog!` elapsed or keep the dlog for its async/synchronous annotation while the trace carries the number.
+- [ ] **Step 4:** `cargo test --locked -p irlume-auth && cargo clippy --locked -p irlume-auth --all-targets -- -D warnings && cargo fmt --check`.
+
+### Task B3: Daemon ingress, queue, engine-call and unseal boundaries
+
+**Files:**
+- Modify: `crates/irlume-daemon/src/main.rs:1576` (`Queued`), serve_peer queue-submission site, worker `arbiter.take()` site (`:943`), Authenticate arm (`:4953`), `UnsealPassword`/`UnsealKeyring` arms (`:4461`)
+- Test: `crates/irlume-daemon/src/main.rs` test module
+
+**Interfaces:**
+- Consumes: `TraceStage::{IngressParse, QueueWait, EngineAuthenticate, CredentialUnseal}` (Task B1), `OperationScope: DiagnosticSink`.
+
+- [ ] **Step 1: Write failing tests** using the existing `serve`/`serve_peer` test scaffolding (it builds a real arbiter and socketpair): an Authenticate request produces `QueueWait` then `EngineAuthenticate` StageTiming events on its operation scope in that order; an Unseal request produces `CredentialUnseal`; `IngressParse` precedes `QueueWait`.
+- [ ] **Step 2: Verify failure.**
+- [ ] **Step 3: Implement:** record `read_request` start before the read in `serve_peer` and emit `IngressParse` through the operation scope once created (the boundary is measured pre-scope and reported inside the operation; document this in the field docs). Add `enqueued_at: std::time::Instant` to `Queued`, set at submit; the worker emits `QueueWait` as `enqueued_at.elapsed()` immediately after `arbiter.take()` returns the job. In the Authenticate arm, emit `EngineAuthenticate` with the existing `t` measurement. In the Unseal arms, emit `CredentialUnseal` the same way. Bound all values with the existing `u64::try_from(...).unwrap_or(u64::MAX)` convention.
+- [ ] **Step 4:** `cargo test --locked -p irlume-daemon && cargo clippy --locked -p irlume-daemon --all-targets -- -D warnings && cargo fmt --check`.
+
+### Task B4: `daemon_timing` harness example
+
+**Files:**
+- Create: `crates/irlume-daemon/examples/daemon_timing.rs`
+- Test: unit tests inside the example (offline merge/table logic only)
+
+**Interfaces:**
+- Consumes: the real daemon socket (`/run/irlume/…`, resolved the same way `irlume-cli` resolves it), `Request::Authenticate`, `Request::TraceSubscribe` (schema 3), `TraceValidator`/`ParsedTrace`.
+
+- [ ] **Step 1: Write failing unit tests** for the pure boundary-table builder: given synthetic `TraceRecord`s with StageTiming events plus wall-clock request/reply instants, the builder labels every boundary, refuses to sum stages, and prints the explicit gaps (socket write after worker reply, PAM stack time, desktop unlock) as `unmeasured` lines. Test: gaps always present, stages never summed, cancel trials labeled.
+- [ ] **Step 2: Verify failure.**
+- [ ] **Step 3: Implement** the example: options `--service`, `--purpose`, `--trials N`, `--cancel-after MS`, `--user`; per trial it opens the daemon socket, optionally subscribes a diagnostic trace on a second connection, sends one Authenticate, measures request-to-reply, and prints the merged boundary table plus categorical outcome (granted/refused/cancelled). Refused outcomes are labeled, not pooled with grants. No camera/TPM access beyond what the daemon itself does for the request. `--help` performs no request.
+- [ ] **Step 4:** `cargo test --locked -p irlume-daemon --example daemon_timing && cargo clippy --locked -p irlume-daemon --example daemon_timing -- -D warnings`.
+
+### Task B5: Document the boundary contract
+
+**Files:**
+- Modify: `docs/research/benchmark-harness.md`
+
+- [ ] **Step 1:** Add a `daemon_timing` section stating exactly what each boundary covers (ingress parse, queue wait, engine call with its nested engine stages, credential unseal), the explicit unmeasured gaps (worker reply to socket write, PAM stack, desktop-unlock completion), the cold/warm and route-labeling protocol (route evidence comes from the trace's stream-contract and capture-schedule events, never from the service name), and the desktop-unlock completion-signal finding: investigate whether a trustworthy signal exists (greeter/kscreenlocker journal events); if none is established, the gap stays explicit and this section says so.
+- [ ] **Step 2:** `grep` the docs for consistency with `CONTEXT.md` vocabulary; run `cargo doc` gate once more.
+
+---
+
+## Self-Review
+
+1. **Spec coverage:** typed causes at origin (A1/A2) with parity tests preserving messages/retry eligibility/accounting/deadlines; missing timing boundaries incl. queue/template loading (B1-B3); repeatable harness not overlapping existing tools (B4); desktop-unlock signal validated or gap retained (B5); no-face/cancel/loaded-system behavior (harness cancel mode + docs protocol; loaded-system documented as session protocol). Optimization choice deliberately deferred until measurements exist, per spec.
+2. **Placeholders:** none; each step names files, anchors, and code.
+3. **Type consistency:** `DenyCause` names/shapes match between A1 and A2; stage names match between B1, B2, B3, B4.


### PR DESCRIPTION
## Final pre-merge audit and acceptance

**Final head:** `232d365aead35109bf739aa2b64e5153c390c564`.
**Tested tree:** `c4ed7a563f5dd0e348faa211ed92bddb7af4b2b2`.
**Base:** main `529f5d0e1a186e37fade5c6273bdfa0205ac4643`, including merged #706.

The audit covered the complete production, protocol, example and documentation change, including all commits in this PR. Typed refusal causes are set at their producers, preserved through assessment, reset when PAD/stale-pair decisions replace the verdict, and checked against the prior routing contract. New timing stages retain schema-1/schema-2 filtering and existing authorization, deadline, cancellation and grant decisions.

### Findings resolved before acceptance

1. A synchronous enrollment-load error returned before its timing event. The error now propagates after emitting the attempted-load interval.
2. An unexpected trace-handshake response was Debug-formatted with its payload. It now produces a fixed diagnostic without exposing that payload.

Both defects were reproduced with failing regression cases on `82fce80`, then passed after the fixes in `232d365`. No blocking product-code finding remains from this audit.

### Exact-head software verification

- **1,386 library/daemon tests passed:** auth 227, camera 694, common 148, daemon 288, liveness 29; 34 existing hardware ignores retained.
- **17 timing-example tests and 11 sensor CLI tests passed.**
- Six-crate all-target Clippy with warnings denied, formatting and diff checks passed.
- All 15 current GitHub checks passed, including DCO, sanitizers, hardware checks, CodeQL and both Fedora builds.
- Native Fedora/Rust 1.96.0 release build passed. Daemon SHA256 `1a9b3a5c9f4c41074287ea6f5e986448321e2ae8a2400c122fcdb3f9f0b185dc`; timing example SHA256 `cc9e868610f2fc250b90fbb34781257f0411f5dae7697300e5ad9622f826a92b`.

### Attended ASUS acceptance

The user confirmed face desktop unlock and direct password fallback on the final candidate. The face trial recorded candidate IR/authentication stages; the password trial had no face timing events. No LockedHint transitions were captured inside their 40-second cue windows, so these remain qualitative user reports, not desktop-latency measurements or independent credential-delivery proof.

Additional source-bound direct checks:

- The actual `daemon_timing` executable ran with its default schema-3 trace enabled, completed the trace and returned a **grant at 3,665.872 ms**. Ingress, queue wait, enrollment load and engine-call intervals were present; unmeasured boundaries and non-additive stage warnings were correctly reported.
- **Three printed-face requests were explicitly refused by IR PAD**, not account policy lockout: 3,363.821 / 3,252.895 / 3,248.947 ms, camera quiet after each.
- Cancellation ran last, after an observed camera open. Camera release completed in **512.640 ms**, then the immediate genuine recovery request **granted in 3,561.886 ms** with no pending journals.
- Every final observer lifecycle and automatic restoration passed. Independent final-block verification at 2026-09-14 01:33:24 UTC found the original daemon/PAM, active/enabled services, Pong, no holders/journals/override and cleared recovery arm. Protected paths changed only for normal retry accounting.

The final hardware tests exercised the existing experimental IR-only policy. Paired-path typed-cause equivalence is covered by the automated parity/producer tests and historical hardware evidence; this report does not relabel older-head results as new-head trials. SELinux was Enforcing with actual `unconfined_service_t`, so no dedicated confined-domain claim is made. Credential-unseal timing has automated request-path coverage; cold login, wallet behavior and independently proven credential delivery are outside these observations. No broad PAD assurance or authentication-speedup claim is made.

The maintainer authorized merging validated PRs after this audit. The listed acceptance gates for this instrumentation/refactoring change are complete. The separate #702 capture experiment and #703/#705 audit findings remain separate merge gates.


<details>
<summary>Earlier development and validation history (superseded by the final acceptance above)</summary>

## What & why

Complete authentication latency attribution and replace text-prefix liveness refusal classification with typed causes, establishing reliable measurements before choosing a performance optimization.

**Review state:** ready for code review. Keep this PR open until the maintainer completes at-home hardware testing of the final candidate and confirms that it works. No merge or automatic merge is requested yet.

### Typed refusal causes

- `irlume-liveness` carries `DenyCause` (`Other`, `NoIrFace`, `ExposureUnmeasurable`) on `Cues`, set where the special refusals originate.
- `irlume-auth` carries the cause through `Assessment`, resets it when another refusal replaces the verdict, and classifies `(Verdict, DenyCause)` instead of matching reason-string prefixes.
- Authentication decision semantics, outward daemon reasons, retry eligibility/accounting, deadlines and existing wire refusal values are preserved. Parity tests compare against the replaced prefix contract.

### Timing boundaries and reliable measurement

- Trace schema 3 adds `EnrollmentLoad`, `IngressParse`, `QueueWait`, `EngineAuthenticate` and `CredentialUnseal`. Schema-1/schema-2 subscribers remain supported and do not receive unsupported new stages.
- The IR-only route now emits its separate enrollment-load interval through resolution/error/cancellation drain. A request already expired before loading emits none; read-only readiness probes do not emit authentication timings. The dual-sensor deferred load can overlap camera preflight, so stage intervals are attribution labels, not addends.
- `daemon_timing` sends newline-framed requests with a separate 30-second reply deadline. Replies winning the cancellation race retain their actual timing; peer EOF is distinguished from a harness-initiated disconnect. Refusal/error reasons are escaped for terminal display, and grant identity/similarity scores are omitted.
- Concurrent trace draining checks the schema-3 start record before authentication and rejects shortened windows, lost events, malformed/truncated streams, missing terminal records and trial-window overruns. Trace plans are bounded to five minutes before connecting; longer plans require explicit untraced operation.
- Grant/refusal samples are kept separate, with nearest-rank medians. Worker-reply-to-socket-write, surrounding PAM work and visible desktop-unlock completion remain explicitly unmeasured. No trustworthy positive desktop-unlock signal has been established.

Boundary definitions and measurement limits are documented in `docs/research/benchmark-harness.md`. A subscription observes all daemon operations in its window, so a quiet daemon is required before associating stages with this harness's trials.

## Testing

### Latest follow-up: `d74f992`

- [x] `cargo test --release --locked -j 1 -p irlume-auth --lib -- --test-threads=2`: **226 passed, zero failed, three existing ignored**.
- [x] `cargo test --release --locked -j 1 -p irlume-daemon --example daemon_timing`: **16 passed, zero failed**.
- [x] `cargo clippy --release --locked -j 1 -p irlume-auth -p irlume-daemon --all-targets -- -D warnings`.
- [x] Formatting and `git diff --check`.
- [x] Locked release build of daemon, CLI, `burst_dump` and `daemon_timing`; `daemon_timing --help` smoke.
- [x] Signed commit with exactly one DCO trailer; committed patch matches the locally verified source snapshot.
- [ ] Fresh CI on the updated PR head: consult the current checks below. Earlier green checks do not validate a later head.
- [ ] At-home hardware acceptance of the final candidate and maintainer confirmation before merge.

The initial local authentication run exposed a missing developer-worktree mesh model required by two existing tests. Linking the installed, checksum-verified public model resolved those fixture failures without a product-code change. The new IR-loader regression passed in both runs.

### Earlier evidence, bound to `aa58646d`

- Full workspace: **2,443 tests passed**; example suites: **25 passed**. Workspace Clippy/formatting passed. Documentation had only seven pre-existing base-commit warnings.
- ASUS attended lit-room trials: **3/3 grants**, median **3.592 seconds**, with live timing boundaries. Dark-room refusal occurred on both candidate and original. A later UVC streaming incident interrupted validation; original daemon was restored, and camera recovery requires verification after powering the laptop on.
- Unattended NexiGo/minihost and BRIO/Archhost controls passed capture, non-policy refusal, cancellation and post-cancellation capture checks. Original installed daemons and protected state were restored; temporary frames and private test state were deleted.
- Harness compatibility failures were preserved and corrected: the older installed daemon emitted schema 1, and Archhost required the production socket-activation path under its existing AppArmor profile. Unattended testing also observed NexiGo companion-device reconnects and baseline AppArmor diagnostic denials. These isolated candidate tests do not qualify installed packaging/confinement.

These earlier hardware results apply to their recorded binaries, **not** the latest follow-up. The ASUS worktree's offline edits were independently reconstructed locally and must be reconciled on reconnection.

## At-home merge gate

- [ ] Confirm the original ASUS camera/daemon works after power-on.
- [ ] Reconcile overlapping offline ASUS edits and use one exact final PR revision.
- [ ] Validate genuine authentication, applicable password fallback/desktop behavior, timing output, refusal and cancellation cleanup; run cancellation controls last.
- [ ] Confirm the final candidate works and all required checks pass, then merge.

No authentication-speedup claim is made by this instrumentation/refactoring PR.


</details>
